### PR TITLE
Add isnull and notnull

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -6,7 +6,7 @@ from .core import (Array, stack, concatenate, tensordot, transpose, from_array,
 from .core import (arccos, arcsin, arctan, arctanh, arccosh, arcsinh, arctan2,
         ceil, copysign, cos, cosh, degrees, exp, expm1, fabs, floor, fmod,
         frexp, hypot, isinf, isnan, ldexp, log, log10, log1p, modf, radians,
-        sin, sinh, sqrt, tan, tanh, trunc)
+        sin, sinh, sqrt, tan, tanh, trunc, isnull, notnull)
 from .reductions import (sum, prod, mean, std, var, any, all, min, max, vnorm,
                          nansum, nanmean, nanstd, nanvar, nanmin,
                          nanmax, nanargmin, nanargmax)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -585,6 +585,8 @@ class Array(object):
         return elemwise(operator.gt, self, other)
     def __ge__(self, other):
         return elemwise(operator.ge, self, other)
+    def __invert__(self):
+        return elemwise(operator.invert, self)
     def __lshift__(self, other):
         return elemwise(operator.lshift, self, other)
     def __rlshift__(self, other):
@@ -607,6 +609,8 @@ class Array(object):
         return elemwise(operator.neg, self)
     def __or__(self, other):
         return elemwise(operator.or_, self, other)
+    def __pos__(self):
+        return self
     def __ror__(self, other):
         return elemwise(operator.or_, other, self)
     def __pow__(self, other):
@@ -1074,6 +1078,16 @@ sqrt = wrap_elemwise(np.sqrt)
 tan = wrap_elemwise(np.tan)
 tanh = wrap_elemwise(np.tanh)
 trunc = wrap_elemwise(np.trunc)
+
+
+def isnull(values):
+    """ pandas.isnull for dask arrays """
+    import pandas as pd
+    return elemwise(pd.isnull, values)
+
+def notnull(values):
+    """ pandas.notnull for dask arrays """
+    return ~isnull(values)
 
 
 def variadic_choose(a, *choices):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -257,6 +257,13 @@ def test_binops():
     assert f(10) == 100
 
 
+def test_isnull():
+    x = np.array([1, np.nan])
+    a = from_array(x, blockshape=(2,))
+    assert eq(isnull(a), np.isnan(x))
+    assert eq(notnull(a), ~np.isnan(x))
+
+
 def test_elemwise_on_scalars():
     x = np.arange(10)
     a = from_array(x, blockshape=(5,))
@@ -288,6 +295,7 @@ def test_operators():
     assert eq(c, np.exp(x))
 
     assert eq(abs(-a), a)
+    assert eq(a, +x)
 
 
 def test_field_access():


### PR DESCRIPTION
The pandas functions are more robust than np.isnan (e.g., they don't fail on integer dtypes).

Also added support for the unary operations `~` and `+` which turned out to be missing.