### PR TITLE
Add `inline_constants=True` keyword to inline.

### DIFF
--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -209,3 +209,10 @@ def test_inline():
     d = {'a': 1, 'b': (inc, 'a'), 'c': (inc, 'b'), 'd': (add, 'a', 'c')}
     assert inline(d) == {'b': (inc, 1), 'c': (inc, 'b'), 'd': (add, 1, 'c')}
     assert inline(d, ['a', 'b', 'c']) == {'d': (add, 1, (inc, (inc, 1)))}
+
+    d = {'x': 1, 'y': (inc, 'x'), 'z': (add, 'x', 'y')}
+    assert inline(d) == {'y': (inc, 1), 'z': (add, 1, 'y')}
+    assert inline(d, keys='y') == {'z': (add, 1, (inc, 1))}
+    assert inline(d, keys='y', inline_constants=False) == {
+        'x': 1, 'z': (add, 'x', (inc, 'x'))}
+


### PR DESCRIPTION
As brought up in #25.

`inline_constants` keyword is a good idea.  Inlining constants based on whether `keys` was given or not seemed like a good idea at the time, but it's awkward to introduce a new and unnecessary convention to use in a single function.