### PR TITLE
Add argmin/argmax

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -558,6 +558,14 @@ class Array(object):
         from .reductions import max
         return max(self, axis=axis, keepdims=keepdims)
 
+    def argmin(self, axis=0):
+        from .reductions import argmin
+        return argmin(self, axis=axis)
+
+    def argmax(self, axis=0):
+        from .reductions import argmax
+        return argmax(self, axis=axis)
+
     def sum(self, axis=None, keepdims=False):
         from .reductions import sum
         return sum(self, axis=axis, keepdims=keepdims)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -558,11 +558,11 @@ class Array(object):
         from .reductions import max
         return max(self, axis=axis, keepdims=keepdims)
 
-    def argmin(self, axis=0):
+    def argmin(self, axis=None):
         from .reductions import argmin
         return argmin(self, axis=axis)
 
-    def argmax(self, axis=0):
+    def argmax(self, axis=None):
         from .reductions import argmax
         return argmax(self, axis=axis)
 

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -57,12 +57,12 @@ def max(a, axis=None, keepdims=False):
 
 
 @wraps(np.argmin)
-def argmin(a, axis=0):
+def argmin(a, axis=None):
     return arg_reduction(a, np.min, np.argmin, axis=axis)
 
 
 @wraps(np.argmax)
-def argmax(a, axis=0):
+def argmax(a, axis=None):
     return arg_reduction(a, np.max, np.argmax, axis=axis)
 
 
@@ -165,7 +165,11 @@ def arg_reduction(a, func, argfunc, axis=0):
 
     >>> arg_reduction(my_array, np.min, axis=0)  # doctest: +SKIP
     """
-    assert isinstance(axis, int)
+    if not isinstance(axis, int):
+        raise ValueError("Must specify integer axis= keyword argument.\n"
+                "For example:\n"
+                "  Before:  x.argmin()\n"
+                "  After:   x.argmin(axis=0)\n")
 
     def argreduce(x):
         """ Get both min/max and argmin/argmax of each block """

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import, division, print_function
+
+import dask.array as da
+from dask.array.reductions import arg_aggregate
+import numpy as np
+
+
+def eq(a, b):
+    if isinstance(a, da.Array):
+        a = a.compute()
+    if isinstance(b, da.Array):
+        b = b.compute()
+    c = a == b
+    if isinstance(c, np.ndarray):
+        c = c.all()
+    return c
+
+
+def test_arg_reduction():
+    pairs = [([4, 3, 5], [10, 11, 12]),
+             ([3, 5, 1], [1, 2, 3])]
+    result = arg_aggregate(np.min, np.argmin, (100, 100), pairs)
+    assert eq(result, np.array([101, 11, 103]))
+
+
+def test_reductions():
+    x = np.random.random((20, 20))
+    a = da.from_array(x, blockshape=(7, 7))
+
+    assert eq(a.argmin(axis=1), x.argmin(axis=1))
+    assert eq(a.argmax(axis=0), x.argmax(axis=0))
+    # assert eq(a.argmin(), x.argmin())
+


### PR DESCRIPTION
Add `argmin/argmax` to `dask.array`.  Note that this raises an exception when not given an axis argument as in  `x.argmin()`.  NumPy resorts to `x.flatten().argmin()` in this case which isn't as available to us because we don't think about data in a continuous way.

Example
-------

```Python
In [1]: import numpy as np

In [2]: x = np.random.randint(10, size=(4, 4))

In [3]: x
Out[3]: 
array([[5, 3, 8, 0],
       [0, 2, 9, 2],
       [3, 7, 2, 4],
       [7, 1, 8, 9]])

In [4]: import dask.array as da

In [5]: d = da.from_array(x, blockshape=(2, 2))

In [6]: np.array(d.argmin(axis=0))
Out[6]: array([1, 3, 2, 0])

In [7]: np.array(d.argmin(axis=1))
Out[7]: array([3, 0, 2, 1])

In [8]: x.argmin(axis=0)
Out[8]: array([1, 3, 2, 0])

In [10]: x.argmin(axis=1)
Out[10]: array([3, 0, 2, 1])

In [11]: x.argmin()
Out[11]: 3

In [12]: d.argmin()
ValueError: Must specify integer axis= keyword argument.
For example:
  Before:  x.argmin()
  After:   x.argmin(axis=0)
```

This came up in conversation with @stefanv