### PR TITLE
Add *.egg-info to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+*.egg-info


### PR DESCRIPTION
I found it listed as an untracked file after installing dask.