### PR TITLE
Add NaN-aware reductions

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -5,6 +5,8 @@ from .core import (arccos, arcsin, arctan, arctanh, arccosh, arcsinh, arctan2,
         ceil, copysign, cos, cosh, degrees, exp, expm1, fabs, floor, fmod,
         frexp, hypot, isinf, isnan, ldexp, log, log10, log1p, modf, radians,
         sin, sinh, sqrt, tan, tanh, trunc)
-from .reductions import (sum, mean, std, var, any, all, min, max, vnorm)
+from .reductions import (sum, prod, mean, std, var, any, all, min, max, vnorm,
+                         nansum, nanprod, nanmean, nanstd, nanvar, nanmin,
+                         nanmax)
 from . import random, linalg
 from .wrap import ones, zeros, empty

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -1,12 +1,15 @@
 from __future__ import absolute_import, division, print_function
 
+from ..utils import ignoring
 from .core import Array, stack, concatenate, tensordot, transpose, from_array
 from .core import (arccos, arcsin, arctan, arctanh, arccosh, arcsinh, arctan2,
         ceil, copysign, cos, cosh, degrees, exp, expm1, fabs, floor, fmod,
         frexp, hypot, isinf, isnan, ldexp, log, log10, log1p, modf, radians,
         sin, sinh, sqrt, tan, tanh, trunc)
 from .reductions import (sum, prod, mean, std, var, any, all, min, max, vnorm,
-                         nansum, nanprod, nanmean, nanstd, nanvar, nanmin,
+                         nansum, nanmean, nanstd, nanvar, nanmin,
                          nanmax, nanargmin, nanargmax)
+with ignoring(ImportError):
+    from .reductions import nanprod
 from . import random, linalg
 from .wrap import ones, zeros, empty

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -7,6 +7,6 @@ from .core import (arccos, arcsin, arctan, arctanh, arccosh, arcsinh, arctan2,
         sin, sinh, sqrt, tan, tanh, trunc)
 from .reductions import (sum, prod, mean, std, var, any, all, min, max, vnorm,
                          nansum, nanprod, nanmean, nanstd, nanvar, nanmin,
-                         nanmax)
+                         nanmax, nanargmin, nanargmax)
 from . import random, linalg
 from .wrap import ones, zeros, empty

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -570,6 +570,10 @@ class Array(object):
         from .reductions import sum
         return sum(self, axis=axis, keepdims=keepdims)
 
+    def prod(self, axis=None, keepdims=False):
+        from .reductions import prod
+        return prod(self, axis=axis, keepdims=keepdims)
+
     def mean(self, axis=None, keepdims=False):
         from .reductions import mean
         return mean(self, axis=axis, keepdims=keepdims)

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -66,9 +66,19 @@ def argmin(a, axis=None):
     return arg_reduction(a, np.min, np.argmin, axis=axis)
 
 
+@wraps(np.nanargmin)
+def nanargmin(a, axis=None):
+    return arg_reduction(a, np.nanmin, np.nanargmin, axis=axis)
+
+
 @wraps(np.argmax)
 def argmax(a, axis=None):
     return arg_reduction(a, np.max, np.argmax, axis=axis)
+
+
+@wraps(np.nanargmax)
+def nanargmax(a, axis=None):
+    return arg_reduction(a, np.nanmax, np.nanargmax, axis=axis)
 
 
 @wraps(np.any)

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -7,6 +7,7 @@ from toolz import compose, curry
 from .core import (_concatenate2, insert_many, Array, atop, names, sqrt,
         elemwise)
 from ..core import flatten
+from ..utils import ignoring
 
 
 def reduction(x, chunk, aggregate, axis=None, keepdims=None):
@@ -96,9 +97,10 @@ def nansum(a, axis=None, keepdims=False):
     return reduction(a, np.nansum, np.sum, axis=axis, keepdims=keepdims)
 
 
-@wraps(np.nanprod)
-def nanprod(a, axis=None, keepdims=False):
-    return reduction(a, np.nanprod, np.prod, axis=axis, keepdims=keepdims)
+with ignoring(AttributeError):
+    @wraps(np.nanprod)
+    def nanprod(a, axis=None, keepdims=False):
+        return reduction(a, np.nanprod, np.prod, axis=axis, keepdims=keepdims)
 
 
 @wraps(np.nanmin)

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -46,6 +46,11 @@ def sum(a, axis=None, keepdims=False):
     return reduction(a, np.sum, np.sum, axis=axis, keepdims=keepdims)
 
 
+@wraps(np.prod)
+def prod(a, axis=None, keepdims=False):
+    return reduction(a, np.prod, np.prod, axis=axis, keepdims=keepdims)
+
+
 @wraps(np.min)
 def min(a, axis=None, keepdims=False):
     return reduction(a, np.min, np.min, axis=axis, keepdims=keepdims)
@@ -76,50 +81,99 @@ def all(a, axis=None, keepdims=False):
     return reduction(a, np.all, np.all, axis=axis, keepdims=keepdims)
 
 
+@wraps(np.nansum)
+def nansum(a, axis=None, keepdims=False):
+    return reduction(a, np.nansum, np.sum, axis=axis, keepdims=keepdims)
+
+
+@wraps(np.nanprod)
+def nanprod(a, axis=None, keepdims=False):
+    return reduction(a, np.nanprod, np.prod, axis=axis, keepdims=keepdims)
+
+
+@wraps(np.nanmin)
+def nanmin(a, axis=None, keepdims=False):
+    return reduction(a, np.nanmin, np.min, axis=axis, keepdims=keepdims)
+
+
+@wraps(np.nanmax)
+def nanmax(a, axis=None, keepdims=False):
+    return reduction(a, np.nanmax, np.max, axis=axis, keepdims=keepdims)
+
+
+def numel(x, **kwargs):
+    """ A reduction to count the number of elements """
+    return np.sum(np.ones_like(x), **kwargs)
+
+
+def nannumel(x, **kwargs):
+    """ A reduction to count the number of elements """
+    return np.sum(~np.isnan(x), **kwargs)
+
+
+def mean_chunk(x, sum=np.sum, numel=numel, **kwargs):
+    n = numel(x, **kwargs)
+    total = sum(x, **kwargs)
+    result = np.empty(shape=n.shape,
+              dtype=[('total', total.dtype), ('n', n.dtype)])
+    result['n'] = n
+    result['total'] = total
+    return result
+
+def mean_agg(pair, **kwargs):
+    return pair['total'].sum(**kwargs) / pair['n'].sum(**kwargs)
+
+
 @wraps(np.mean)
 def mean(a, axis=None, keepdims=False):
-    def chunk(x, **kwargs):
-        n = np.ones_like(x).sum(**kwargs)
-        total = np.sum(x, **kwargs)
-        result = np.empty(shape=n.shape,
-                  dtype=[('total', total.dtype), ('n', n.dtype)])
-        result['n'] = n
-        result['total'] = total
-        return result
-    def agg(pair, **kwargs):
-        return pair['total'].sum(**kwargs) / pair['n'].sum(**kwargs)
-    return reduction(a, chunk, agg, axis=axis, keepdims=keepdims)
+    return reduction(a, mean_chunk, mean_agg, axis=axis, keepdims=keepdims)
+
+
+@wraps(np.nanmean)
+def nanmean(a, axis=None, keepdims=False):
+    return reduction(a, partial(mean_chunk, sum=np.nansum, numel=nannumel),
+                     mean_agg, axis=axis, keepdims=keepdims)
+
+def var_chunk(A, sum=np.sum, numel=numel, **kwargs):
+    n = numel(A, **kwargs)
+    x = sum(A, dtype='f8', **kwargs)
+    x2 = sum(A**2, dtype='f8', **kwargs)
+    result = np.empty(shape=n.shape, dtype=[('x', x.dtype),
+                                            ('x2', x2.dtype),
+                                            ('n', n.dtype)])
+    result['x'] = x
+    result['x2'] = x2
+    result['n'] = n
+    return result
+
+def var_agg(A, ddof=None, **kwargs):
+    x = A['x'].sum(**kwargs)
+    x2 = A['x2'].sum(**kwargs)
+    n = A['n'].sum(**kwargs)
+    result = (x2 / n) - (x / n)**2
+    if ddof:
+        result = result * n / (n - ddof)
+    return result
 
 
 @wraps(np.var)
 def var(a, axis=None, keepdims=False, ddof=0):
-    def chunk(A, **kwargs):
-        n = np.ones_like(A).sum(**kwargs)
-        x = np.sum(A, dtype='f8', **kwargs)
-        x2 = np.sum(A**2, dtype='f8', **kwargs)
-        result = np.empty(shape=n.shape, dtype=[('x', x.dtype),
-                                                ('x2', x2.dtype),
-                                                ('n', n.dtype)])
-        result['x'] = x
-        result['x2'] = x2
-        result['n'] = n
-        return result
+    return reduction(a, var_chunk, partial(var_agg, ddof=ddof), axis=axis, keepdims=keepdims)
 
-    def agg(A, **kwargs):
-        x = A['x'].sum(**kwargs)
-        x2 = A['x2'].sum(**kwargs)
-        n = A['n'].sum(**kwargs)
-        result = (x2 / n) - (x / n)**2
-        if ddof:
-            result = result * n / (n - ddof)
-        return result
 
-    return reduction(a, chunk, agg, axis=axis, keepdims=keepdims)
-
+@wraps(np.nanvar)
+def nanvar(a, axis=None, keepdims=False, ddof=0):
+    return reduction(a, partial(var_chunk, sum=np.nansum, numel=nannumel),
+                     partial(var_agg, ddof=ddof), axis=axis, keepdims=keepdims)
 
 @wraps(np.std)
 def std(a, axis=None, keepdims=False, ddof=0):
     return sqrt(a.var(axis=axis, keepdims=keepdims, ddof=ddof))
+
+
+@wraps(np.nanstd)
+def nanstd(a, axis=None, keepdims=False, ddof=0):
+    return sqrt(nanvar(a, axis=axis, keepdims=keepdims, ddof=ddof))
 
 
 def vnorm(a, ord=None, axis=None, keepdims=False):

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -10,10 +10,10 @@ def eq(a, b):
         a = a.compute()
     if isinstance(b, da.Array):
         b = b.compute()
-    c = a == b
-    if isinstance(c, np.ndarray):
-        c = c.all()
-    return c
+    if isinstance(a, (np.generic, np.ndarray)):
+        return np.allclose(a, b)
+    else:
+        return a == b
 
 
 def test_arg_reduction():
@@ -31,3 +31,18 @@ def test_reductions():
     assert eq(a.argmax(axis=0), x.argmax(axis=0))
     # assert eq(a.argmin(), x.argmin())
 
+
+def test_nan():
+    x = np.array([[1, np.nan, 3, 4],
+                  [5, 6, 7, np.nan],
+                  [9, 10, 11, 12]])
+    d = da.from_array(x, blockshape=(2, 2))
+
+    assert eq(np.nansum(x), da.nansum(d))
+    assert eq(np.nanprod(x), da.nanprod(d))
+    assert eq(np.nansum(x, axis=0), da.nansum(d, axis=0))
+    assert eq(np.nanmean(x, axis=1), da.nanmean(d, axis=1))
+    assert eq(np.nanmin(x, axis=1), da.nanmin(d, axis=1))
+    assert eq(np.nanmax(x, axis=(0, 1)), da.nanmax(d, axis=(0, 1)))
+    assert eq(np.nanvar(x), da.nanvar(d))
+    assert eq(np.nanstd(x, axis=0), da.nanstd(d, axis=0))

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import dask.array as da
+from dask.utils import ignoring
 from dask.array.reductions import arg_aggregate
 import numpy as np
 
@@ -39,7 +40,6 @@ def test_nan():
     d = da.from_array(x, blockshape=(2, 2))
 
     assert eq(np.nansum(x), da.nansum(d))
-    assert eq(np.nanprod(x), da.nanprod(d))
     assert eq(np.nansum(x, axis=0), da.nansum(d, axis=0))
     assert eq(np.nanmean(x, axis=1), da.nanmean(d, axis=1))
     assert eq(np.nanmin(x, axis=1), da.nanmin(d, axis=1))
@@ -48,3 +48,5 @@ def test_nan():
     assert eq(np.nanstd(x, axis=0), da.nanstd(d, axis=0))
     assert eq(np.nanargmin(x, axis=0), da.nanargmin(d, axis=0))
     assert eq(np.nanargmax(x, axis=0), da.nanargmax(d, axis=0))
+    with ignoring(AttributeError):
+        assert eq(np.nanprod(x), da.nanprod(d))

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -46,3 +46,5 @@ def test_nan():
     assert eq(np.nanmax(x, axis=(0, 1)), da.nanmax(d, axis=(0, 1)))
     assert eq(np.nanvar(x), da.nanvar(d))
     assert eq(np.nanstd(x, axis=0), da.nanstd(d, axis=0))
+    assert eq(np.nanargmin(x, axis=0), da.nanargmin(d, axis=0))
+    assert eq(np.nanargmax(x, axis=0), da.nanargmax(d, axis=0))

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
+
 from collections import Iterator
+from contextlib import contextmanager
 
 def raises(err, lamda):
     try:
@@ -24,3 +26,11 @@ def deepmap(func, *seqs):
         return [deepmap(func, *items) for items in zip(*seqs)]
     else:
         return func(*seqs)
+
+
+@contextmanager
+def ignoring(*exceptions):
+    try:
+        yield
+    except exceptions:
+        pass


### PR DESCRIPTION
These use np.nansum, np.nanmin, etc. to implement da.nansum, da.nanmean, etc.

Example
-------

    In [1]: import numpy as np

    In [2]: import dask.array as da

    In [3]: x = np.array([[1, np.nan, 3, 4],
       ...:               [5, 6, 7, np.nan],
          ...:               [9, 10, 11, 12]])

    In [4]: d = da.from_array(x, blockshape=(2, 2))

    In [5]: np.nansum(x)
    Out[5]: 68.0

    In [6]: np.nansum(x, axis=0)
    Out[6]: array([ 15.,  16.,  21.,  16.])

    In [7]: da.nansum(d).compute()
    Out[7]: 68.0

    In [8]: da.nansum(d, axis=0).compute()
    Out[8]: array([ 15.,  16.,  21.,  16.])

    In [9]: da.nanstd(d, axis=0).compute()
    Out[9]: array([ 3.26598632,  2.        ,  3.26598632,  4.        ])

    In [10]: np.nanstd(x, axis=0)
    Out[10]: array([ 3.26598632,  2.        ,  3.26598632,  4.        ])

cc @shoyer https://github.com/xray/xray/issues/328