### PR TITLE
Get functions check globals for pool

### DIFF
--- a/dask/context.py
+++ b/dask/context.py
@@ -8,8 +8,7 @@ from collections import defaultdict
 _globals = defaultdict(lambda: None)
 
 
-@contextmanager
-def set_options(**kwargs):
+class set_options(object):
     """ Set global state within controled context
 
     This lets you specify various global settings in a tightly controlled with
@@ -25,12 +24,13 @@ def set_options(**kwargs):
     >>> with set_options(get=dask.get):  # doctest: +SKIP
     ...     x = np.array(x)  # uses dask.get internally
     """
-    old = _globals.copy()
+    def __init__(self, **kwargs):
+        self.old = _globals.copy()
+        _globals.update(kwargs)
 
-    _globals.update(kwargs)
+    def __enter__(self):
+        return
 
-    try:
-        yield
-    finally:
+    def __exit__(self, type, value, traceback):
         _globals.clear()
-        _globals.update(old)
+        _globals.update(self.old)

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -7,12 +7,13 @@ import psutil
 import dill
 import pickle
 from .async import get_async # TODO: get better get
+from .context import _globals
 
 cpu_count = psutil.cpu_count()
 
 def get(dsk, keys, optimizations=[fuse], num_workers=cpu_count):
     """ Multiprocessed get function appropriate for Bags """
-    pool = multiprocessing.Pool(psutil.cpu_count())
+    pool = _globals['pool'] or multiprocessing.Pool(psutil.cpu_count())
     manager = multiprocessing.Manager()
     queue = manager.Queue()
 

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -13,7 +13,13 @@ cpu_count = psutil.cpu_count()
 
 def get(dsk, keys, optimizations=[fuse], num_workers=cpu_count):
     """ Multiprocessed get function appropriate for Bags """
-    pool = _globals['pool'] or multiprocessing.Pool(psutil.cpu_count())
+    pool = _globals['pool']
+    if pool is None:
+        pool = multiprocessing.Pool(psutil.cpu_count())
+        cleanup = True
+    else:
+        cleanup = False
+
     manager = multiprocessing.Manager()
     queue = manager.Queue()
 
@@ -27,7 +33,8 @@ def get(dsk, keys, optimizations=[fuse], num_workers=cpu_count):
         result = get_async(apply_async, cpu_count, dsk2, keys,
                            queue=queue)
     finally:
-        pool.close()
+        if cleanup:
+            pool.close()
     return result
 
 

--- a/dask/tests/test_context.py
+++ b/dask/tests/test_context.py
@@ -1,4 +1,4 @@
-from dask.context import set_options
+from dask.context import set_options, _globals
 import dask.array as da
 import dask
 
@@ -21,3 +21,15 @@ def test_with_get():
     # Make sure we've cleaned up
     assert x.sum().compute() == 10
     assert var[0] == 1
+
+
+def test_set_options_context_manger():
+    with set_options(foo='bar'):
+        assert _globals['foo'] == 'bar'
+    assert _globals['foo'] is None
+
+    try:
+        set_options(foo='baz')
+        assert _globals['foo'] == 'baz'
+    finally:
+        del _globals['foo']

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -1,6 +1,10 @@
 from dask.multiprocessing import get, dill_apply_async
+from dask.context import set_options
 import multiprocessing
 import dill
+
+
+inc = lambda x: x + 1
 
 
 def test_apply_lambda():
@@ -41,3 +45,10 @@ def test_unpicklable_results_genreate_errors():
     except Exception as e:
         # can't use type because pickle / cPickle distinction
         assert type(e).__name__ == 'PicklingError'
+
+
+def test_reuse_pool():
+    pool = multiprocessing.Pool()
+    with set_options(pool=pool):
+        assert get({'x': (inc, 1)}, 'x') == 2
+        assert get({'x': (inc, 1)}, 'x') == 2

--- a/dask/tests/test_threaded.py
+++ b/dask/tests/test_threaded.py
@@ -2,6 +2,11 @@ from dask.threaded import get
 from dask.async import inc
 from dask.utils import raises
 from operator import add
+from dask.context import set_options
+from multiprocessing.pool import ThreadPool
+
+
+inc = lambda x: x + 1
 
 
 def test_get():
@@ -26,3 +31,9 @@ def bad(x):
 def test_exceptions_rise_to_top():
     dsk = {'x': 1, 'y': (bad, 'x')}
     assert raises(ValueError, lambda: get(dsk, 'y'))
+
+def test_reuse_pool():
+    pool = ThreadPool()
+    with set_options(pool=pool):
+        assert get({'x': (inc, 1)}, 'x') == 2
+        assert get({'x': (inc, 1)}, 'x') == 2

--- a/dask/threaded.py
+++ b/dask/threaded.py
@@ -9,6 +9,7 @@ from multiprocessing.pool import ThreadPool
 import psutil
 from .async import get_async, inc, add
 from .compatibility import Queue
+from .context import _globals
 
 
 NUM_CPUS = psutil.cpu_count()
@@ -40,7 +41,7 @@ def get(dsk, result, nthreads=NUM_CPUS, cache=None, debug_counts=None, **kwargs)
     >>> get(dsk, ['w', 'y'])
     (4, 2)
     """
-    pool = ThreadPool(nthreads)
+    pool = _globals['pool'] or ThreadPool(nthreads)
     queue = Queue()
     try:
         results = get_async(pool.apply_async, nthreads, dsk, result,

--- a/dask/threaded.py
+++ b/dask/threaded.py
@@ -41,14 +41,22 @@ def get(dsk, result, nthreads=NUM_CPUS, cache=None, debug_counts=None, **kwargs)
     >>> get(dsk, ['w', 'y'])
     (4, 2)
     """
-    pool = _globals['pool'] or ThreadPool(nthreads)
+    pool = _globals['pool']
+
+    if pool is None:
+        pool = ThreadPool(nthreads)
+        cleanup = True
+    else:
+        cleanup = False
+
     queue = Queue()
     try:
         results = get_async(pool.apply_async, nthreads, dsk, result,
                             cache=cache, debug_counts=debug_counts,
                             queue=queue, **kwargs)
     finally:
-        pool.close()
-        pool.join()
+        if cleanup:
+            pool.close()
+            pool.join()
 
     return results


### PR DESCRIPTION
This allows multiple computations to share the same thread/process pools

Example
-------

    pool = ThreadPool()
    with set_options(pool=pool):
        ...

    or

    from dask.context import _globals
    _globals['pool'] = pool


Timings
------

```python
In [1]: import dask.array as da

In [2]: from multiprocessing.pool import ThreadPool

In [3]: pool = ThreadPool(8)

In [4]: d = da.ones(10, blockshape=(5,))

In [5]: %time with da.set_options(pool=pool): d.sum().compute() + d.sum().compute()
CPU times: user 2.93 ms, sys: 3.78 ms, total: 6.7 ms
Wall time: 4.46 ms

In [6]: %time d.sum().compute() + d.sum().compute()
CPU times: user 23.9 ms, sys: 649 µs, total: 24.6 ms
Wall time: 212 ms
Out[6]: 20.0
```

cc @shoyer

Fixes https://github.com/ContinuumIO/dask/issues/86