### PR TITLE
Fancy slicing with lists

### DIFF
--- a/dask/array/blaze.py
+++ b/dask/array/blaze.py
@@ -124,6 +124,9 @@ def compute_up(expr, data, **kwargs):
     out = next(names)
     index = expr.index
 
+    if all(i == slice(None, None, None) for i in index):
+        return data
+
     # Turn x[5:10] into x[5:10, :, :] as needed
     index = list(index) + [slice(None, None, None)] * (ndim(expr) - len(index))
 

--- a/dask/array/blaze.py
+++ b/dask/array/blaze.py
@@ -14,7 +14,7 @@ from blaze.expr import (ElemWise, symbol, Reduction, Transpose, TensorDot,
         Expr, Slice, Broadcast)
 
 from .core import (getem, concatenate, concatenate2, top, new_blockdim,
-    broadcast_dimensions, dask_slice, Array, get, atop, names)
+    broadcast_dimensions, fancy_slice, Array, get, atop, names)
 
 
 def compute_it(expr, leaves, *data, **kwargs):
@@ -127,7 +127,7 @@ def compute_up(expr, data, **kwargs):
     # Turn x[5:10] into x[5:10, :, :] as needed
     index = list(index) + [slice(None, None, None)] * (ndim(expr) - len(index))
 
-    dsk = dask_slice(out, data.name, data.shape, data.blockdims, index)
+    dsk = fancy_slice(out, data.name, data.shape, data.blockdims, index)
     blockdims = [new_blockdim(d, db, i)
                 for d, i, db in zip(data.shape, index, data.blockdims)
                 if not isinstance(i, int)]

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -514,7 +514,7 @@ def take(outname, inname, blockdims, index, axis=0):
 
     dims = [[0] if axis == i else list(range(len(bd)))
                 for i, bd in enumerate(blockdims)]
-    keys = product([outname], *dims)
+    keys = list(product([outname], *dims))
 
     colon = slice(None, None, None)
 
@@ -663,8 +663,8 @@ class Array(object):
         self.name = name
         self.shape = shape
         if blockshape is not None:
-            blockdims = tuple((bd,) * (d // bd) for d, bd in zip(shape,
-                blockshape))
+            blockdims = tuple((bd,) * (d // bd) + ((d % bd,) if d % bd else ())
+                              for d, bd in zip(shape, blockshape))
         self.blockdims = tuple(map(tuple, blockdims))
 
     @property

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -22,15 +22,15 @@ def getem(arr, blocksize, shape):
     """ Dask getting various chunks from an array-like
 
     >>> getem('X', blocksize=(2, 3), shape=(4, 6))  # doctest: +SKIP
-    {('X', 0, 0): (operator.getitem, 'X', (slice(0, 2), slice(0, 3))),
-     ('X', 1, 0): (operator.getitem, 'X', (slice(2, 4), slice(0, 3))),
-     ('X', 1, 1): (operator.getitem, 'X', (slice(2, 4), slice(3, 6))),
-     ('X', 0, 1): (operator.getitem, 'X', (slice(0, 2), slice(3, 6)))}
+    {('X', 0, 0): (getitem, 'X', (slice(0, 2), slice(0, 3))),
+     ('X', 1, 0): (getitem, 'X', (slice(2, 4), slice(0, 3))),
+     ('X', 1, 1): (getitem, 'X', (slice(2, 4), slice(3, 6))),
+     ('X', 0, 1): (getitem, 'X', (slice(0, 2), slice(3, 6)))}
     """
     numblocks = tuple([int(ceil(n/k)) for n, k in zip(shape, blocksize)])
     return dict(
                ((arr,) + ijk,
-               (operator.getitem,
+               (getitem,
                  arr,
                  tuple(slice(i*d, (i+1)*d) for i, d in zip(ijk, blocksize))))
                for ijk in product(*map(range, numblocks)))
@@ -527,7 +527,7 @@ def take(outname, inname, blockdims, index, axis=0):
 
 
 def dask_slice(out_name, in_name, shape, blockdims, indexes,
-               getitem_func=operator.getitem):
+               getitem_func=getitem):
     """
     Return a new dask containing the slices for all n-dimensions
 
@@ -679,7 +679,7 @@ def get(dsk, keys, get=threaded.get, **kwargs):
     2. Use custom score function
     """
     fast_functions=kwargs.get('fast_functions',
-                             set([operator.getitem, np.transpose]))
+                             set([getitem, np.transpose]))
     dsk2 = core.cull(dsk, list(core.flatten(keys)))
     dsk3 = inline_functions(dsk2, fast_functions=fast_functions)
     return get(dsk3, keys, **kwargs)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -501,7 +501,7 @@ def take(outname, inname, blockdims, index, axis=0):
 
     Mimics ``np.take``
 
-    >>> take('y', 'x', [(20, 20, 20, 20)], [5, 1, 47, 3], axis=0)
+    >>> take('y', 'x', [(20, 20, 20, 20)], [5, 1, 47, 3], axis=0)  # doctest: +SKIP
     {('y', 0): (getitem, (np.concatenate, [(getitem, ('x', 0), ([1, 3, 5],)),
                                            (getitem, ('x', 2), ([7],))],
                                           0),

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -132,6 +132,11 @@ def test_Array():
     assert a.blockdims == ((100,) * 10, (100,) * 10)
 
 
+def test_uneven_blockdims():
+    a = Array({}, 'x', shape=(10, 10), blockshape=(3, 3))
+    assert a.blockdims == ((3, 3, 3, 1), (3, 3, 3, 1))
+
+
 def test_numblocks_suppoorts_singleton_block_dims():
     shape = (100, 10)
     blockshape = (10, 10)

--- a/dask/array/tests/test_blaze.py
+++ b/dask/array/tests/test_blaze.py
@@ -89,3 +89,20 @@ def test_slicing_with_singleton_dimensions():
     assert arr.dask[(y, 1)] == (getitem, (x, 2, 2), (slice(0, 4, 1), 2))
     assert arr.dask[(y, 2)] == (getitem, (x, 3, 2), (slice(0, 3, 1), 2))
     assert all(len(k) == 2 for k in arr.keys())
+
+
+def test_slicing_with_lists():
+    nx = np.arange(16).reshape((4, 4))
+    dx = convert(Array, nx, blockshape=(2, 2))
+    sx = symbol('x', discover(dx))
+    expr = sx[[2, 0, 3]],
+    assert eq(np.array(compute(sx, dx)), compute(sx, nx))
+
+    expr = sx[::2, [2, 0, 3]],
+    assert eq(np.array(compute(sx, dx)), compute(sx, nx))
+
+    expr = sx[1, [2, 0, 3]],
+    assert eq(np.array(compute(sx, dx)), compute(sx, nx))
+
+    expr = sx[[2, 0, 3], -2],
+    assert eq(np.array(compute(sx, dx)), compute(sx, nx))

--- a/dask/array/tests/test_blaze.py
+++ b/dask/array/tests/test_blaze.py
@@ -92,7 +92,7 @@ def test_slicing_with_singleton_dimensions():
 
 
 def test_slicing_with_lists():
-    nx = np.arange(16).reshape((4, 4))
+    nx = np.arange(20).reshape((4, 5))
     dx = convert(Array, nx, blockshape=(2, 2))
     sx = symbol('x', discover(dx))
     expr = sx[[2, 0, 3]],
@@ -112,3 +112,15 @@ def test_slicing_with_lists():
 
     expr = sx[0],
     assert eq(np.array(compute(sx, dx)), compute(sx, nx))
+
+    expr = sx[0, [3, 1, 4]],
+    assert eq(np.array(compute(sx, dx)), compute(sx, nx))
+
+
+def test_more_slicing():
+    nx = np.arange(100).reshape((10, 10))
+    dx = convert(Array, nx, blockshape=(3, 3))
+    sx = symbol('x', discover(dx))
+    expr = sx[0, [1, 3, 9, 3]]
+
+    result = compute(expr, dx)

--- a/dask/array/tests/test_blaze.py
+++ b/dask/array/tests/test_blaze.py
@@ -106,3 +106,9 @@ def test_slicing_with_lists():
 
     expr = sx[[2, 0, 3], -2],
     assert eq(np.array(compute(sx, dx)), compute(sx, nx))
+
+    expr = sx[:, :]
+    assert compute(sx, dx).dask == dx.dask
+
+    expr = sx[0],
+    assert eq(np.array(compute(sx, dx)), compute(sx, nx))

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -125,35 +125,35 @@ def test_slice_singleton_value_on_boundary():
 
 def test_dask_slice_1d():
     #x[24::2]
-    expected = {('y', 0): (operator.getitem, ('x', 0), (slice(24, 25, 2),)),
-                ('y', 1): (operator.getitem, ('x', 1), (slice(1, 25, 2),)),
-                ('y', 2): (operator.getitem, ('x', 2), (slice(0, 25, 2),)),
-                ('y', 3): (operator.getitem, ('x', 3), (slice(1, 25, 2),))}
+    expected = {('y', 0): (getitem, ('x', 0), (slice(24, 25, 2),)),
+                ('y', 1): (getitem, ('x', 1), (slice(1, 25, 2),)),
+                ('y', 2): (getitem, ('x', 2), (slice(0, 25, 2),)),
+                ('y', 3): (getitem, ('x', 3), (slice(1, 25, 2),))}
     result = dask_slice('y', 'x', [100], [[25]*4], [slice(24,None,2)])
 
     assert expected == result
 
     #x[26::2]
-    expected = {('y', 0): (operator.getitem, ('x', 1), (slice(1, 25, 2),)),
-                ('y', 1): (operator.getitem, ('x', 2), (slice(0, 25, 2),)),
-                ('y', 2): (operator.getitem, ('x', 3), (slice(1, 25, 2),))}
+    expected = {('y', 0): (getitem, ('x', 1), (slice(1, 25, 2),)),
+                ('y', 1): (getitem, ('x', 2), (slice(0, 25, 2),)),
+                ('y', 2): (getitem, ('x', 3), (slice(1, 25, 2),))}
 
     result = dask_slice('y', 'x', [100], [[25]*4], [slice(26,None,2)])
     assert expected == result
 
     #x[24::2]
-    expected = {('y', 0): (operator.getitem, ('x', 0), (slice(24, 25, 2),)),
-                ('y', 1): (operator.getitem, ('x', 1), (slice(1, 25, 2),)),
-                ('y', 2): (operator.getitem, ('x', 2), (slice(0, 25, 2),)),
-                ('y', 3): (operator.getitem, ('x', 3), (slice(1, 25, 2),))}
+    expected = {('y', 0): (getitem, ('x', 0), (slice(24, 25, 2),)),
+                ('y', 1): (getitem, ('x', 1), (slice(1, 25, 2),)),
+                ('y', 2): (getitem, ('x', 2), (slice(0, 25, 2),)),
+                ('y', 3): (getitem, ('x', 3), (slice(1, 25, 2),))}
     result = dask_slice('y', 'x', (100,), [(25,)*4], (slice(24,None,2),))
 
     assert expected == result
 
     #x[26::2]
-    expected = {('y', 0): (operator.getitem, ('x', 1), (slice(1, 25, 2),)),
-                ('y', 1): (operator.getitem, ('x', 2), (slice(0, 25, 2),)),
-                ('y', 2): (operator.getitem, ('x', 3), (slice(1, 25, 2),))}
+    expected = {('y', 0): (getitem, ('x', 1), (slice(1, 25, 2),)),
+                ('y', 1): (getitem, ('x', 2), (slice(0, 25, 2),)),
+                ('y', 2): (getitem, ('x', 3), (slice(1, 25, 2),))}
 
     result = dask_slice('y', 'x', (100,), [(25,)*4], (slice(26,None,2),))
     assert expected == result
@@ -161,13 +161,13 @@ def test_dask_slice_1d():
 
 def test_dask_slice_2d():
     #2d slices: x[13::2,10::1]
-    expected = {('y', 0, 0): (operator.getitem,
+    expected = {('y', 0, 0): (getitem,
                                ('x', 0, 0),
                                (slice(13, 20, 2), slice(10, 20, 1))),
-                 ('y', 0, 1): (operator.getitem,
+                 ('y', 0, 1): (getitem,
                                ('x', 0, 1),
                                (slice(13, 20, 2), slice(0, 20, 1))),
-                 ('y', 0, 2): (operator.getitem,
+                 ('y', 0, 2): (getitem,
                                ('x', 0, 2),
                                (slice(13, 20, 2), slice(0, 5, 1)))}
 
@@ -177,13 +177,13 @@ def test_dask_slice_2d():
     assert expected == result
 
     #2d slices with one dimension: x[5,10::1]
-    expected = {('y', 0): (operator.getitem,
+    expected = {('y', 0): (getitem,
                                ('x', 0, 0),
                                (5, slice(10, 20, 1))),
-                 ('y', 1): (operator.getitem,
+                 ('y', 1): (getitem,
                                ('x', 0, 1),
                                (5, slice(0, 20, 1))),
-                 ('y', 2): (operator.getitem,
+                 ('y', 2): (getitem,
                                ('x', 0, 2),
                                (5, slice(0, 5, 1)))}
 
@@ -211,7 +211,7 @@ def test_slicing_with_singleton_indices():
     result = dask_slice('y', 'x', (10, 10), ([5, 5], [5, 5]),
                         (slice(0, 5), 8))
 
-    expected = {('y', 0): (operator.getitem, ('x', 0, 1), (slice(0, 5, 1), 3))}
+    expected = {('y', 0): (getitem, ('x', 0, 1), (slice(0, 5, 1), 3))}
 
     assert expected == result
 

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -228,24 +228,24 @@ def test_take():
     assert result == expected
 
     result = take('y', 'x', [(20, 20, 20, 20), (20, 20)], [5, 1, 47, 3], axis=0)
-    expected = {('y', 0, j):
+    expected = dict((('y', 0, j),
             (getitem,
               (np.concatenate, (list,
                 [(getitem, ('x', 0, j), ([1, 3, 5], slice(None, None, None))),
                  (getitem, ('x', 2, j), ([7], slice(None, None, None)))]),
                 0),
-              ((2, 0, 3, 1), slice(None, None, None)))
-            for j in range(2)}
+              ((2, 0, 3, 1), slice(None, None, None))))
+            for j in range(2))
     assert result == expected
 
     result = take('y', 'x', [(20, 20, 20, 20), (20, 20)], [5, 1, 37, 3], axis=1)
-    expected = {('y', i, 0):
+    expected = dict((('y', i, 0),
             (getitem,
               (np.concatenate, (list,
                 [(getitem, ('x', i, 0), (slice(None, None, None), [1, 3, 5])),
                  (getitem, ('x', i, 1), (slice(None, None, None), [17]))]),
                 1),
-             (slice(None, None, None), (2, 0, 3, 1)))
-           for i in range(4)}
+             (slice(None, None, None), (2, 0, 3, 1))))
+           for i in range(4))
 
     assert result == expected

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -220,9 +220,9 @@ def test_take():
     result = take('y', 'x', [(20, 20, 20, 20)], [5, 1, 47, 3], axis=0)
     expected = {('y', 0):
             (getitem,
-              (np.concatenate,
-                ((getitem, ('x', 0), ([1, 3, 5],)),
-                 (getitem, ('x', 2), ([7],))),
+              (np.concatenate, (list,
+                [(getitem, ('x', 0), ([1, 3, 5],)),
+                 (getitem, ('x', 2), ([7],))]),
                0),
              ((2, 0, 3, 1),))}
     assert result == expected
@@ -230,9 +230,9 @@ def test_take():
     result = take('y', 'x', [(20, 20, 20, 20), (20, 20)], [5, 1, 47, 3], axis=0)
     expected = {('y', 0, j):
             (getitem,
-              (np.concatenate,
-                ((getitem, ('x', 0, j), ([1, 3, 5], slice(None, None, None))),
-                 (getitem, ('x', 2, j), ([7], slice(None, None, None)))),
+              (np.concatenate, (list,
+                [(getitem, ('x', 0, j), ([1, 3, 5], slice(None, None, None))),
+                 (getitem, ('x', 2, j), ([7], slice(None, None, None)))]),
                 0),
               ((2, 0, 3, 1), slice(None, None, None)))
             for j in range(2)}
@@ -241,9 +241,9 @@ def test_take():
     result = take('y', 'x', [(20, 20, 20, 20), (20, 20)], [5, 1, 37, 3], axis=1)
     expected = {('y', i, 0):
             (getitem,
-              (np.concatenate,
-                ((getitem, ('x', i, 0), (slice(None, None, None), [1, 3, 5])),
-                 (getitem, ('x', i, 1), (slice(None, None, None), [17]))),
+              (np.concatenate, (list,
+                [(getitem, ('x', i, 0), (slice(None, None, None), [1, 3, 5])),
+                 (getitem, ('x', i, 1), (slice(None, None, None), [17]))]),
                 1),
              (slice(None, None, None), (2, 0, 3, 1)))
            for i in range(4)}

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -258,7 +258,7 @@ def test_fancy_slice():
     y = fancy_slice('y', x.name, x.shape, x.blockdims,
                     ([1, 2, 9], slice(None, None, None)))
     assert y == \
-        {('y', 0, i): (getitem,
+        dict((('y', 0, i), (getitem,
                        (np.concatenate,
                         (list,
                          [(getitem,
@@ -269,5 +269,5 @@ def test_fancy_slice():
                            ([0], slice(None, None, None))),
                            ]),
                         0),
-                       ((0, 1, 2), slice(None, None, None)))
-                for i in range(4)}
+                       ((0, 1, 2), slice(None, None, None))))
+                for i in range(4))

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -218,19 +218,21 @@ def test_slicing_with_singleton_indices():
 
 def test_take():
     result = take('y', 'x', [(20, 20, 20, 20)], [5, 1, 47, 3], axis=0)
-    expected = {('y', 0): (getitem, (np.concatenate,
-                                            [(getitem, ('x', 0), ([1, 3, 5],)),
-                                             (getitem, ('x', 2), ([7],))],
-                                            0),
-                                    ((2, 0, 3, 1),))}
+    expected = {('y', 0):
+            (getitem,
+              (np.concatenate,
+                ((getitem, ('x', 0), ([1, 3, 5],)),
+                 (getitem, ('x', 2), ([7],))),
+               0),
+             ((2, 0, 3, 1),))}
     assert result == expected
 
     result = take('y', 'x', [(20, 20, 20, 20), (20, 20)], [5, 1, 47, 3], axis=0)
     expected = {('y', 0, j):
             (getitem,
               (np.concatenate,
-                [(getitem, ('x', 0, j), ([1, 3, 5], slice(None, None, None))),
-                 (getitem, ('x', 2, j), ([7], slice(None, None, None)))],
+                ((getitem, ('x', 0, j), ([1, 3, 5], slice(None, None, None))),
+                 (getitem, ('x', 2, j), ([7], slice(None, None, None)))),
                 0),
               ((2, 0, 3, 1), slice(None, None, None)))
             for j in range(2)}
@@ -240,8 +242,8 @@ def test_take():
     expected = {('y', i, 0):
             (getitem,
               (np.concatenate,
-                [(getitem, ('x', i, 0), (slice(None, None, None), [1, 3, 5])),
-                 (getitem, ('x', i, 1), (slice(None, None, None), [17]))],
+                ((getitem, ('x', i, 0), (slice(None, None, None), [1, 3, 5])),
+                 (getitem, ('x', i, 1), (slice(None, None, None), [17]))),
                 1),
              (slice(None, None, None), (2, 0, 3, 1)))
            for i in range(4)}

--- a/dask/async.py
+++ b/dask/async.py
@@ -405,7 +405,7 @@ def inline_functions(dsk, fast_functions=None):
 def functions_of(task):
     """ Set of functions contained within nested task
 
-    >>> task = (add, (mul, 1, 2), (inc, 3))  # doctest: +SKIp
+    >>> task = (add, (mul, 1, 2), (inc, 3))  # doctest: +SKIP
     >>> functions_of(task)  # doctest: +SKIP
     set([add, mul, inc])
     """

--- a/dask/async.py
+++ b/dask/async.py
@@ -372,7 +372,7 @@ Inlining
 We join small cheap tasks on to others to avoid the creation of intermediaries.
 '''
 
-def inline_functions(dsk, fast_functions=None):
+def inline_functions(dsk, fast_functions=None, inline_constants=False):
     """ Inline cheap functions into larger operations
 
     >>> dsk = {'out': (add, 'i', 'd'),  # doctest: +SKIP
@@ -396,7 +396,7 @@ def inline_functions(dsk, fast_functions=None):
               and functions_of(v).issubset(fast_functions)
               and dependents[k]]
     if keys:
-        return inline(dsk, keys)
+        return inline(dsk, keys, inline_constants=inline_constants)
     else:
         return dsk
 

--- a/dask/async.py
+++ b/dask/async.py
@@ -372,7 +372,6 @@ Inlining
 We join small cheap tasks on to others to avoid the creation of intermediaries.
 '''
 
-
 def inline_functions(dsk, fast_functions=None):
     """ Inline cheap functions into larger operations
 
@@ -393,9 +392,14 @@ def inline_functions(dsk, fast_functions=None):
     dependents = reverse_dict(dependencies)
 
     keys = [k for k, v in dsk.items()
-              if functions_of(v).issubset(fast_functions)
+              if istask(v)
+              and functions_of(v).issubset(fast_functions)
               and dependents[k]]
-    return inline(dsk, keys)
+    if keys:
+        return inline(dsk, keys)
+    else:
+        return dsk
+
 
 
 def functions_of(task):

--- a/dask/core.py
+++ b/dask/core.py
@@ -527,4 +527,3 @@ def inline(dsk, keys=None):
             val = subs(val, item, keysubs[item])
         rv[key] = val
     return rv
-

--- a/dask/core.py
+++ b/dask/core.py
@@ -374,7 +374,7 @@ def cull(dsk, keys):
     """
     if not isinstance(keys, list):
         keys = [keys]
-    nxt = set(keys)
+    nxt = set(flatten(keys))
     seen = nxt
     while nxt:
         cur = nxt

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -126,21 +126,14 @@ def test_inline_traverses_lists():
     assert result == expected
 
 
-def test_expand_value():
-    dsk = {'out': (sum, ['i', 'd']),
-           'i': (inc, 'x'),
-           'd': (double, 'y'),
-           'x': 1, 'y': 1}
-    assert expand_value(dsk, [inc], 'd') == (double, 'y')
-    assert expand_value(dsk, [inc], 'i') == (inc, 'x')
-    assert expand_value(dsk, [inc], 'out') == (sum, [(inc, 'x'), 'd'])
-
-
-def test_expand_key():
-    dsk = {'out': (sum, ['i', 'd']),
-           'i': (inc, 'x'),
-           'd': (double, 'y'),
-           'x': 1, 'y': 1}
-    assert expand_key(dsk, [inc], 'd') == 'd'
-    assert expand_key(dsk, [inc], 'i') == (inc, 'x')
-    assert expand_key(dsk, [inc], ['i', 'd']) == [(inc, 'x'), 'd']
+def test_functions_of():
+    a = lambda x: x
+    b = lambda x: x
+    c = lambda x: x
+    assert functions_of((a, 1)) == set([a])
+    assert functions_of((a, (b, 1))) == set([a, b])
+    assert functions_of((a, [(b, 1)])) == set([a, b])
+    assert functions_of((a, [[[(b, 1)]]])) == set([a, b])
+    assert functions_of(1) == set()
+    assert functions_of(a) == set()
+    assert functions_of((a,)) == set([a])

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -115,6 +115,7 @@ def test_cull():
     assert culled == {'x': 1, 'y': (inc, 'x'), 'out': (add, 'y', 10)}
     assert cull(d, 'out') == cull(d, ['out'])
     assert cull(d, ['out', 'z']) == d
+    assert cull(d, [['out'], ['z']]) == cull(d, ['out', 'z'])
     assert raises(KeyError, lambda: cull(d, 'badkey'))
 
 

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -209,3 +209,7 @@ def test_inline():
     d = {'a': 1, 'b': (inc, 'a'), 'c': (inc, 'b'), 'd': (add, 'a', 'c')}
     assert inline(d) == {'b': (inc, 1), 'c': (inc, 'b'), 'd': (add, 1, 'c')}
     assert inline(d, ['a', 'b', 'c']) == {'d': (add, 1, (inc, (inc, 1)))}
+
+def test_inline_always_doesnt_collapse_constants():
+    d = {'a': 1, 'b': (inc, 'a'), 'c': (inc, 'b'), 'd': (add, 'a', 'c')}
+    assert inline(d, ['b', 'c']) == {'a': 1, 'd': (add, 'a', (inc, (inc, 'a')))}


### PR DESCRIPTION
OK, so we do a dual approach to achieve fancy indexing.

Given an index, like 
    
    (5, slice(5, 10, 2), [1, 2, 3])

We first do the normal `dask_slice` solution on the array with the slice replaced with an empty list

    (5, slice(5, 10, 2), slice(None, None, None))

We then follow with the final list list.  I suspect that we could repeat these for multiple lists and achieve Matlab style orthogonal indexing.

It mostly works

Example
-------

```Python
In [1]: from blaze import Data, compute, into

In [2]: import dask.array as da

In [3]: import numpy as np

In [4]: x = np.arange(100).reshape((10, 10))

In [5]: d = Data(into(da.Array, x, blockshape=(3, 3)))

In [6]: np.array(d[5:9, 1:9:2])  # could do this before
Out[6]: 
array([[51, 53, 55, 57],
       [61, 63, 65, 67],
       [71, 73, 75, 77],
       [81, 83, 85, 87]])

In [7]: np.array(d[0:3, [1, 3, 8, 3]])  # Now can do this
Out[7]: 
array([[ 1,  3,  8,  3],
       [11, 13, 18, 13],
       [21, 23, 28, 23]])
```

The actual dask looks like the following 

```Python
In [8]: y = compute(d[0:3, [1, 3, 8, 3]])

In [14]: cull(y.dask, y.keys())
Out[14]: 
{'x_1': array([[ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9],
        [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
        [20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
        [30, 31, 32, 33, 34, 35, 36, 37, 38, 39],
        [40, 41, 42, 43, 44, 45, 46, 47, 48, 49],
        [50, 51, 52, 53, 54, 55, 56, 57, 58, 59],
        [60, 61, 62, 63, 64, 65, 66, 67, 68, 69],
        [70, 71, 72, 73, 74, 75, 76, 77, 78, 79],
        [80, 81, 82, 83, 84, 85, 86, 87, 88, 89],
        [90, 91, 92, 93, 94, 95, 96, 97, 98, 99]]),
 ('slice-2', 0, 0): (<function operator.getitem>,
  ('x_1', 0, 0),
  (slice(0, 3, 1), slice(0, 3, 1))),
 ('slice-2', 0, 1): (<function operator.getitem>,
  ('x_1', 0, 1),
  (slice(0, 3, 1), slice(0, 3, 1))),
 ('slice-2', 0, 2): (<function operator.getitem>,
  ('x_1', 0, 2),
  (slice(0, 3, 1), slice(0, 3, 1))),
 ('x_1', 0, 0): (<function operator.getitem>,
  'x_1',
  (slice(0, 3, None), slice(0, 3, None))),
 ('x_1', 0, 1): (<function operator.getitem>,
  'x_1',
  (slice(0, 3, None), slice(3, 6, None))),
 ('x_1', 0, 2): (<function operator.getitem>,
  'x_1',
  (slice(0, 3, None), slice(6, 9, None))),
 ('x_4', 0, 0): (<function operator.getitem>,
  (<function numpy.core.multiarray.concatenate>,
   (list,
    [(<function operator.getitem>,
      ('slice-2', 0, 0),
      (slice(None, None, None), [1])),
     (<function operator.getitem>,
      ('slice-2', 0, 1),
      (slice(None, None, None), [0, 0])),
     (<function operator.getitem>,
      ('slice-2', 0, 2),
      (slice(None, None, None), [2]))]),
   1),
  (slice(None, None, None), (0, 1, 3, 1)))}
```

Some known problems
--------------------

- [x] `d[0]` fails 
- [ ] Multiple lists fail (though I think that this is probably easy to fix in the Matlab style)
- [x] edge cases may fail

cc @nevermindewe @shoyer