### PR TITLE
Add `cull` to remove unnecessary tasks.  See issue #2.

### DIFF
--- a/dask/core.py
+++ b/dask/core.py
@@ -9,7 +9,7 @@ def inc(x):
 def ishashable(x):
     """ Is x hashable?
 
-    Exmaple
+    Example
     -------
 
     >>> ishashable(1)
@@ -29,7 +29,7 @@ def istask(x):
 
     A task is a tuple with a callable first argument
 
-    Exmaple
+    Example
     -------
 
     >>> inc = lambda x: x + 1
@@ -44,7 +44,7 @@ def istask(x):
 def get(d, key, get=None, concrete=True, **kwargs):
     """ Get value from Dask
 
-    Exmaple
+    Example
     -------
 
     >>> inc = lambda x: x + 1
@@ -84,7 +84,7 @@ _get = get
 def set(d, key, val, args=[]):
     """ Set value for key in Dask
 
-    Exmaple
+    Example
     -------
 
     >>> d = {}
@@ -202,7 +202,7 @@ def cull(dsk, keys):
     In other words, remove unnecessary tasks from dask.
     ``keys`` may be a single key or list of keys.
 
-    Exmaple
+    Example
     -------
 
     >>> d = {'x': 1, 'y': (inc, 'x'), 'out': (add, 'x', 10)}


### PR DESCRIPTION
For now, I just put this in `dask.core`.

For posterity, the following is a more concise solution, but is slower:
```python
from toolz import concat, keyfilter

def cull(dsk, keys):
    if not isinstance(keys, list):
        keys = [keys]
    seen = set()
    cur = set(keys)
    while cur:
        seen.update(cur)
        cur = set(concat(get_dependencies(dsk, x) for x in cur))
        cur.difference_update(seen)
    return keyfilter(seen.__contains__, dsk)
```