### PR TITLE
Use syntactic rewriting to leverage column stores

### DIFF
--- a/dask/frame/__init__.py
+++ b/dask/frame/__init__.py
@@ -1,1 +1,2 @@
 from .core import Frame, read_csv, from_array, from_bcolz
+from .shuffle import from_pframe

--- a/dask/frame/core.py
+++ b/dask/frame/core.py
@@ -767,7 +767,7 @@ def get(dsk, keys, get=get_sync, **kwargs):
     else:
         dsk2 = cull(dsk, [keys])
     dsk3 = fuse(dsk2)
-    dsk4 = rewrite_rules.rewrite(dsk3)
+    dsk4 = valmap(rewrite_rules.rewrite, dsk3)
     return get(dsk4, keys, **kwargs)  # use synchronous scheduler for now
 
 

--- a/dask/frame/core.py
+++ b/dask/frame/core.py
@@ -13,6 +13,7 @@ from chest import Chest
 import gzip
 import bz2
 from pframe import pframe
+import bcolz
 
 from .. import array as da
 from ..optimize import cull, fuse
@@ -504,7 +505,7 @@ def from_array(x, chunksize=50000):
 
 from pframe.categories import reapply_categories
 
-def from_bcolz(x, chunksize=None, categorize=True, index=None, **kwargs):
+def from_bcolz(x, chunksize=None, categorize=True, index=None, columns=None, **kwargs):
     """ Read dask frame from bcolz.ctable
 
     Parameters
@@ -542,18 +543,10 @@ def from_bcolz(x, chunksize=None, categorize=True, index=None, **kwargs):
     blockdivs = tuple(range(chunksize, len(x), chunksize))
     new_name = next(from_array_names)
     dsk = dict(((new_name, i),
-        (pd.DataFrame,
-          (dict, (zip,
-            x.names,
-            [(getitem, x[name], (slice(i * chunksize, (i + 1) * chunksize),))
-             if name not in categories else
-             (pd.Categorical.from_codes,
-                 (np.searchsorted,
-                   categories[name],
-                   (getitem, x[name], (slice(i * chunksize, (i + 1) * chunksize),))),
-                 categories[name],
-                 True)
-             for name in x.names]))))
+                (dataframe_from_ctable,
+                  x,
+                  (slice(i * chunksize, (i + 1) * chunksize),),
+                  columns, categories))
            for i in range(0, int(ceil(float(len(x)) / chunksize))))
 
     result = Frame(dsk, new_name, columns, blockdivs)
@@ -566,6 +559,58 @@ def from_bcolz(x, chunksize=None, categorize=True, index=None, **kwargs):
         return set_partition(result, index, blockdivs, **kwargs)
     else:
         return result
+
+
+def dataframe_from_ctable(x, slc, columns=None, categories=None):
+    """ Get DataFrame from bcolz.ctable
+
+    Parameters
+    ----------
+
+    x: bcolz.ctable
+    slc: slice
+    columns: list of column names or None
+
+    >>> x = bcolz.ctable([[1, 2, 3, 4], [10, 20, 30, 40]], names=['a', 'b'])
+    >>> get_dataframe_from_ctable(x, slice(1, 3))
+       a   b
+    0  2  20
+    1  3  30
+
+    >>> get_dataframe_from_ctable(x, slice(1, 3), columns=['b'])
+        b
+    0  20
+    1  30
+
+    >>> get_dataframe_from_ctable(x, slice(1, 3), columns='b')
+    0    20
+    1    30
+    Name: b, dtype: int64
+
+    """
+    if columns is not None:
+        if isinstance(columns, tuple):
+            columns = list(columns)
+        x = x[columns]
+
+    name = next(names)
+
+    if isinstance(x, bcolz.ctable):
+        chunks = [x[name][slc] for name in x.names]
+        if categories is not None:
+            chunks = [pd.Categorical.from_codes(np.searchsorted(categories[name],
+                                                                chunk),
+                                                categories[name], True)
+                       if name in categories else chunk
+                       for name, chunk in zip(x.names, chunks)]
+        return pd.DataFrame(dict(zip(x.names, chunks)))
+    elif isinstance(x, bcolz.carray):
+        chunk = x[slc]
+        if categories is not None and columns and columns in categories:
+            chunk = pc.Categorical.from_codes(
+                        np.searchsorted(categories[columns], chunk),
+                        categories[columns], True)
+        return pd.Series(chunk, name=columns)
 
 
 class GroupBy(object):

--- a/dask/frame/core.py
+++ b/dask/frame/core.py
@@ -505,7 +505,7 @@ def from_array(x, chunksize=50000):
 
 from pframe.categories import reapply_categories
 
-def from_bcolz(x, chunksize=None, categorize=True, index=None, columns=None, **kwargs):
+def from_bcolz(x, chunksize=None, categorize=True, index=None, **kwargs):
     """ Read dask frame from bcolz.ctable
 
     Parameters
@@ -546,7 +546,7 @@ def from_bcolz(x, chunksize=None, categorize=True, index=None, columns=None, **k
                 (dataframe_from_ctable,
                   x,
                   (slice(i * chunksize, (i + 1) * chunksize),),
-                  columns, categories))
+                  None, categories))
            for i in range(0, int(ceil(float(len(x)) / chunksize))))
 
     result = Frame(dsk, new_name, columns, blockdivs)
@@ -801,9 +801,11 @@ a, b, c, d, e = '~a', '~b', '~c', '~d', '~e'
 from dask.rewrite import RuleSet, RewriteRule
 
 rewrite_rules = RuleSet(
+        # Merge column access into pframe loading
         RewriteRule((getitem, (pframe.get_partition, a, b), c),
                     (pframe.get_partition, a, b, c),
                     (a, b, c)),
+        # Merge column access into bcolz loading
         RewriteRule((getitem, (dataframe_from_ctable, a, b, c, d), e),
                     (dataframe_from_ctable, a, b, e, d),
                     (a, b, c, d, e)))

--- a/dask/frame/core.py
+++ b/dask/frame/core.py
@@ -4,7 +4,7 @@ from functools import wraps
 import toolz
 import bisect
 import os
-from toolz import merge, partial, accumulate, unique, first, dissoc
+from toolz import merge, partial, accumulate, unique, first, dissoc, valmap
 from operator import getitem, setitem
 import pandas as pd
 import numpy as np

--- a/dask/frame/core.py
+++ b/dask/frame/core.py
@@ -607,7 +607,7 @@ def dataframe_from_ctable(x, slc, columns=None, categories=None):
     elif isinstance(x, bcolz.carray):
         chunk = x[slc]
         if categories is not None and columns and columns in categories:
-            chunk = pc.Categorical.from_codes(
+            chunk = pd.Categorical.from_codes(
                         np.searchsorted(categories[columns], chunk),
                         categories[columns], True)
         return pd.Series(chunk, name=columns)
@@ -792,9 +792,9 @@ def quantiles(f, q, **kwargs):
     return result
 
 
-3################
+#################
 # Optimizations #
-3################
+#################
 
 
 a, b, c, d, e = '~a', '~b', '~c', '~d', '~e'
@@ -804,9 +804,9 @@ rewrite_rules = RuleSet(
         RewriteRule((getitem, (pframe.get_partition, a, b), c),
                     (pframe.get_partition, a, b, c),
                     (a, b, c)),
-        RewriteRule((getitem, (dataframe_from_ctable, a, b, None, c), d),
-                    (dataframe_from_ctable, a, b, d, c),
-                    (a, b, c, d)))
+        RewriteRule((getitem, (dataframe_from_ctable, a, b, c, d), e),
+                    (dataframe_from_ctable, a, b, e, d),
+                    (a, b, c, d, e)))
 
 
 def get(dsk, keys, get=get_sync, **kwargs):

--- a/dask/frame/core.py
+++ b/dask/frame/core.py
@@ -572,17 +572,17 @@ def dataframe_from_ctable(x, slc, columns=None, categories=None):
     columns: list of column names or None
 
     >>> x = bcolz.ctable([[1, 2, 3, 4], [10, 20, 30, 40]], names=['a', 'b'])
-    >>> get_dataframe_from_ctable(x, slice(1, 3))
+    >>> dataframe_from_ctable(x, slice(1, 3))
        a   b
     0  2  20
     1  3  30
 
-    >>> get_dataframe_from_ctable(x, slice(1, 3), columns=['b'])
+    >>> dataframe_from_ctable(x, slice(1, 3), columns=['b'])
         b
     0  20
     1  30
 
-    >>> get_dataframe_from_ctable(x, slice(1, 3), columns='b')
+    >>> dataframe_from_ctable(x, slice(1, 3), columns='b')
     0    20
     1    30
     Name: b, dtype: int64

--- a/dask/frame/core.py
+++ b/dask/frame/core.py
@@ -797,12 +797,16 @@ def quantiles(f, q, **kwargs):
 3################
 
 
-a, b, c = '~a', '~b', '~c'
+a, b, c, d, e = '~a', '~b', '~c', '~d', '~e'
 from dask.rewrite import RuleSet, RewriteRule
 
-rewrite_rules = RuleSet(RewriteRule((getitem, (pframe.get_partition, a, b), c),
-                                    (pframe.get_partition, a, b, c),
-                                    (a, b, c)))
+rewrite_rules = RuleSet(
+        RewriteRule((getitem, (pframe.get_partition, a, b), c),
+                    (pframe.get_partition, a, b, c),
+                    (a, b, c)),
+        RewriteRule((getitem, (dataframe_from_ctable, a, b, None, c), d),
+                    (dataframe_from_ctable, a, b, d, c),
+                    (a, b, c, d)))
 
 
 def get(dsk, keys, get=get_sync, **kwargs):

--- a/dask/frame/shuffle.py
+++ b/dask/frame/shuffle.py
@@ -81,7 +81,7 @@ def unique(blockdivs):
     >>> unique(np.array([1, 2, 3, 1, 2, 3]))
     array([1, 2, 3])
 
-    >>> unique(pd.Categorical(['Alice', 'Bob', 'Alice']))
+    >>> unique(pd.Categorical(['Alice', 'Bob', 'Alice'], ordered=False))
     [Alice, Bob]
     Categories (2, object): [Alice, Bob]
     """

--- a/dask/frame/shuffle.py
+++ b/dask/frame/shuffle.py
@@ -60,11 +60,16 @@ def set_partition(f, index, blockdivs, get=threaded.get, **kwargs):
     f2.map_blocks(append, columns=['a']).compute(get=get)
     pf.flush()
 
-    name = next(partition_names)
-    dsk2 = dict(((name, i), (pframe.get_partition, pf, i))
+    return from_pframe(pf)
+
+
+def from_pframe(pf):
+    """ Load dask.array from pframe """
+    name = next(names)
+    dsk = dict(((name, i), (pframe.get_partition, pf, i))
                 for i in range(pf.npartitions))
 
-    return Frame(dsk2, name, head.columns, blockdivs)
+    return Frame(dsk, name, pf.columns, pf.blockdivs)
 
 
 def unique(blockdivs):

--- a/dask/frame/shuffle.py
+++ b/dask/frame/shuffle.py
@@ -73,7 +73,23 @@ def from_pframe(pf):
 
 
 def unique(blockdivs):
+    """ Polymorphic unique function
+
+    >>> list(unique([1, 2, 3, 1, 2, 3]))
+    [1, 2, 3]
+
+    >>> unique(np.array([1, 2, 3, 1, 2, 3]))
+    array([1, 2, 3])
+
+    >>> unique(pd.Categorical(['Alice', 'Bob', 'Alice']))
+    [Alice, Bob]
+    Categories (2, object): [Alice, Bob]
+    """
     if isinstance(blockdivs, np.ndarray):
         return np.unique(blockdivs)
+    if isinstance(blockdivs, pd.Categorical):
+        return pd.Categorical.from_codes(np.unique(blockdivs.codes),
+                blockdivs.categories, blockdivs.ordered)
     if isinstance(blockdivs, (tuple, list, Iterator)):
         return tuple(toolz.unique(blockdivs))
+    raise NotImplementedError()

--- a/dask/frame/tests/test_frame.py
+++ b/dask/frame/tests/test_frame.py
@@ -372,11 +372,14 @@ def test_from_pframe():
 
 
 def test_column_optimizations_with_pframe_and_rewrite():
-    dsk2 = {('x', i): (getitem, (pframe.get_partition, pf, i), (list, ['a', 'b']))
-            for i in [1, 2, 3]}
+    dsk2 = dict((('x', i), (getitem,
+                             (pframe.get_partition, pf, i),
+                             (list, ['a', 'b'])))
+            for i in [1, 2, 3])
 
-    expected = {('x', i): (pframe.get_partition, pf, i, (list, ['a', 'b']))
-            for i in [1, 2, 3]}
+    expected = dict((('x', i),
+                     (pframe.get_partition, pf, i, (list, ['a', 'b'])))
+            for i in [1, 2, 3])
     result = valmap(rewrite_rules.rewrite, dsk2)
 
     assert result == expected
@@ -386,15 +389,16 @@ def test_column_optimizations_with_bcolz_and_rewrite():
     bc = bcolz.ctable([[1, 2, 3], [10, 20, 30]], names=['a', 'b'])
     func = lambda x: x
     for cols in [None, 'abc', ['abc']]:
-        dsk2 = {('x', i): (func,
-                            (getitem,
-                              (dataframe_from_ctable, bc, slice(0, 2), cols, {}),
-                              (list, ['a', 'b'])))
-                for i in [1, 2, 3]}
+        dsk2 = dict((('x', i),
+                     (func,
+                       (getitem,
+                         (dataframe_from_ctable, bc, slice(0, 2), cols, {}),
+                         (list, ['a', 'b']))))
+                for i in [1, 2, 3])
 
-        expected = {('x', i): (func, (dataframe_from_ctable,
-                                       bc, slice(0, 2), (list, ['a', 'b']), {}))
-                for i in [1, 2, 3]}
+        expected = dict((('x', i), (func, (dataframe_from_ctable,
+                                     bc, slice(0, 2), (list, ['a', 'b']), {})))
+                for i in [1, 2, 3])
         result = valmap(rewrite_rules.rewrite, dsk2)
 
         assert result == expected

--- a/dask/frame/tests/test_frame.py
+++ b/dask/frame/tests/test_frame.py
@@ -358,7 +358,12 @@ def test_loc():
 def test_iloc_raises():
     assert raises(AttributeError, lambda: d.iloc[:5])
 
-dfs = list(dsk.values())
+
+#####################
+# Play with PFrames #
+#####################
+
+
 dfs = list(dsk.values())
 pf = pframe(like=dfs[0], blockdivs=[5])
 for df in dfs:

--- a/docs/source/frame.rst
+++ b/docs/source/frame.rst
@@ -104,51 +104,8 @@ Shard and Recombine
 
 Once we know good partition values we need to shard sections out of the old
 blocks and then reconstruct those shards in new blocks.  We do this by
-leveraging in-core pandas segmentation on each block, and then using a
-dict-like data structure to communicate results.
-
-Split old blocks, dump shards to dict::
-
-        name, balance                       name, balance
-        Alice, 100                          Alice, 100
-        Bob, 200           -> Shard ->      Alice, 300       -> dict
-        Alice, 300
-        Frank, 400                          name, balance
-                                            Bob, 200         -> dict
-
-                                            name, balance
-                                            Frank, 400       -> dict
-
-        name, balance                       name, balance
-        Dan, 500                            Alice, 600
-        Alice, 600         -> Shard ->      Alice, 700       -> dict
-        Alice, 700
-        Charlie, 800                        name, balance
-                                            Dan, 500         -> dict
-                                            Charlie, 800
-                               ...
-
-
-Pull shards from dict, construct new blocks::
-
-                  name, balance                     name, balance
-                  Alice, 100                        Alice, 100
-        dict ->   Alice, 300                        Alice, 300
-                                   -> collect ->    Alice, 600
-                  name, balance                     Alice, 700
-        dict ->   Alice, 600
-                  Alice, 700
-
-                  name, balance
-        dict ->   Bob, 200                          name, balance
-                                   -> collect ->    Bob, 200
-                  name, balance                     Dan, 500
-        dict ->   Dan, 500                          Charlie, 800
-                  Charlie, 800
-                                        ...
-
-We rely heavily on this dict to intelligently manage the storage of and
-collection of temporary shards.  In practice for out-of-core frames we use
-Chest_, a spill-to-disk dictionary.
+leveraging in-core pandas segmentation on each block, and then using a special
+appendable on-disk data structure, pframe_.
 
 .. _Chest: http://github.com/ContinuumIO/chest
+.. _pframe: pframe.html

--- a/docs/source/frame.rst
+++ b/docs/source/frame.rst
@@ -107,5 +107,37 @@ blocks and then reconstruct those shards in new blocks.  We do this by
 leveraging in-core pandas segmentation on each block, and then using a special
 appendable on-disk data structure, pframe_.
 
+
+Supported API
+-------------
+
+Dask frame supports the following API from Pandas
+
+* Trivially parallelizable (fast):
+    *  Elementwise operations:  ``df.x + df.y``
+    *  Row-wise selections:  ``df[df.x > 0]``
+    *  Loc:  ``df.loc[4.0:10.5]``
+    *  Common aggregations:  ``df.x.max()``
+    *  Is in:  ``df[df.x.isin([1, 2, 3])]``
+* Cleverly parallelizable (also fast):
+    *  groupby-aggregate (with common aggregations): ``df.groupby(df.x).y.max()``
+    *  value_counts:  ``df.x.value_counts``
+    *  Drop duplicates:  ``df.x.drop_duplicates()``
+* Requires shuffle (slow-ish, unless on index)
+    *  Set index:  ``df.set_index(df.x)``
+    *  groupby-apply (with anything):  ``df.groupby(df.x).apply(myfunc)``
+* Ingest
+    *  ``pd.read_csv``  (in all its glory)
+
+Dask frame also introduces some new API
+
+* Requires full dataset read, but otherwise fast
+    *  Approximate quantiles:  ``df.x.quantiles([25, 50, 75])``
+    *  Convert object dtypes to categoricals:  ``df.categorize()``
+* Ingest
+    *  Read from bcolz (efficient on-disk column-store):
+      ``from_bcolz(x, index='mycol', categorize=True)``
+
+
 .. _Chest: http://github.com/ContinuumIO/chest
 .. _pframe: pframe.html

--- a/pframe/categories.py
+++ b/pframe/categories.py
@@ -68,6 +68,8 @@ def reapply_categories(df, metadata):
             d = metadata[df.name]
             return pd.Series(pd.Categorical.from_codes(df.values,
                                 d['categories'], d['ordered']))
+        else:
+            return df
 
     for name, d in metadata.items():
         if name in df.columns:

--- a/pframe/categories.py
+++ b/pframe/categories.py
@@ -30,8 +30,10 @@ def strip_categories(df):
     for name in df.columns:
         if isinstance(df.dtypes[name], pd.core.common.CategoricalDtype):
             df[name] = df[name].cat.codes
-    if isinstance(df.index, pd.CategoricalIndex):
-        df.index = pd.Index(df.index.codes)
+
+    if hasattr(pd, 'CategoricalIndex'):  # Pandas 0.16.1
+        if isinstance(df.index, pd.CategoricalIndex):
+            df.index = pd.Index(df.index.codes)
 
     return df
 
@@ -49,9 +51,12 @@ def categorical_metadata(df):
         if isinstance(df.dtypes[name], pd.core.common.CategoricalDtype):
             result[name] = {'categories': df[name].cat.categories,
                             'ordered': df[name].cat.ordered}
-    if isinstance(df.index, pd.CategoricalIndex):
-        result['_index'] = {'categories': df.index.categories,
-                            'ordered': False}
+
+    if hasattr(pd, 'CategoricalIndex'):  # Pandas 0.16.1
+        if isinstance(df.index, pd.CategoricalIndex):
+            result['_index'] = {'categories': df.index.categories,
+                                'ordered': False}
+
     return result
 
 
@@ -81,10 +86,11 @@ def reapply_categories(df, metadata):
                 df[name] = pd.Categorical.from_codes(df[name].values,
                                              d['categories'], d['ordered'])
 
-    if '_index' in metadata:
-        cat = pd.Categorical.from_codes(df.index.values,
-                                        metadata['_index']['categories'],
-                                        metadata['_index']['ordered'])
-        df.index = pd.CategoricalIndex(cat, df.index.name)
+    if hasattr(pd, 'CategoricalIndex'):  # Pandas 0.16.1
+        if '_index' in metadata:
+            cat = pd.Categorical.from_codes(df.index.values,
+                                            metadata['_index']['categories'],
+                                            metadata['_index']['ordered'])
+            df.index = pd.CategoricalIndex(cat, df.index.name)
 
     return df

--- a/pframe/categories.py
+++ b/pframe/categories.py
@@ -63,6 +63,12 @@ def reapply_categories(df, metadata):
     1    Bob
     2  Alice
     """
+    if isinstance(df, pd.Series):
+        if df.name in metadata:
+            d = metadata[df.name]
+            return pd.Series(pd.Categorical.from_codes(df.values,
+                                d['categories'], d['ordered']))
+
     for name, d in metadata.items():
         if name in df.columns:
             df[name] = pd.Categorical.from_codes(df[name].values,

--- a/pframe/categories.py
+++ b/pframe/categories.py
@@ -30,21 +30,28 @@ def strip_categories(df):
     for name in df.columns:
         if isinstance(df.dtypes[name], pd.core.common.CategoricalDtype):
             df[name] = df[name].cat.codes
+    if isinstance(df.index, pd.CategoricalIndex):
+        df.index = pd.Index(df.index.codes)
+
     return df
 
 
 def categorical_metadata(df):
     """ Collects category metadata
 
-    >>> df = pd.DataFrame({'a': pd.Categorical(['Alice', 'Bob', 'Alice'])})
+    >>> cat = pd.Categorical(['Alice', 'Bob', 'Alice'], ordered=False)
+    >>> df = pd.DataFrame({'a': cat})
     >>> categorical_metadata(df)  # doctest: +SKIP
-    {'a': {'ordered': True, 'categories': Index([u'Alice', u'Bob'], dtype='object')}}
+    {'a': {'ordered': False, 'categories': Index([u'Alice', u'Bob'], dtype='object')}}
     """
     result = dict()
     for name in df.columns:
         if isinstance(df.dtypes[name], pd.core.common.CategoricalDtype):
             result[name] = {'categories': df[name].cat.categories,
                             'ordered': df[name].cat.ordered}
+    if isinstance(df.index, pd.CategoricalIndex):
+        result['_index'] = {'categories': df.index.categories,
+                            'ordered': False}
     return result
 
 
@@ -66,13 +73,18 @@ def reapply_categories(df, metadata):
     if isinstance(df, pd.Series):
         if df.name in metadata:
             d = metadata[df.name]
-            return pd.Series(pd.Categorical.from_codes(df.values,
+            df = pd.Series(pd.Categorical.from_codes(df.values,
                                 d['categories'], d['ordered']))
-        else:
-            return df
+    else:
+        for name, d in metadata.items():
+            if name in df.columns:
+                df[name] = pd.Categorical.from_codes(df[name].values,
+                                             d['categories'], d['ordered'])
 
-    for name, d in metadata.items():
-        if name in df.columns:
-            df[name] = pd.Categorical.from_codes(df[name].values,
-                                         d['categories'], d['ordered'])
+    if '_index' in metadata:
+        cat = pd.Categorical.from_codes(df.index.values,
+                                        metadata['_index']['categories'],
+                                        metadata['_index']['ordered'])
+        df.index = pd.CategoricalIndex(cat, df.index.name)
+
     return df

--- a/pframe/tests/test_categories.py
+++ b/pframe/tests/test_categories.py
@@ -1,4 +1,4 @@
-from pframe.categories import reapply_categories
+from pframe.categories import reapply_categories, strip_categories, categorical_metadata
 from pandas.util import testing as tm
 import pandas as pd
 
@@ -12,3 +12,20 @@ def test_reapply_categories():
     assert list(reapply_categories(df[['a']], metadata).columns) == ['a']
     assert list(reapply_categories(df.a, metadata)) == ['Alice', 'Bob', 'Alice']
     assert list(reapply_categories(df.b, metadata)) == [1, 0, 00]
+
+
+def test_index_categorical():
+    df = pd.DataFrame({'a': [1, 2, 3]},
+                      index=pd.Categorical(['Alice', 'Bob', 'Alice']))
+
+    df2 = strip_categories(df.copy())
+    assert df2.index.equals(pd.Index([0, 1, 0], dtype='i2'))
+
+    metadata = categorical_metadata(df)
+
+    assert metadata['_index']['categories'].equals(df.index.categories)
+
+    df3 = reapply_categories(df2.copy(), metadata)
+
+    assert df.equals(df3)
+

--- a/pframe/tests/test_categories.py
+++ b/pframe/tests/test_categories.py
@@ -6,10 +6,9 @@ import pandas as pd
 def test_reapply_categories():
     df = pd.DataFrame({'a': [0, 1, 0], 'b': [1, 0, 0]})
     metadata = {'a': {'ordered': True,
-                      'categories': pd.Index(['Alice', 'Bob'], dtype='object')},
-                'b': {'ordered': True,
-                      'categories': pd.Index(['Apple', 'Orange'], dtype='object')}}
+                      'categories': pd.Index(['Alice', 'Bob'], dtype='object')}}
 
 
     assert list(reapply_categories(df[['a']], metadata).columns) == ['a']
     assert list(reapply_categories(df.a, metadata)) == ['Alice', 'Bob', 'Alice']
+    assert list(reapply_categories(df.b, metadata)) == [1, 0, 00]

--- a/pframe/tests/test_categories.py
+++ b/pframe/tests/test_categories.py
@@ -1,0 +1,15 @@
+from pframe.categories import reapply_categories
+from pandas.util import testing as tm
+import pandas as pd
+
+
+def test_reapply_categories():
+    df = pd.DataFrame({'a': [0, 1, 0], 'b': [1, 0, 0]})
+    metadata = {'a': {'ordered': True,
+                      'categories': pd.Index(['Alice', 'Bob'], dtype='object')},
+                'b': {'ordered': True,
+                      'categories': pd.Index(['Apple', 'Orange'], dtype='object')}}
+
+
+    assert list(reapply_categories(df[['a']], metadata).columns) == ['a']
+    assert list(reapply_categories(df.a, metadata)) == ['Alice', 'Bob', 'Alice']

--- a/pframe/tests/test_categories.py
+++ b/pframe/tests/test_categories.py
@@ -15,6 +15,8 @@ def test_reapply_categories():
 
 
 def test_index_categorical():
+    if not hasattr(pd, 'CategoricalIndex'):
+        return
     df = pd.DataFrame({'a': [1, 2, 3]},
                       index=pd.Categorical(['Alice', 'Bob', 'Alice']))
 


### PR DESCRIPTION
This builds off of #82 to transform tasks that look like 

    (getitem, (get_block_from_column_store, mystore, some_rows), some_columns)

to 

    (get_block_from_column_store, mystore, some_rows, some_columns)

It works for pframe.  Doesn't yet work for bcolz, because that function also needs a dict of categories which is not hashable, which screws with @jcrist 's term rewriting algorithms.