### PR TITLE
Stack adds new dimension to blocks

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -890,8 +890,12 @@ def stack(seq, axis=0):
     keys = list(product([name], *[range(len(bd)) for bd in blockdims]))
 
     names = [a.name for a in seq]
-    values = [(names[key[axis+1]],) + key[1:axis + 1] + key[axis + 2:]
+    inputs = [(names[key[axis+1]],) + key[1:axis + 1] + key[axis + 2:]
                 for key in keys]
+    values = [(getitem, inp, (slice(None, None, None),) * axis
+                           + (None,)
+                           + (slice(None, None, None),) * (ndim - axis))
+                for inp in inputs]
 
     dsk = dict(zip(keys, values))
     dsk2 = merge(dsk, *[a.dask for a in seq])


### PR DESCRIPTION
For arrays with dimension k, `stack([x, y, z])` has dimension k + 1.
The blocks of this result should also have dimension k + 1.

We add these dimensions by injecting calls like `x[None, ...]`

Fixes #100
cc @shoyer