### PR TITLE
Dask.array tracks dtypes when possible

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -11,7 +11,7 @@ from collections import Iterator
 from functools import partial, wraps
 from toolz.curried import (identity, pipe, partition, concat, unique, pluck,
         frequencies, join, first, memoize, map, groupby, valmap, accumulate,
-        merge, curry, compose, reduce, memoize)
+        merge, curry, compose, reduce)
 import numpy as np
 from . import chunk
 from .slicing import slice_array, insert_many, remove_full_slices
@@ -468,7 +468,7 @@ class Array(object):
         return sum(self.blockdims[0])
 
     @property
-    @memoize
+    @memoize(key=lambda args, kwargs: (id(args[0]), args[0].name, args[0].blockdims))
     def dtype(self):
         if self._dtype is not None:
             return self._dtype
@@ -1126,6 +1126,7 @@ def isnull(values):
     """ pandas.isnull for dask arrays """
     import pandas as pd
     return elemwise(pd.isnull, values)
+
 
 def notnull(values):
     """ pandas.notnull for dask arrays """

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -11,7 +11,7 @@ from collections import Iterator
 from functools import partial, wraps
 from toolz.curried import (identity, pipe, partition, concat, unique, pluck,
         frequencies, join, first, memoize, map, groupby, valmap, accumulate,
-        merge, curry, compose)
+        merge, curry, compose, reduce)
 import numpy as np
 from . import chunk
 from .slicing import slice_array, insert_many, remove_full_slices

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -11,7 +11,7 @@ from collections import Iterator
 from functools import partial, wraps
 from toolz.curried import (identity, pipe, partition, concat, unique, pluck,
         frequencies, join, first, memoize, map, groupby, valmap, accumulate,
-        merge, curry, compose, reduce)
+        merge, curry, compose, reduce, memoize)
 import numpy as np
 from . import chunk
 from .slicing import slice_array, insert_many, remove_full_slices
@@ -468,6 +468,7 @@ class Array(object):
         return sum(self.blockdims[0])
 
     @property
+    @memoize
     def dtype(self):
         if self._dtype is not None:
             return self._dtype

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -11,7 +11,7 @@ from . import chunk
 from ..utils import ignoring
 
 
-def reduction(x, chunk, aggregate, axis=None, keepdims=None):
+def reduction(x, chunk, aggregate, axis=None, keepdims=None, dtype=None):
     """ General version of reductions
 
     >>> reduction(my_array, np.sum, np.sum, axis=0, keepdims=False)  # doctest: +SKIP
@@ -30,7 +30,7 @@ def reduction(x, chunk, aggregate, axis=None, keepdims=None):
     inds2 = tuple(i for i in inds if i not in axis)
 
     result = atop(compose(aggregate2, curry(_concatenate2, axes=axis)),
-                  next(names), inds2, tmp, inds)
+                  next(names), inds2, tmp, inds, dtype=dtype)
 
     if keepdims:
         dsk = result.dask.copy()
@@ -38,80 +38,108 @@ def reduction(x, chunk, aggregate, axis=None, keepdims=None):
             k2 = (k[0],) + insert_many(k[1:], axis, 0)
             dsk[k2] = dsk.pop(k)
         blockdims = insert_many(result.blockdims, axis, [1])
-        return Array(dsk, result.name, blockdims=blockdims)
+        return Array(dsk, result.name, blockdims=blockdims, dtype=dtype)
     else:
         return result
 
 
 @wraps(chunk.sum)
 def sum(a, axis=None, keepdims=False):
-    return reduction(a, chunk.sum, chunk.sum, axis=axis, keepdims=keepdims)
+    if a._dtype is not None:
+        dt = np.empty((1,), dtype=a._dtype).sum().dtype
+    else:
+        dt = None
+    return reduction(a, chunk.sum, chunk.sum, axis=axis, keepdims=keepdims,
+                     dtype=dt)
 
 
 @wraps(chunk.prod)
 def prod(a, axis=None, keepdims=False):
-    return reduction(a, chunk.prod, chunk.prod, axis=axis, keepdims=keepdims)
+    if a._dtype is not None:
+        dt = np.empty((1,), dtype=a._dtype).prod().dtype
+    else:
+        dt = None
+    return reduction(a, chunk.prod, chunk.prod, axis=axis, keepdims=keepdims,
+                     dtype=dt)
 
 
 @wraps(chunk.min)
 def min(a, axis=None, keepdims=False):
-    return reduction(a, chunk.min, chunk.min, axis=axis, keepdims=keepdims)
+    return reduction(a, chunk.min, chunk.min, axis=axis, keepdims=keepdims,
+                     dtype=a._dtype)
 
 
 @wraps(chunk.max)
 def max(a, axis=None, keepdims=False):
-    return reduction(a, chunk.max, chunk.max, axis=axis, keepdims=keepdims)
+    return reduction(a, chunk.max, chunk.max, axis=axis, keepdims=keepdims,
+                     dtype=a._dtype)
 
 
 @wraps(chunk.argmin)
 def argmin(a, axis=None):
-    return arg_reduction(a, chunk.min, chunk.argmin, axis=axis)
+    return arg_reduction(a, chunk.min, chunk.argmin, axis=axis, dtype='i8')
 
 
 @wraps(chunk.nanargmin)
 def nanargmin(a, axis=None):
-    return arg_reduction(a, chunk.nanmin, chunk.nanargmin, axis=axis)
+    return arg_reduction(a, chunk.nanmin, chunk.nanargmin, axis=axis,
+                         dtype='i8')
 
 
 @wraps(chunk.argmax)
 def argmax(a, axis=None):
-    return arg_reduction(a, chunk.max, chunk.argmax, axis=axis)
+    return arg_reduction(a, chunk.max, chunk.argmax, axis=axis, dtype='i8')
 
 
 @wraps(chunk.nanargmax)
 def nanargmax(a, axis=None):
-    return arg_reduction(a, chunk.nanmax, chunk.nanargmax, axis=axis)
+    return arg_reduction(a, chunk.nanmax, chunk.nanargmax, axis=axis,
+                         dtype='i8')
 
 
 @wraps(chunk.any)
 def any(a, axis=None, keepdims=False):
-    return reduction(a, chunk.any, chunk.any, axis=axis, keepdims=keepdims)
+    return reduction(a, chunk.any, chunk.any, axis=axis, keepdims=keepdims,
+                     dtype=np.bool_)
 
 
 @wraps(chunk.all)
 def all(a, axis=None, keepdims=False):
-    return reduction(a, chunk.all, chunk.all, axis=axis, keepdims=keepdims)
+    return reduction(a, chunk.all, chunk.all, axis=axis, keepdims=keepdims,
+                     dtype=np.bool_)
 
 
 @wraps(chunk.nansum)
 def nansum(a, axis=None, keepdims=False):
-    return reduction(a, chunk.nansum, chunk.sum, axis=axis, keepdims=keepdims)
+    if a._dtype is not None:
+        dt = chunk.nansum(np.empty((1,), dtype=a._dtype)).dtype
+    else:
+        dt = None
+    return reduction(a, chunk.nansum, chunk.sum, axis=axis, keepdims=keepdims,
+                     dtype=dt)
 
 
 with ignoring(AttributeError):
     @wraps(chunk.nanprod)
     def nanprod(a, axis=None, keepdims=False):
-        return reduction(a, chunk.nanprod, chunk.prod, axis=axis, keepdims=keepdims)
+        if a._dtype is not None:
+            dt = np.empty((1,), dtype=a._dtype).nanprod().dtype
+        else:
+            dt = None
+        return reduction(a, chunk.nanprod, chunk.prod, axis=axis,
+                         keepdims=keepdims, dtype=dt)
 
 
 @wraps(chunk.nanmin)
 def nanmin(a, axis=None, keepdims=False):
-    return reduction(a, chunk.nanmin, chunk.min, axis=axis, keepdims=keepdims)
+    return reduction(a, chunk.nanmin, chunk.min, axis=axis, keepdims=keepdims,
+                     dtype=a._dtype)
 
 
 @wraps(chunk.nanmax)
 def nanmax(a, axis=None, keepdims=False):
-    return reduction(a, chunk.nanmax, chunk.max, axis=axis, keepdims=keepdims)
+    return reduction(a, chunk.nanmax, chunk.max, axis=axis, keepdims=keepdims,
+                     dtype=a._dtype)
 
 
 def numel(x, **kwargs):
@@ -139,12 +167,13 @@ def mean_agg(pair, **kwargs):
 
 @wraps(chunk.mean)
 def mean(a, axis=None, keepdims=False):
-    return reduction(a, mean_chunk, mean_agg, axis=axis, keepdims=keepdims)
+    return reduction(a, mean_chunk, mean_agg, axis=axis, keepdims=keepdims,
+                     dtype='f8')
 
 
 def nanmean(a, axis=None, keepdims=False):
     return reduction(a, partial(mean_chunk, sum=chunk.nansum, numel=nannumel),
-                     mean_agg, axis=axis, keepdims=keepdims)
+                     mean_agg, axis=axis, keepdims=keepdims, dtype='f8')
 with ignoring(AttributeError):
     nanmean = wraps(chunk.nanmean)(nanmean)
 
@@ -172,7 +201,8 @@ def var_agg(A, ddof=None, **kwargs):
 
 @wraps(chunk.var)
 def var(a, axis=None, keepdims=False, ddof=0):
-    return reduction(a, var_chunk, partial(var_agg, ddof=ddof), axis=axis, keepdims=keepdims)
+    return reduction(a, var_chunk, partial(var_agg, ddof=ddof), axis=axis,
+                     keepdims=keepdims, dtype='f8')
 
 
 def nanvar(a, axis=None, keepdims=False, ddof=0):
@@ -230,7 +260,7 @@ def arg_aggregate(func, argfunc, dims, pairs):
     return np.choose(args, argmins + offsets)
 
 
-def arg_reduction(a, func, argfunc, axis=0):
+def arg_reduction(a, func, argfunc, axis=0, dtype=None):
     """ General version of argmin/argmax
 
     >>> arg_reduction(my_array, np.min, axis=0)  # doctest: +SKIP
@@ -249,4 +279,4 @@ def arg_reduction(a, func, argfunc, axis=0):
 
     return atop(partial(arg_aggregate, func, argfunc, a.blockdims[axis]),
                 next(names), [i for i in range(a.ndim) if i != axis],
-                a2, list(range(a.ndim)))
+                a2, list(range(a.ndim)), dtype=dtype)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -485,3 +485,41 @@ def test_np_array_with_zero_dimensions():
     d = da.ones((4, 4), blockshape=(2, 2))
     assert eq(np.array(d.sum()), np.array(d.compute().sum()))
 
+
+def test_dtype_complex():
+    x = np.arange(24).reshape((4, 6)).astype('f4')
+    y = np.arange(24).reshape((4, 6)).astype('i8')
+    z = np.arange(24).reshape((4, 6)).astype('i2')
+
+    a = da.from_array(x, blockshape=(2, 3))
+    b = da.from_array(y, blockshape=(2, 3))
+    c = da.from_array(z, blockshape=(2, 3))
+
+    def eq(a, b):
+        return (isinstance(a, np.dtype) and
+                isinstance(b, np.dtype) and
+                str(a) == str(b))
+
+    assert eq(a._dtype, x.dtype)
+    assert eq(b._dtype, y.dtype)
+
+    assert eq((a + 1)._dtype, (x + 1).dtype)
+    assert eq((a + b)._dtype, (x + y).dtype)
+    assert eq(a.T._dtype, x.T.dtype)
+    assert eq(a[:3]._dtype, x[:3].dtype)
+    assert eq((a.dot(b.T))._dtype, (x.dot(y.T)).dtype)
+
+    assert eq(stack([a, b])._dtype, np.vstack([x, y]).dtype)
+    assert eq(concatenate([a, b])._dtype, np.concatenate([x, y]).dtype)
+
+    x = np.array([('a', 1)], dtype=[('text', 'S1'), ('numbers', 'i4')])
+    d = da.from_array(x, blockshape=(1,))
+
+    assert eq(d['text']._dtype, x['text'].dtype)
+    assert eq(d[['numbers', 'text']]._dtype, x[['numbers', 'text']].dtype)
+
+    assert eq(b.std()._dtype, y.std().dtype)
+    assert eq(c.sum()._dtype, z.sum().dtype)
+    assert eq(a.min()._dtype, a.min().dtype)
+    assert eq(b.std()._dtype, b.std().dtype)
+    assert eq(a.argmin(axis=0)._dtype, a.argmin(axis=0).dtype)


### PR DESCRIPTION
The Array class now holds a `_dtype` attribute.  Various dask.array functions
propagate dtype information, repeating a bit of numpy logic where necessary.

If this logic fails then we fall back on computation of a small element of the
dask array.

Fixes https://github.com/ContinuumIO/dask/issues/64

cc @shoyer