### PR TITLE
Dask.array no longer depends on Blaze

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -8,6 +8,7 @@ from .core import (arccos, arcsin, arctan, arctanh, arccosh, arcsinh, arctan2,
         ceil, copysign, cos, cosh, degrees, exp, expm1, fabs, floor, fmod,
         frexp, hypot, isinf, isnan, ldexp, log, log10, log1p, modf, radians,
         sin, sinh, sqrt, tan, tanh, trunc)
+from .reductions import (sum, mean, std, var, any, all, min, max)
 from . import random
 from .wrap import ones, zeros, empty
 restart_ordering()

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -4,6 +4,11 @@ import blaze
 
 halt_ordering()
 from .core import Array, stack, concatenate, tensordot, transpose, from_array
+
+from .core import (arccos, arcsin, arctan, arctanh, arccosh, arcsinh, arctan2,
+        ceil, copysign, cos, cosh, degrees, exp, expm1, fabs, floor, fmod,
+        frexp, hypot, isinf, isnan, ldexp, log, log10, log1p, modf, radians,
+        sin, sinh, sqrt, tan, tanh, trunc)
 from .blaze import np  # need to go through import process here
 from .into import into # Otherwise someone might import later
                        # without ordering halted

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 from multipledispatch import halt_ordering, restart_ordering
-import blaze
 
 halt_ordering()
 from .core import Array, stack, concatenate, tensordot, transpose, from_array
@@ -9,9 +8,6 @@ from .core import (arccos, arcsin, arctan, arctanh, arccosh, arcsinh, arctan2,
         ceil, copysign, cos, cosh, degrees, exp, expm1, fabs, floor, fmod,
         frexp, hypot, isinf, isnan, ldexp, log, log10, log1p, modf, radians,
         sin, sinh, sqrt, tan, tanh, trunc)
-from .blaze import np  # need to go through import process here
-from .into import into # Otherwise someone might import later
-                       # without ordering halted
 from . import random
 from .wrap import ones, zeros, empty
 restart_ordering()

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -450,6 +450,13 @@ class Array(object):
     __float__ = __int__ = __bool__ = __complex__ = compute
 
     def __getitem__(self, index):
+        # Field access, e.g. x['a'] or x[['a', 'b']]
+        if (isinstance(index, (str, unicode)) or
+            (    isinstance(index, list)
+            and all(isinstance(i, (str, unicode)) for i in index))):
+            return elemwise(getitem, self, index)
+
+        # Slicing
         out = next(names)
         if not isinstance(index, tuple):
             index = (index,)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -16,6 +16,7 @@ from .slicing import slice_array, insert_many
 from ..utils import deepmap
 from ..async import inline_functions
 from ..optimize import cull
+from ..compatibility import unicode
 from .. import threaded, core
 
 
@@ -604,12 +605,13 @@ def atop(func, out, out_ind, *args):
     dsk = top(func, out, out_ind, *argindsstr, numblocks=numblocks)
 
     # Dictionary mapping {i: 3, j: 4, ...} for i, j, ... the dimensions
-    shapes = dict((a, a.shape) for a, _ in arginds)
-    dims = broadcast_dimensions(arginds, shapes)
+    shapes = dict((a.name, a.shape) for a, _ in arginds)
+    nameinds = [(a.name, i) for a, i in arginds]
+    dims = broadcast_dimensions(nameinds, shapes)
     shape = tuple(dims[i] for i in out_ind)
 
-    blockdim_dict = dict((a, a.blockdims) for a, _ in arginds)
-    blockdimss = broadcast_dimensions(arginds, blockdim_dict)
+    blockdim_dict = dict((a.name, a.blockdims) for a, _ in arginds)
+    blockdimss = broadcast_dimensions(nameinds, blockdim_dict)
     blockdims = tuple(blockdimss[i] for i in out_ind)
 
     dsks = [a.dask for a, _ in arginds]

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -524,60 +524,37 @@ class Array(object):
     def __rfloordiv__(self, other):
         return elemwise(operator.floordiv, other, self)
 
-    def sum(a, axis=None, keepdims=False):
-        return reduction(a, np.sum, np.sum, axis=axis, keepdims=keepdims)
+    def any(self, axis=None, keepdims=False):
+        from .reductions import any
+        return any(self, axis=axis, keepdims=keepdims)
 
-    def min(a, axis=None, keepdims=False):
-        return reduction(a, np.min, np.min, axis=axis, keepdims=keepdims)
+    def all(self, axis=None, keepdims=False):
+        from .reductions import all
+        return all(self, axis=axis, keepdims=keepdims)
 
-    def max(a, axis=None, keepdims=False):
-        return reduction(a, np.max, np.max, axis=axis, keepdims=keepdims)
+    def min(self, axis=None, keepdims=False):
+        from .reductions import min
+        return min(self, axis=axis, keepdims=keepdims)
 
-    def any(a, axis=None, keepdims=False):
-        return reduction(a, np.any, np.any, axis=axis, keepdims=keepdims)
+    def max(self, axis=None, keepdims=False):
+        from .reductions import max
+        return max(self, axis=axis, keepdims=keepdims)
 
-    def all(a, axis=None, keepdims=False):
-        return reduction(a, np.all, np.all, axis=axis, keepdims=keepdims)
+    def sum(self, axis=None, keepdims=False):
+        from .reductions import sum
+        return sum(self, axis=axis, keepdims=keepdims)
 
-    def mean(a, axis=None, keepdims=False):
-        def chunk(x, **kwargs):
-            n = np.ones_like(x).sum(**kwargs)
-            total = np.sum(x, **kwargs)
-            result = np.empty(shape=n.shape,
-                      dtype=[('total', total.dtype), ('n', n.dtype)])
-            result['n'] = n
-            result['total'] = total
-            return result
-        def agg(pair, **kwargs):
-            return pair['total'].sum(**kwargs) / pair['n'].sum(**kwargs)
-        return reduction(a, chunk, agg, axis=axis, keepdims=keepdims)
+    def mean(self, axis=None, keepdims=False):
+        from .reductions import mean
+        return mean(self, axis=axis, keepdims=keepdims)
 
-    def var(a, axis=None, keepdims=False, ddof=0):
-        def chunk(A, **kwargs):
-            n = np.ones_like(A).sum(**kwargs)
-            x = np.sum(A, dtype='f8', **kwargs)
-            x2 = np.sum(A**2, dtype='f8', **kwargs)
-            result = np.empty(shape=n.shape, dtype=[('x', x.dtype),
-                                                    ('x2', x2.dtype),
-                                                    ('n', n.dtype)])
-            result['x'] = x
-            result['x2'] = x2
-            result['n'] = n
-            return result
+    def std(self, axis=None, keepdims=False, ddof=0):
+        from .reductions import std
+        return std(self, axis=axis, keepdims=keepdims, ddof=ddof)
 
-        def agg(A, **kwargs):
-            x = A['x'].sum(**kwargs)
-            x2 = A['x2'].sum(**kwargs)
-            n = A['n'].sum(**kwargs)
-            result = (x2 / n) - (x / n)**2
-            if ddof:
-                result = result * n / (n - ddof)
-            return result
-
-        return reduction(a, chunk, agg, axis=axis, keepdims=keepdims)
-
-    def std(a, axis=None, keepdims=False, ddof=0):
-        return sqrt(a.var(axis=axis, keepdims=keepdims, ddof=ddof))
+    def var(self, axis=None, keepdims=False, ddof=0):
+        from .reductions import var
+        return var(self, axis=axis, keepdims=keepdims, ddof=ddof)
 
 
 def from_array(x, blockshape=None, name=None, **kwargs):
@@ -907,35 +884,3 @@ sqrt = wrap_elemwise(np.sqrt)
 tan = wrap_elemwise(np.tan)
 tanh = wrap_elemwise(np.tanh)
 trunc = wrap_elemwise(np.trunc)
-
-
-def reduction(x, chunk, aggregate, axis=None, keepdims=None):
-    """ General version of reductions
-
-    >>> reduction(my_array, np.sum, np.sum, axis=0, keepdims=False)  # doctest: +SKIP
-    """
-    if axis is None:
-        axis = tuple(range(x.ndim))
-    if isinstance(axis, int):
-        axis = (axis,)
-
-    chunk2 = partial(chunk, axis=axis, keepdims=True)
-    aggregate2 = partial(aggregate, axis=axis, keepdims=keepdims)
-
-    inds = tuple(range(x.ndim))
-    tmp = atop(chunk2, next(names), inds, x, inds)
-
-    inds2 = tuple(i for i in inds if i not in axis)
-
-    result = atop(compose(aggregate2, curry(_concatenate2, axes=axis)),
-                  next(names), inds2, tmp, inds)
-
-    if keepdims:
-        dsk = result.dask.copy()
-        for k in core.flatten(result._keys()):
-            k2 = (k[0],) + insert_many(k[1:], axis, 0)
-            dsk[k2] = dsk.pop(k)
-        blockdims = insert_many(result.blockdims, axis, [1])
-        return Array(dsk, result.name, blockdims=blockdims)
-    else:
-        return result

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -584,6 +584,9 @@ def from_array(x, blockshape=None, name=None, **kwargs):
 
     Input must have a ``.shape`` and support numpy-style slicing.
 
+    Example
+    -------
+
     >>> x = h5py.File('...')['/data/path']  # doctest: +SKIP
     >>> a = da.from_array(x, blockshape=(1000, 1000))  # doctest: +SKIP
     """
@@ -644,7 +647,7 @@ def stack(seq, axis=0):
     >>> import dask.array as da
     >>> import numpy as np
 
-    >>> data = [Array.from_array(np.ones((4, 4)), blockshape=(2, 2))
+    >>> data = [from_array(np.ones((4, 4)), blockshape=(2, 2))
     ...          for i in range(3)]
 
     >>> x = da.stack(data, axis=0)
@@ -706,7 +709,7 @@ def concatenate(seq, axis=0):
     >>> import dask.array as da
     >>> import numpy as np
 
-    >>> data = [Array.from_array(np.ones((4, 4)), blockshape=(2, 2))
+    >>> data = [from_array(np.ones((4, 4)), blockshape=(2, 2))
     ...          for i in range(3)]
 
     >>> x = da.concatenate(data, axis=0)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -10,7 +10,7 @@ from collections import Iterator
 from functools import partial, wraps
 from toolz.curried import (identity, pipe, partition, concat, unique, pluck,
         frequencies, join, first, memoize, map, groupby, valmap, accumulate,
-        merge, curry)
+        merge, curry, compose)
 import numpy as np
 from .slicing import slice_array
 from ..utils import deepmap
@@ -523,6 +523,61 @@ class Array(object):
     def __rfloordiv__(self, other):
         return elemwise(operator.floordiv, other, self)
 
+    def sum(a, axis=None, keepdims=False):
+        return reduction(a, np.sum, np.sum, axis=axis, keepdims=keepdims)
+
+    def min(a, axis=None, keepdims=False):
+        return reduction(a, np.min, np.min, axis=axis, keepdims=keepdims)
+
+    def max(a, axis=None, keepdims=False):
+        return reduction(a, np.max, np.max, axis=axis, keepdims=keepdims)
+
+    def any(a, axis=None, keepdims=False):
+        return reduction(a, np.any, np.any, axis=axis, keepdims=keepdims)
+
+    def all(a, axis=None, keepdims=False):
+        return reduction(a, np.all, np.all, axis=axis, keepdims=keepdims)
+
+    def mean(a, axis=None, keepdims=False):
+        def chunk(x, **kwargs):
+            n = np.ones_like(x).sum(**kwargs)
+            total = np.sum(x, **kwargs)
+            result = np.empty(shape=n.shape,
+                      dtype=[('total', total.dtype), ('n', n.dtype)])
+            result['n'] = n
+            result['total'] = total
+            return result
+        def agg(pair, **kwargs):
+            return pair['total'].sum(**kwargs) / pair['n'].sum(**kwargs)
+        return reduction(a, chunk, agg, axis=axis, keepdims=keepdims)
+
+    def var(a, axis=None, keepdims=False, ddof=0):
+        def chunk(A, **kwargs):
+            n = np.ones_like(A).sum(**kwargs)
+            x = np.sum(A, dtype='f8', **kwargs)
+            x2 = np.sum(A**2, dtype='f8', **kwargs)
+            result = np.empty(shape=n.shape, dtype=[('x', x.dtype),
+                                                    ('x2', x2.dtype),
+                                                    ('n', n.dtype)])
+            result['x'] = x
+            result['x2'] = x2
+            result['n'] = n
+            return result
+
+        def agg(A, **kwargs):
+            x = A['x'].sum(**kwargs)
+            x2 = A['x2'].sum(**kwargs)
+            n = A['n'].sum(**kwargs)
+            result = (x2 / n) - (x / n)**2
+            if ddof:
+                result = result * n / (n - ddof)
+            return result
+
+        return reduction(a, chunk, agg, axis=axis, keepdims=keepdims)
+
+    def std(a, axis=None, keepdims=False, ddof=0):
+        return sqrt(a.var(axis=axis, keepdims=keepdims, ddof=ddof))
+
 
 def from_array(x, blockshape=None, name=None, **kwargs):
     """ Create dask array from something that looks like an array
@@ -765,7 +820,7 @@ def insert_to_ooc(out, arr):
 def partial_by_order(op, other):
     """
 
-    >>> f = partial_by_order(add, (1, 10))
+    >>> f = partial_by_order(add, [(1, 10)])
     >>> f(5)
     15
     """
@@ -847,3 +902,25 @@ sqrt = wrap_elemwise(np.sqrt)
 tan = wrap_elemwise(np.tan)
 tanh = wrap_elemwise(np.tanh)
 trunc = wrap_elemwise(np.trunc)
+
+
+def reduction(x, chunk, aggregate, axis=None, keepdims=None):
+    """ General version of reductions
+
+    >>> reduction(my_array, np.sum, np.sum, axis=0, keepdims=False)  # doctest: +SKIP
+    """
+    if axis is None:
+        axis = tuple(range(x.ndim))
+    if isinstance(axis, int):
+        axis = (axis,)
+
+    chunk2 = partial(chunk, axis=axis, keepdims=True)
+    aggregate2 = partial(aggregate, axis=axis, keepdims=keepdims)
+
+    inds = tuple(range(x.ndim))
+    tmp = atop(chunk2, next(names), inds, x, inds)
+
+    inds2 = tuple(i for i in inds if i not in axis)
+
+    return atop(compose(aggregate2, curry(_concatenate2, axes=axis)),
+                next(names), inds2, tmp, inds)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -489,6 +489,10 @@ class Array(object):
         return elemwise(operator.gt, self, other)
     def __ge__(self, other):
         return elemwise(operator.ge, self, other)
+    def __lshift__(self, other):
+        return elemwise(operator.lshift, self, other)
+    def __rlshift__(self, other):
+        return elemwise(operator.lshift, other, self)
     def __lt__(self, other):
         return elemwise(operator.lt, self, other)
     def __le__(self, other):
@@ -502,15 +506,21 @@ class Array(object):
     def __rmul__(self, other):
         return elemwise(operator.mul, other, self)
     def __ne__(self, other):
-        return elemwise(operator.ne, other, self)
+        return elemwise(operator.ne, self, other)
     def __neg__(self, other):
         return elemwise(operator.neg, self)
     def __or__(self, other):
+        return elemwise(operator.or_, self, other)
+    def __ror__(self, other):
         return elemwise(operator.or_, other, self)
     def __pow__(self, other):
         return elemwise(operator.pow, self, other)
     def __rpow__(self, other):
         return elemwise(operator.pow, other, self)
+    def __rshift__(self, other):
+        return elemwise(operator.rshift, self, other)
+    def __rrshift__(self, other):
+        return elemwise(operator.rshift, other, self)
     def __sub__(self, other):
         return elemwise(operator.sub, self, other)
     def __rsub__(self, other):
@@ -523,6 +533,10 @@ class Array(object):
         return elemwise(operator.floordiv, self, other)
     def __rfloordiv__(self, other):
         return elemwise(operator.floordiv, other, self)
+    def __xor__(self, other):
+        return elemwise(operator.xor, self, other)
+    def __rxor__(self, other):
+        return elemwise(operator.xor, other, self)
 
     def any(self, axis=None, keepdims=False):
         from .reductions import any

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4,7 +4,7 @@ from operator import add, getitem
 from collections import Iterable
 from bisect import bisect
 import operator
-from math import ceil, floor
+import math
 from itertools import product, count
 from collections import Iterator
 from functools import partial, wraps
@@ -31,7 +31,7 @@ def getem(arr, blocksize, shape):
      ('X', 1, 1): (getitem, 'X', (slice(2, 4), slice(3, 6))),
      ('X', 0, 1): (getitem, 'X', (slice(0, 2), slice(3, 6)))}
     """
-    numblocks = tuple([int(ceil(n/k)) for n, k in zip(shape, blocksize)])
+    numblocks = tuple([int(math.ceil(n/k)) for n, k in zip(shape, blocksize)])
     return dict(
                ((arr,) + ijk,
                (getitem,
@@ -796,3 +796,47 @@ def elemwise(op, *args, **kwargs):
 
     return atop(op2, name, expr_inds,
                 *concat((a, tuple(range(a.ndim)[::-1])) for a in arrays))
+
+
+def wrap_elemwise(func):
+    """ Wrap up numpy function into dask.array """
+    f = partial(elemwise, func)
+    f.__doc__ = func.__doc__
+    f.__name__ = func.__name__
+    return f
+
+
+arccos = wrap_elemwise(np.arccos)
+arcsin = wrap_elemwise(np.arcsin)
+arctan = wrap_elemwise(np.arctan)
+arctanh = wrap_elemwise(np.arctanh)
+arccosh = wrap_elemwise(np.arccosh)
+arcsinh = wrap_elemwise(np.arcsinh)
+arctan2 = wrap_elemwise(np.arctan2)
+
+ceil = wrap_elemwise(np.ceil)
+copysign = wrap_elemwise(np.copysign)
+cos = wrap_elemwise(np.cos)
+cosh = wrap_elemwise(np.cosh)
+degrees = wrap_elemwise(np.degrees)
+exp = wrap_elemwise(np.exp)
+expm1 = wrap_elemwise(np.expm1)
+fabs = wrap_elemwise(np.fabs)
+floor = wrap_elemwise(np.floor)
+fmod = wrap_elemwise(np.fmod)
+frexp = wrap_elemwise(np.frexp)
+hypot = wrap_elemwise(np.hypot)
+isinf = wrap_elemwise(np.isinf)
+isnan = wrap_elemwise(np.isnan)
+ldexp = wrap_elemwise(np.ldexp)
+log = wrap_elemwise(np.log)
+log10 = wrap_elemwise(np.log10)
+log1p = wrap_elemwise(np.log1p)
+modf = wrap_elemwise(np.modf)
+radians = wrap_elemwise(np.radians)
+sin = wrap_elemwise(np.sin)
+sinh = wrap_elemwise(np.sinh)
+sqrt = wrap_elemwise(np.sqrt)
+tan = wrap_elemwise(np.tan)
+tanh = wrap_elemwise(np.tanh)
+trunc = wrap_elemwise(np.trunc)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -461,6 +461,61 @@ class Array(object):
 
         return Array(merge(self.dask, dsk), out, blockdims=blockdims)
 
+    def __abs__(self, other):
+        return elemwise(operator.abs, self)
+    def __add__(self, other):
+        return elemwise(operator.add, self, other)
+    def __radd__(self, other):
+        return elemwise(operator.add, other, self)
+    def __and__(self, other):
+        return elemwise(operator.and_, self, other)
+    def __rand__(self, other):
+        return elemwise(operator.and_, other, self)
+    def __div__(self, other):
+        return elemwise(operator.div, self, other)
+    def __rdiv__(self, other):
+        return elemwise(operator.div, other, self)
+    def __eq__(self, other):
+        return elemwise(operator.eq, self, other)
+    def __gt__(self, other):
+        return elemwise(operator.gt, self, other)
+    def __ge__(self, other):
+        return elemwise(operator.ge, self, other)
+    def __lt__(self, other):
+        return elemwise(operator.lt, self, other)
+    def __le__(self, other):
+        return elemwise(operator.le, self, other)
+    def __mod__(self, other):
+        return elemwise(operator.mod, self, other)
+    def __rmod__(self, other):
+        return elemwise(operator.mod, other, self)
+    def __mul__(self, other):
+        return elemwise(operator.mul, self, other)
+    def __rmul__(self, other):
+        return elemwise(operator.mul, other, self)
+    def __ne__(self, other):
+        return elemwise(operator.ne, other, self)
+    def __neg__(self, other):
+        return elemwise(operator.neg, self)
+    def __or__(self, other):
+        return elemwise(operator.or_, other, self)
+    def __pow__(self, other):
+        return elemwise(operator.pow, self, other)
+    def __rpow__(self, other):
+        return elemwise(operator.pow, other, self)
+    def __sub__(self, other):
+        return elemwise(operator.sub, self, other)
+    def __rsub__(self, other):
+        return elemwise(operator.sub, other, self)
+    def __truediv__(self, other):
+        return elemwise(operator.truediv, self, other)
+    def __rtruediv__(self, other):
+        return elemwise(operator.truediv, other, self)
+    def __floordiv__(self, other):
+        return elemwise(operator.floordiv, self, other)
+    def __rfloordiv__(self, other):
+        return elemwise(operator.floordiv, other, self)
+
 
 def from_array(x, blockshape=None, name=None, **kwargs):
     """ Create dask array from something that looks like an array
@@ -726,7 +781,7 @@ def elemwise(op, *args, **kwargs):
     See also:
         atop
     """
-    name = kwargs['name'] or next(names)
+    name = kwargs.get('name') or next(names)
     out_ndim = max(len(arg.shape) if isinstance(arg, Array) else 0
                    for arg in args)
     expr_inds = tuple(range(out_ndim))[::-1]

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1,0 +1,111 @@
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+from functools import partial, wraps
+from toolz import compose, curry
+
+from .core import _concatenate2, insert_many, Array, atop, names, sqrt
+from ..core import flatten
+
+
+def reduction(x, chunk, aggregate, axis=None, keepdims=None):
+    """ General version of reductions
+
+    >>> reduction(my_array, np.sum, np.sum, axis=0, keepdims=False)  # doctest: +SKIP
+    """
+    if axis is None:
+        axis = tuple(range(x.ndim))
+    if isinstance(axis, int):
+        axis = (axis,)
+
+    chunk2 = partial(chunk, axis=axis, keepdims=True)
+    aggregate2 = partial(aggregate, axis=axis, keepdims=keepdims)
+
+    inds = tuple(range(x.ndim))
+    tmp = atop(chunk2, next(names), inds, x, inds)
+
+    inds2 = tuple(i for i in inds if i not in axis)
+
+    result = atop(compose(aggregate2, curry(_concatenate2, axes=axis)),
+                  next(names), inds2, tmp, inds)
+
+    if keepdims:
+        dsk = result.dask.copy()
+        for k in flatten(result._keys()):
+            k2 = (k[0],) + insert_many(k[1:], axis, 0)
+            dsk[k2] = dsk.pop(k)
+        blockdims = insert_many(result.blockdims, axis, [1])
+        return Array(dsk, result.name, blockdims=blockdims)
+    else:
+        return result
+
+
+@wraps(np.sum)
+def sum(a, axis=None, keepdims=False):
+    return reduction(a, np.sum, np.sum, axis=axis, keepdims=keepdims)
+
+
+@wraps(np.min)
+def min(a, axis=None, keepdims=False):
+    return reduction(a, np.min, np.min, axis=axis, keepdims=keepdims)
+
+
+@wraps(np.max)
+def max(a, axis=None, keepdims=False):
+    return reduction(a, np.max, np.max, axis=axis, keepdims=keepdims)
+
+
+@wraps(np.any)
+def any(a, axis=None, keepdims=False):
+    return reduction(a, np.any, np.any, axis=axis, keepdims=keepdims)
+
+
+@wraps(np.all)
+def all(a, axis=None, keepdims=False):
+    return reduction(a, np.all, np.all, axis=axis, keepdims=keepdims)
+
+
+@wraps(np.mean)
+def mean(a, axis=None, keepdims=False):
+    def chunk(x, **kwargs):
+        n = np.ones_like(x).sum(**kwargs)
+        total = np.sum(x, **kwargs)
+        result = np.empty(shape=n.shape,
+                  dtype=[('total', total.dtype), ('n', n.dtype)])
+        result['n'] = n
+        result['total'] = total
+        return result
+    def agg(pair, **kwargs):
+        return pair['total'].sum(**kwargs) / pair['n'].sum(**kwargs)
+    return reduction(a, chunk, agg, axis=axis, keepdims=keepdims)
+
+
+@wraps(np.var)
+def var(a, axis=None, keepdims=False, ddof=0):
+    def chunk(A, **kwargs):
+        n = np.ones_like(A).sum(**kwargs)
+        x = np.sum(A, dtype='f8', **kwargs)
+        x2 = np.sum(A**2, dtype='f8', **kwargs)
+        result = np.empty(shape=n.shape, dtype=[('x', x.dtype),
+                                                ('x2', x2.dtype),
+                                                ('n', n.dtype)])
+        result['x'] = x
+        result['x2'] = x2
+        result['n'] = n
+        return result
+
+    def agg(A, **kwargs):
+        x = A['x'].sum(**kwargs)
+        x2 = A['x2'].sum(**kwargs)
+        n = A['n'].sum(**kwargs)
+        result = (x2 / n) - (x / n)**2
+        if ddof:
+            result = result * n / (n - ddof)
+        return result
+
+    return reduction(a, chunk, agg, axis=axis, keepdims=keepdims)
+
+
+@wraps(np.std)
+def std(a, axis=None, keepdims=False, ddof=0):
+    return sqrt(a.var(axis=axis, keepdims=keepdims, ddof=ddof))

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -417,7 +417,6 @@ def posify_index(shape, ind):
     return ind
 
 
-
 def insert_many(seq, where, val):
     """ Insert value at many locations in sequence
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -258,3 +258,6 @@ def test_operators():
 
     expr = (3 / a * b)**2 > 5
     assert eq(expr, (3 / x * y)**2 > 5)
+
+    c = exp(a)
+    assert eq(c, np.exp(x))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -66,6 +66,10 @@ def test_rec_concatenate():
 
 
 def eq(a, b):
+    if isinstance(a, Array):
+        a = np.array(a)
+    if isinstance(b, Array):
+        b = np.array(b)
     c = a == b
     if isinstance(c, np.ndarray):
         c = c.all()
@@ -238,3 +242,19 @@ def test_binops():
     assert result.dask[('c', 0)][1] == ('a', 0)
     f = result.dask[('c', 0)][0]
     assert f(10) == 100
+
+
+def test_operators():
+    x = np.arange(10)
+    y = np.arange(10).reshape((10, 1))
+    a = from_array(x, blockshape=(5,))
+    b = from_array(y, blockshape=(5, 1))
+
+    c = a + 1
+    assert eq(c, x + 1)
+
+    c = a + b
+    assert eq(c, x + x.reshape((10, 1)))
+
+    expr = (3 / a * b)**2 > 5
+    assert eq(expr, (3 / x * y)**2 > 5)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -261,3 +261,10 @@ def test_operators():
 
     c = exp(a)
     assert eq(c, np.exp(x))
+
+
+def test_field_access():
+    x = np.array([(1, 1.0), (2, 2.0)], dtype=[('a', 'i4'), ('b', 'f4')])
+    y = from_array(x, blockshape=(1,))
+    assert eq(y['a'], x['a'])
+    assert eq(y[['b', 'a']], x[['b', 'a']])

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -67,9 +67,9 @@ def test_rec_concatenate():
 
 def eq(a, b):
     if isinstance(a, Array):
-        a = np.array(a)
+        a = a.compute()
     if isinstance(b, Array):
-        b = np.array(b)
+        b = b.compute()
     c = a == b
     if isinstance(c, np.ndarray):
         c = c.all()
@@ -268,3 +268,15 @@ def test_field_access():
     y = from_array(x, blockshape=(1,))
     assert eq(y['a'], x['a'])
     assert eq(y[['b', 'a']], x[['b', 'a']])
+
+
+def test_reductions():
+    x = np.arange(400).reshape((20, 20))
+    a = from_array(x, blockshape=(7, 7))
+
+    assert eq(a.sum(), x.sum())
+    assert eq(a.sum(axis=1), x.sum(axis=1))
+    assert eq(a.sum(axis=1, keepdims=True), x.sum(axis=1, keepdims=True))
+    assert eq(a.mean(), x.mean())
+    assert eq(a.var(axis=(1, 0)), x.var(axis=(1, 0)))
+    # assert eq(a.std(axis=0, keepdims=True), x.std(axis=0, keepdims=True))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -279,4 +279,8 @@ def test_reductions():
     assert eq(a.sum(axis=1, keepdims=True), x.sum(axis=1, keepdims=True))
     assert eq(a.mean(), x.mean())
     assert eq(a.var(axis=(1, 0)), x.var(axis=(1, 0)))
-    # assert eq(a.std(axis=0, keepdims=True), x.std(axis=0, keepdims=True))
+
+    b = a.sum(keepdims=True)
+    assert b._keys() == [[(b.name, 0, 0)]]
+
+    assert eq(a.std(axis=0, keepdims=True), x.std(axis=0, keepdims=True))

--- a/dask/array/tests/test_blaze.py
+++ b/dask/array/tests/test_blaze.py
@@ -10,6 +10,10 @@ from operator import getitem
 
 
 def eq(a, b):
+    if isinstance(a, Array):
+        a = a.compute()
+    if isinstance(b, Array):
+        b = b.compute()
     c = a == b
     if isinstance(c, np.ndarray):
         c = c.all()

--- a/dask/array/tests/test_blaze.py
+++ b/dask/array/tests/test_blaze.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import dask
 from dask.array.blaze import *
+from dask.array.into import into
 from into import discover, convert, into
 from collections import Iterable
 from toolz import concat

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -8,7 +8,9 @@ PY2 = sys.version_info[0] == 2
 if PY3:
     import builtins
     from queue import Queue
+    unicode = str
 else:
     import __builtin__ as builtins
     from Queue import Queue
     import operator
+    unicode = unicode


### PR DESCRIPTION
This mostly involved duplicating some logic in blaze, mostly around arithmetic, math functions, and reductions.

```Python
In [1]: import numpy as np

In [2]: import dask.array as da

In [3]: x = np.arange(100).reshape((10, 10))

In [4]: a = da.from_array(x, blockshape=(5, 5))

In [5]: da.exp(a + 1).mean(axis=0)
Out[5]: <dask.array.core.Array at 0x7fede0da33b0>

In [6]: np.array(_)
Out[6]: 
array([  3.31755071e+38,   9.01803782e+38,   2.45135683e+39,
         6.66347874e+39,   1.81132132e+40,   4.92368182e+40,
         1.33839548e+41,   3.63813612e+41,   9.88947930e+41,
         2.68823919e+42])
```

Note that dask's interface is somewhat bare-bones.  Things that Blaze has that dask.array doesn't

1.  clean normalization of various keyword arguments (e.g. `axis=...`)
2.  optimization before generation of dasks (e.g. could move slices up and down expression tree)
3.  Loop fusion through numba 
4.  General abstract-ness and integration with caching systems, blaze server, etc...

Still though, it's nice to be able to code in raw `dask.array`