### PR TITLE
get_sync function for debugging

### DIFF
--- a/dask/async.py
+++ b/dask/async.py
@@ -503,3 +503,14 @@ def state_to_networkx(dsk, state):
     from .dot import to_networkx
     data, func = color_nodes(dsk, state)
     return to_networkx(dsk, data_attributes=data, function_attributes=func)
+
+
+def apply_sync(func, args=(), kwds={}):
+    """ A naive synchronous version of apply_async """
+    return func(*args, **kwds)
+
+
+def get_sync(dsk, keys, **kwargs):
+    from .compatibility import Queue
+    queue = Queue()
+    return get_async(apply_sync, 1, dsk, keys, queue=queue, **kwargs)

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -80,3 +80,13 @@ def test_state_to_networkx():
     g = state_to_networkx(dsk, state)
     assert isinstance(g, nx.DiGraph)
 
+
+def test_get():
+    dsk = {'x': 1, 'y': 2, 'z': (inc, 'x'), 'w': (add, 'z', 'y')}
+    assert get_sync(dsk, 'w') == 4
+    assert get_sync(dsk, ['w', 'z']) == (4, 2)
+
+
+def test_nested_get():
+    dsk = {'x': 1, 'y': 2, 'a': (add, 'x', 'y'), 'b': (sum, ['x', 'y'])}
+    assert get_sync(dsk, ['a', 'b']) == (3, 3)


### PR DESCRIPTION
This provides a synchronous, debuggable `get` function that runs through the threaded/async scheduler.  This allows us to properly debug the fancy scheduler without having to deal with concurrency issues.