### PR TITLE
Coarsen

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from ..utils import ignoring
 from .core import (Array, stack, concatenate, tensordot, transpose, from_array,
-        choose)
+        choose, coarsen)
 from .core import (arccos, arcsin, arctan, arctanh, arccosh, arcsinh, arctan2,
         ceil, copysign, cos, cosh, degrees, exp, expm1, fabs, floor, fmod,
         frexp, hypot, isinf, isnan, ldexp, log, log10, log1p, modf, radians,

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -1,0 +1,51 @@
+""" A set of NumPy functions to apply per chunk """
+
+from toolz import concat
+import numpy as np
+
+
+def coarsen(reduction, x, axes):
+    """ Coarsen array by applying reduction to fixed size neighborhoods
+
+    Parameters
+    ----------
+
+    reduction: function
+        Function like np.sum, np.mean, etc...
+    x: np.ndarray
+        Array to be coarsened
+    axes: dict
+        Mapping of axis to coarsening factor
+
+    Example
+    -------
+
+    >>> x = np.array([1, 2, 3, 4, 5, 6])
+    >>> coarsen(np.sum, x, {0: 2})
+    array([ 3,  7, 11])
+    >>> coarsen(np.max, x, {0: 3})
+    array([3, 6])
+
+    Provide dictionary of scale per dimension
+
+    >>> x = np.arange(24).reshape((4, 6))
+    >>> x
+    array([[ 0,  1,  2,  3,  4,  5],
+           [ 6,  7,  8,  9, 10, 11],
+           [12, 13, 14, 15, 16, 17],
+           [18, 19, 20, 21, 22, 23]])
+
+    >>> coarsen(np.min, x, {0: 2, 1: 3})
+    array([[ 0,  3],
+           [12, 15]])
+    """
+    # Insert singleton dimensions if they don't exist already
+    for i in range(x.ndim):
+        if i not in axes:
+            axes[i] = 1
+
+    # (10, 10) -> (5, 2, 5, 2)
+    newshape = tuple(concat([(x.shape[i] / axes[i], axes[i])
+                                for i in range(x.ndim)]))
+
+    return reduction(x.reshape(newshape), axis=tuple(range(1, x.ndim*2, 2)))

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -956,10 +956,13 @@ def coarsen(reduction, x, axes):
         raise ValueError(
             "Coarsening factor does not align with block dimensions")
 
+    if 'dask' in reduction.func_code.co_filename:
+        reduction = getattr(np, reduction.__name__)
+
     name = next(names)
     dsk = dict(((name,) + key[1:], (chunk.coarsen, reduction, key, axes))
                 for key in core.flatten(x._keys()))
-    blockdims = tuple(tuple(bd / axes.get(i, 1) for bd in bds)
+    blockdims = tuple(tuple(int(bd / axes.get(i, 1)) for bd in bds)
                       for i, bds in enumerate(x.blockdims))
 
     return Array(merge(x.dask, dsk), name, blockdims=blockdims)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from operator import add, getitem
+import inspect
 from collections import Iterable
 from bisect import bisect
 import operator
@@ -956,7 +957,7 @@ def coarsen(reduction, x, axes):
         raise ValueError(
             "Coarsening factor does not align with block dimensions")
 
-    if 'dask' in reduction.func_code.co_filename:
+    if 'dask' in inspect.getfile(reduction):
         reduction = getattr(np, reduction.__name__)
 
     name = next(names)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -343,3 +343,11 @@ def test_choose():
 
     assert eq(choose(d > 5, [0, d]), np.choose(x > 5, [0, x]))
     assert eq(choose(d > 5, [-d, d]), np.choose(x > 5, [-x, x]))
+
+
+def test_coarsen():
+    x = np.random.randint(10, size=(24, 24))
+    d = from_array(x, blockshape=(4, 8))
+
+    assert eq(chunk.coarsen(np.sum, x, {0: 2, 1: 4}),
+                    coarsen(np.sum, d, {0: 2, 1: 4}))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import dask
+import dask.array as da
 from dask.array.core import *
 from dask.utils import raises
 from toolz import merge
@@ -351,3 +352,5 @@ def test_coarsen():
 
     assert eq(chunk.coarsen(np.sum, x, {0: 2, 1: 4}),
                     coarsen(np.sum, d, {0: 2, 1: 4}))
+    assert eq(chunk.coarsen(np.sum, x, {0: 2, 1: 4}),
+                    coarsen(da.sum, d, {0: 2, 1: 4}))

--- a/dask/array/tests/test_chunk.py
+++ b/dask/array/tests/test_chunk.py
@@ -13,3 +13,13 @@ def test_coarsen():
     y = coarsen(np.sum, x, {0: 2, 1: 4})
     assert y.shape == (12, 6)
     assert y[0, 0] == np.sum(x[:2, :4])
+
+
+"""
+def test_coarsen_on_uneven_shape():
+    x = np.random.randint(10, size=(23, 24))
+    y = coarsen(np.sum, x, {0: 2, 1: 4})
+    assert y.shape == (12, 6)
+    assert y[0, 0] == np.sum(x[:2, :4])
+    assert eq(y[11, :], x[23, :])
+"""

--- a/dask/array/tests/test_chunk.py
+++ b/dask/array/tests/test_chunk.py
@@ -1,0 +1,15 @@
+import numpy as np
+from dask.array.chunk import coarsen
+
+def eq(a, b):
+    c = a == b
+    if isinstance(c, np.ndarray):
+        c = c.all()
+    return c
+
+
+def test_coarsen():
+    x = np.random.randint(10, size=(24, 24))
+    y = coarsen(np.sum, x, {0: 2, 1: 4})
+    assert y.shape == (12, 6)
+    assert y[0, 0] == np.sum(x[:2, :4])


### PR DESCRIPTION
Coarsening operation.  Efficiently applies any numpy reduction to small neighborhoods.  This includes both a numpy version and a dask version.  

This assumes that shape and block sizes line up nicely with coarsening scales which can be a significant limitation.

This would be useful for some abstract rendering techniques (cc @bryevdv) and part of multigrid (cc @maxhutch)

Example
-------

```Python
    >>> x = np.array([1, 2, 3, 4, 5, 6])
    >>> coarsen(np.sum, x, {0: 2})
    array([ 3,  7, 11])
    >>> coarsen(np.max, x, {0: 3})
    array([3, 6])

    Provide dictionary of scale per dimension

    >>> x = np.arange(24).reshape((4, 6))
    >>> x
    array([[ 0,  1,  2,  3,  4,  5],
           [ 6,  7,  8,  9, 10, 11],
           [12, 13, 14, 15, 16, 17],
           [18, 19, 20, 21, 22, 23]])

    >>> coarsen(np.min, x, {0: 2, 1: 3})
    array([[ 0,  3],
           [12, 15]])
```

Dask example
-----------

```Python
Here is an example workflow and image:

Point to potentially very large dataset (although in this case quite small)

In [1]: import netCDF4

In [2]: t = netCDF4.Dataset('2014-01-01.nc3').variables['t2m']

In [3]: t.shape
Out[3]: (4, 721, 1440)

Tell dask how to block up this dataset (still no actual work done)

In [4]: import dask.array as da

In [5]: d = da.from_array(t, blockshape=(4, 90, 90))

In [6]: d = d[:, :-1, :]

In [7]: d.shape
Out[7]: (4, 720, 1440)

Coarsen by 5x5 blocks in first an second dimensions, using np.min/max on each block.

In [8]: import numpy as np

In [9]: max = da.coarsen(np.max, d, {1: 5, 2: 5})

In [10]: min = da.coarsen(np.min, d, {1: 5, 2: 5})

In [11]: max.shape
Out[11]: (4, 144, 288)

Plot (btw, bokeh should accept __array__ protocol)

In [12]: import matplotlib.pyplot as plt
In [13]: plt.imshow((max - min).mean(axis=0), cmap='RdBu_r')
```

![diff](https://cloud.githubusercontent.com/assets/306380/6320950/5f378aa6-baa1-11e4-8d94-ddf315840574.png)
