### PR TITLE
Fix slicing dask arrays with ndarrays

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -616,7 +616,7 @@ class Array(object):
         if not isinstance(index, tuple):
             index = (index,)
 
-        if all(i == slice(None, None, None) for i in index):
+        if all(isinstance(i, slice) and i == slice(None) for i in index):
             return self
 
         dsk, blockdims = slice_array(out, self.name, self.blockdims, index)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -493,6 +493,14 @@ def test_slicing_with_ellipsis():
     assert eq(d[0, ..., 1], x[0, ..., 1])
 
 
+def test_slicing_with_ndarray():
+    x = np.arange(64).reshape((8, 8))
+    d = da.from_array(x, blockshape=((4, 4)))
+
+    assert eq(d[np.arange(8)], x)
+    assert eq(d[np.ones(8, dtype=bool)], x)
+
+
 def test_dtype():
     d = da.ones((4, 4), blockshape=(2, 2))
 


### PR DESCRIPTION
Previously, this raised the error:

	--> 619         if all(i == slice(None, None, None) for i in index):
	    620             return self
	    621

	ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()