### PR TITLE
Provide support for __len__

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -454,6 +454,9 @@ class Array(object):
     def shape(self):
         return tuple(map(sum, self.blockdims))
 
+    def __len__(self):
+        return self.shape[0]
+
     @property
     def dtype(self):
         if self.shape:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -455,7 +455,7 @@ class Array(object):
         return tuple(map(sum, self.blockdims))
 
     def __len__(self):
-        return self.shape[0]
+        return sum(self.blockdims[0])
 
     @property
     def dtype(self):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -137,6 +137,10 @@ def test_Array():
 
     assert a.blockdims == ((100,) * 10, (100,) * 10)
 
+    assert a.shape == shape
+
+    assert len(a) == shape[0]
+
 
 def test_uneven_blockdims():
     a = Array({}, 'x', shape=(10, 10), blockshape=(3, 3))


### PR DESCRIPTION
Fixes #54. Provides an easy way to get the `len` of a dask.