### PR TITLE
np.array(dask.Array) works even with no shape

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -495,6 +495,8 @@ class Array(object):
         x = self.compute()
         if dtype and x.dtype != dtype:
             x = x.astype(dtype)
+        if not isinstance(x, np.ndarray):
+            x = np.array(x)
         return x
 
     def store(self, target, **kwargs):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -463,3 +463,9 @@ def test_compute():
     A, B = compute(a, b)
     assert eq(A, d + 1)
     assert eq(B, d + 2)
+
+
+def test_np_array_with_zero_dimensions():
+    d = da.ones((4, 4), blockshape=(2, 2))
+    assert eq(np.array(d.sum()), np.array(d.compute().sum()))
+


### PR DESCRIPTION
Example
-------

    In [1]: import dask.array as da

    In [2]: import numpy as np

    In [3]: x = da.ones(5, blockshape=(2,))

    In [4]: np.array(x.sum())
    Out[4]: array(5.0)

Fixes https://github.com/mrocklin/dask/issues/3
Reported by @rhattersley