### PR TITLE
Add syntactic rewriting

### DIFF
--- a/dask/rewrite.py
+++ b/dask/rewrite.py
@@ -1,0 +1,307 @@
+from collections import deque
+from dask.core import istask, subs
+
+
+def head(task):
+    """Return the top level node of a task"""
+
+    if task is None:
+        return None
+    if istask(task):
+        return task[0]
+    elif isinstance(task, list):
+        return list
+    else:
+        return task
+
+
+def args(task):
+    """Get the arguments for the current task"""
+
+    if istask(task):
+        return task[1:]
+    elif isinstance(task, list):
+        return task
+    else:
+        return ()
+
+
+class Traverser(object):
+    """Traverser interface for tasks"""
+
+    def __init__(self, term, stack=None):
+        self._term = term
+        if not stack:
+            self._stack = deque([None])
+        else:
+            self._stack = stack
+
+    def copy(self):
+        return Traverser(self._term, deque(self._stack))
+
+    def next(self):
+        subterms = args(self._term)
+        if not subterms:
+            # No subterms, pop off stack
+            self._term = self._stack.pop()
+        else:
+            self._term = subterms[0]
+            for t in reversed(subterms[1:]):
+                self._stack.append(t)
+
+    @property
+    def current(self):
+        return head(self._term)
+
+    def skip(self):
+        self._term = self._stack.pop()
+
+
+def preorder_traversal(task):
+    """Traverse a task."""
+    for item in task:
+        if isinstance(item, tuple):
+            for i in preorder_traversal(item):
+                yield i
+        elif isinstance(item, list):
+            yield list
+            for i in preorder_traversal(item):
+                yield i
+        else:
+            yield item
+
+
+class Var(object):
+    """A variable object. Matches with any node."""
+
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return self._name
+
+
+# A variable to represent *all* variables in a discrimination net
+VAR = Var('?')
+
+
+class Node(tuple):
+    """A Discrimination Net node."""
+
+    __slots__ = ()
+
+    def __new__(cls, edges=None, patterns=None):
+        edges = edges if edges else {}
+        patterns = patterns if patterns else []
+        return tuple.__new__(cls, (edges, patterns))
+
+    @property
+    def edges(self):
+        """A dictionary, where the keys are edges, and the values are nodes"""
+        return self[0]
+
+    @property
+    def patterns(self):
+        """A list of all patterns that currently match at this node"""
+        return self[1]
+
+
+class RewriteRule(object):
+    """A rewrite rule.
+
+    Expresses ``lhs`` -> ``rhs``, for variables ``vars``.
+
+    Parameters
+    ----------
+
+    lhs : task
+        The left-hand-side of the rewrite rule.
+    rhs : task
+        The right-hand-side of the rewrite rule.
+    vars: tuple
+        Tuple of variables found in the lhs.
+    """
+
+    def __init__(self, lhs, rhs, vars=()):
+        if not istask(lhs) or not istask(rhs):
+            raise TypeError("lhs and rhs must both be tasks")
+        if not isinstance(vars, tuple):
+            raise TypeError("vars must be a tuple of variables")
+        self.lhs = lhs
+        self.rhs = rhs
+        self._varlist = [t for t in preorder_traversal(lhs) if t in vars]
+        # Reduce vars down to just variables found in lhs
+        self.vars = tuple(set(self._varlist))
+
+    def __str__(self):
+        return "RewriteRule({0}, {1}, {2})".format(self.lhs, self.rhs, self.vars)
+
+    def __repr__(self):
+        return str(self)
+
+
+class RuleSet(object):
+    """A set of rewrite rules.
+
+    Forms a structure for fast rewriting over a set of rewrite rules.
+
+    Parameters:
+    -----------
+    rules: RewriteRule
+        One or instances of RewriteRule
+    """
+
+    def __init__(self, *rules):
+        self._net = Node()
+        self._rules = []
+        for p in rules:
+            self.add(p)
+
+    def add(self, rule):
+        """Add a rule to the RuleSet."""
+
+        if not isinstance(rule, RewriteRule):
+            raise TypeError("rule must be instance of RewriteRule")
+        vars = rule.vars
+        curr_node = self._net
+        ind = len(self._rules)
+        # List of variables, in order they appear in the POT of the term
+        for t in preorder_traversal(rule.lhs):
+            prev_node = curr_node
+            if t in vars:
+                t = VAR
+            if t in curr_node.edges:
+                curr_node = curr_node.edges[t]
+            else:
+                curr_node.edges[t] = Node()
+                curr_node = curr_node.edges[t]
+        # We've reached a leaf node. Add the term index to this leaf.
+        prev_node.edges[t].patterns.append(ind)
+        self._rules.append(rule)
+
+    def iter_matches(self, term):
+        """Lazily find matchings for term from the RuleSet.
+
+        Paramters:
+        ----------
+        term : task
+
+        Returns:
+        --------
+        A generator that yields tuples of ``(rule, subs)``, where ``rule`` is
+        the rewrite rule being matched, and ``subs`` is a dictionary mapping
+        the variables in that lhs of the rule to their matching values in the
+        term."""
+
+        S = Traverser(term)
+        for m, syms in _match(S, self._net):
+            for i in m:
+                rule = self._rules[i]
+                subs = _process_match(rule, syms)
+                if subs is not None:
+                    yield rule, subs
+
+    def _rewrite(self, term):
+        """Apply the rewrite rules in RuleSet to top level of term"""
+
+        try:
+            rule, sd = next(self.iter_matches(term))
+            term = rule.rhs
+            for key, val in sd.items():
+                term = subs(term, key, val)
+            return term
+        except StopIteration:
+            return term
+
+    def rewrite(self, term, strategy="bottom_up"):
+        """Apply the rule set to ``term``.
+
+        Parameters:
+        -----------
+        term: dask, or a task
+            The item to be rewritten
+        strategy: str, optional
+            The rewriting strategy to use. Options are "bottom_up" (default),
+            or "top_level".
+        """
+        func = strategies[strategy]
+        if isinstance(term, dict):
+            return dict((k, func(self, v)) for (k, v) in term.items())
+        return func(self, term)
+
+
+def _top_level(net, term):
+    return net._rewrite(term)
+
+
+def _bottom_up(net, term):
+    if not istask(term):
+        return net._rewrite(term)
+    else:
+        new_args = tuple(_bottom_up(net, t) for t in args(term))
+        new_term = (head(term),) + new_args
+    return net._rewrite(new_term)
+
+
+strategies = {'top_level': _top_level,
+              'bottom_up': _bottom_up}
+
+
+def _match(S, N):
+    """Structural matching of term S to discrimination net node N."""
+
+    stack = deque()
+    matches = deque()
+    restore_state_flag = False
+    while True:
+        n = N.edges.get(VAR, None)
+        if n and restore_state_flag:
+            matches.pop()
+        if n and not restore_state_flag:
+            stack.append((S.copy(), N))
+            matches.append(S._term)
+            S.skip()
+            N = n
+        else:
+            n = N.edges.get(S.current, None)
+            if n:
+                restore_state_flag = False
+                N = n
+                S.next()
+                continue
+            if S.current is None:
+                yield N.patterns, matches
+            try:
+                (S, N) = stack.pop()
+                restore_state_flag = True
+            except:
+                return
+
+
+def _process_match(rule, syms):
+    """Process a match to determine if it is correct, and to find the correct
+    substitution that will convert the term into the pattern.
+
+    Parameters:
+    -----------
+    rule : RewriteRule
+    syms : iterable
+        Iterable of subterms that match a corresponding variable.
+
+    Returns:
+    --------
+    A dictionary of {vars : subterms} describing the substitution to make the
+    pattern equivalent with the term. Returns ``None`` if the match is
+    invalid."""
+
+    subs = {}
+    varlist = rule._varlist
+    if not len(varlist) == len(syms):
+        print(rule, syms, varlist)
+        assert 0 == 1
+    for v, s in zip(varlist, syms):
+        if v in subs and subs[v] is not s:
+            return None
+        else:
+            subs[v] = s
+    return subs

--- a/dask/tests/test_rewrite.py
+++ b/dask/tests/test_rewrite.py
@@ -1,0 +1,123 @@
+from dask.rewrite import RewriteRule, RuleSet, head, args, VAR, Traverser
+
+
+def inc(x):
+    return x + 1
+
+
+def add(x, y):
+    return x + y
+
+
+def double(x):
+    return x * 2
+
+
+def test_head():
+    assert head((inc, 1)) == inc
+    assert head((add, 1, 2)) == add
+    assert head((add, (inc, 1), (inc, 1))) == add
+    assert head([1, 2, 3]) == list
+
+
+def test_args():
+    assert args((inc, 1)) == (1,)
+    assert args((add, 1, 2)) == (1, 2)
+    assert args(1) == ()
+    assert args([1, 2, 3]) == [1, 2, 3]
+
+
+def test_traverser():
+    term = (add, (inc, 1), (double, (inc, 1), 2))
+    t = Traverser(term)
+    t2 = t.copy()
+    assert t.current == add
+    t.next()
+    assert t.current == inc
+    # Ensure copies aren't advanced when the original advances
+    assert t2.current == add
+    t.skip()
+    assert t.current == double
+    t.next()
+    assert t.current == inc
+    assert list(t2) == [add, inc, 1, double, inc, 1, 2]
+
+
+vars = ("a", "b", "c")
+# add(a, 1) -> inc(a)
+rule1 = RewriteRule((add, "a", 1), (inc, "a"), vars)
+# add(a, a) -> double(a)
+rule2 = RewriteRule((add, "a", "a"), (double, "a"), vars)
+# add(inc(a), inc(a)) -> add(double(a), 2)
+rule3 = RewriteRule((add, (inc, "a"), (inc, "a")), (add, (double, "a"), 2), vars)
+# add(inc(b), inc(a)) -> add(add(a, b), 2)
+rule4 = RewriteRule((add, (inc, "b"), (inc, "a")), (add, (add, "a", "b"), 2), vars)
+# sum([c, b, a]) -> add(add(a, b), c)
+rule5 = RewriteRule((sum, ["c", "b", "a"]), (add, (add, "a", "b"), "c"), vars)
+
+
+def test_RewriteRule():
+    # Test extraneous vars are removed, varlist is correct
+    assert rule1.vars == ("a",)
+    assert rule1._varlist == ["a"]
+    assert rule2.vars == ("a",)
+    assert rule2._varlist == ["a", "a"]
+    assert rule3.vars == ("a",)
+    assert rule3._varlist == ["a", "a"]
+    assert rule4.vars == ("a", "b")
+    assert rule4._varlist == ["b", "a"]
+    assert rule5.vars == ("a", "b", "c")
+    assert rule5._varlist == ["c", "b", "a"]
+
+
+rules = [rule1, rule2, rule3, rule4, rule5]
+rs = RuleSet(*rules)
+
+
+def test_RuleSet():
+    net = ({sum: ({list: ({VAR: ({VAR: ({VAR: ({}, [4])}, [])}, [])}, [])},
+        []), add: ({inc: ({VAR: ({inc: ({VAR: ({}, [2, 3])}, [])}, [])}, []),
+            VAR: ({1: ({}, [0]), VAR: ({}, [1])}, [])}, [])}, [])
+    assert rs._net == net
+    assert rs.rules == rules
+
+
+def test_matches():
+    term = (add, 2, 1)
+    matches = list(rs.iter_matches(term))
+    assert len(matches) == 1
+    assert matches[0] == (rule1, {'a': 2})
+    # Test matches specific before general
+    term = (add, 1, 1)
+    matches = list(rs.iter_matches(term))
+    assert len(matches) == 2
+    assert matches[0] == (rule1, {'a': 1})
+    assert matches[1] == (rule2, {'a': 1})
+    # Test matches unhashable. What it's getting rewritten to doesn't make
+    # sense, this is just to test that it works. :)
+    term = (add, [1], [1])
+    matches = list(rs.iter_matches(term))
+    assert len(matches) == 1
+    assert matches[0] == (rule2, {'a': [1]})
+    # Test match at depth
+    term = (add, (inc, 1), (inc, 1))
+    matches = list(rs.iter_matches(term))
+    assert len(matches) == 3
+    assert matches[0] == (rule3, {'a': 1})
+    assert matches[1] == (rule4, {'a': 1, 'b': 1})
+    assert matches[2] == (rule2, {'a': (inc, 1)})
+    # Test non-linear pattern checking
+    term = (add, 2, 3)
+    matches = list(rs.iter_matches(term))
+    assert len(matches) == 0
+
+
+def test_rewrite():
+    term = (sum, [(add, 1, 1), (add, 1, 1), (add, 1, 1)])
+    new_term = rs.rewrite(term)
+    assert new_term == (add, (add, (add, 1, 1), (add, 1, 1)), (add, 1, 1))
+    # Rules aren't applied to exhaustion, this can be further simplified
+    new_term = rs.rewrite(new_term)
+    assert new_term == (add, (add, (double, 1), 2), (inc, 1))
+    term = (add, (add, (add, (add, 1, 2), (add, 1, 2)), (add, (add, 1, 2), (add, 1, 2))), 1)
+    assert rs.rewrite(term) == (inc, (double, (double, (add, 1, 2))))


### PR DESCRIPTION
Allows for creation of a ``RuleSet`` of rewrite rules, and applying these rules to a dask, or a single task. Matching is done syntactically only, and assumes all functions have fixed arity. Addresses #79.

Current capabilities:
- Bottom up rewriting of terms
- Lazy generation of matches from a matchset
- Nonlinear patterns (variables can be in a pattern more than once)

Demonstration:

```
from dask.rewrite import *
from dask.core import get

def f(a):
    return a

def g(a, b):
    return a + b

def h(a):
    return sum(a)

r = RuleSet(RewriteRule((g, (f, 'x'), 'y'), (f, (g, 'x', 'y')), ('x', 'y')),
            RewriteRule((g, (h, ['x']), 'x'), (g, 'x', 'x'), ('x',)))

dsk = {'x': (g, (f, 1), 2),
       'y': (g, (h, [1]), 1)}

new_dsk = r.rewrite(dsk)
```

The code was pulled and modified from some work I've been doing on matching for SymPy, and is thus mostly optimized for computer algebra applications. Even so, the above rewrite operation runs in ~260 microseconds on my 6 year old laptop.

Todo:
- [x] Add tests
- [x] Settle on interface design
