### PR TITLE
Store many arrays simultaneously

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from ..utils import ignoring
 from .core import (Array, stack, concatenate, tensordot, transpose, from_array,
-        choose, coarsen, constant, fromfunction, compute)
+        choose, coarsen, constant, fromfunction, compute, store)
 from .core import (arccos, arcsin, arctan, arctanh, arccosh, arcsinh, arctan2,
         ceil, copysign, cos, cosh, degrees, exp, expm1, fabs, floor, fmod,
         frexp, hypot, isinf, isnan, ldexp, log, log10, log1p, modf, radians,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -481,6 +481,10 @@ def store(sources, targets, **kwargs):
         targets = [targets]
         single_output = False
 
+    if len(sources) != len(targets):
+        raise ValueError("Different number of sources [%d] and targets [%d]"
+                        % (len(sources), len(targets)))
+
     updates = [insert_to_ooc(tgt, src) for tgt, src in zip(targets, sources)]
     dsk = merge([src.dask for src in sources] + updates)
     keys = [key for u in updates for key in u]

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -481,6 +481,18 @@ def test_compute():
     assert eq(B, d + 2)
 
 
+def test_store():
+    d = da.ones((4, 4), blockshape=(2, 2))
+    a, b = d + 1, d + 2
+
+    at = np.empty(shape=(4, 4))
+    bt = np.empty(shape=(4, 4))
+
+    store([a, b], [at, bt])
+    assert (at == 2).all()
+    assert (bt == 3).all()
+
+
 def test_np_array_with_zero_dimensions():
     d = da.ones((4, 4), blockshape=(2, 2))
     assert eq(np.array(d.sum()), np.array(d.compute().sum()))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -492,6 +492,8 @@ def test_store():
     assert (at == 2).all()
     assert (bt == 3).all()
 
+    assert raises(ValueError, lambda: store([a], [at, bt]))
+
 
 def test_np_array_with_zero_dimensions():
     d = da.ones((4, 4), blockshape=(2, 2))


### PR DESCRIPTION
Creates a top-level store function that accepts either a single
dask.array/output pair

    >>> store(x, out)

Or a list/tuple of such pairs

    >>> store([x, y, z], [out1, out2, out3])

Fixes https://github.com/ContinuumIO/dask/issues/84
cc @shoyer