### PR TITLE
Added `merge_sync` and `sync_keys`

### DIFF
--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -8,6 +8,7 @@ PY2 = sys.version_info[0] == 2
 if PY3:
     import builtins
     from queue import Queue
+    from itertools import zip_longest
     unicode = str
     long = int
     def apply(func, args):
@@ -16,6 +17,7 @@ else:
     import __builtin__ as builtins
     from Queue import Queue
     import operator
+    from itertools import izip_longest as zip_longest
     unicode = unicode
     long = long
     apply = apply

--- a/dask/core.py
+++ b/dask/core.py
@@ -41,6 +41,21 @@ def istask(x):
     return isinstance(x, tuple) and x and callable(x[0])
 
 
+def preorder_traversal(task):
+    """A generator to preorder-traverse a task."""
+
+    for item in task:
+        if istask(item):
+            for i in preorder_traversal(item):
+                yield i
+        elif isinstance(item, list):
+            yield list
+            for i in preorder_traversal(item):
+                yield i
+        else:
+            yield item
+
+
 def _get_task(d, task, maxdepth=1000):
     # non-recursive.  DAG property is checked upon reaching maxdepth.
     _iter = lambda *args: iter(args)
@@ -382,4 +397,3 @@ def isdag(d, keys):
     getcycle
     """
     return not getcycle(d, keys)
-

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -266,10 +266,10 @@ def equivalent(term1, term2, subs=None):
     >>> from operator import add
     >>> term1 = (add, 'a', 'b')
     >>> term2 = (add, 'x', 'y')
-    >>> subs = {'a': 'x', 'b': 'y'}
+    >>> subs = {'x': 'a', 'y': 'b'}
     >>> equivalent(term1, term2, subs)
     True
-    >>> subs = {'a': 'x'}
+    >>> subs = {'x': 'a'}
     >>> equivalent(term1, term2, subs)
     False
     """
@@ -316,7 +316,7 @@ def dependency_dict(dsk):
     -------
     >>> from operator import add
     >>> dsk = {'a': 1, 'b': 2, 'c': (add, 'a', 'a'), 'd': (add, 'b', 'a')}
-    >>> dependency_dict(dsk)
+    >>> dependency_dict(dsk)    # doctest: +SKIP
     {(): ['a', 'b'], ('a', 'a'): ['c'], ('b', 'a'): ['d']}
     """
 
@@ -351,7 +351,7 @@ def sync_vars(dsk1, dsk2):
     >>> from operator import add, mul
     >>> dsk1 = {'a': 1, 'b': (add, 'a', 10), 'c': (mul, 'b', 5)}
     >>> dsk2 = {'x': 1, 'y': (add, 'x', 10), 'z': (mul, 'y', 2)}
-    >>> sync_vars(dsk1, dsk2)
+    >>> sync_vars(dsk1, dsk2)   # doctest: +SKIP
     {'x': 'a', 'y': 'b'}
     """
 
@@ -386,7 +386,7 @@ def merge_sync(dsk1, dsk2):
     >>> from operator import add, mul
     >>> dsk1 = {'a': 1, 'b': (add, 'a', 10), 'c': (mul, 'b', 5)}
     >>> dsk2 = {'x': 1, 'y': (add, 'x', 10), 'z': (mul, 'y', 2)}
-    >>> merge_sync(dsk1, dsk2)
+    >>> merge_sync(dsk1, dsk2)  # doctest: +SKIP
     {'a': 1, 'b': (add, 'a', 10), 'c': (mul, 'b', 5), 'z': (mul, 'b', 2)}
     """
 

--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -1,4 +1,4 @@
-from itertools import zip_longest
+from .compatibility import zip_longest
 from .core import (istask, get_dependencies, subs, toposort, flatten,
                    reverse_dict, add, inc, ishashable, preorder_traversal)
 from .rewrite import END

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -1,5 +1,6 @@
 from dask.utils import raises
-from dask.core import istask, get, get_dependencies, flatten, subs
+from dask.core import (istask, get, get_dependencies, flatten, subs,
+        preorder_traversal)
 
 
 def contains(a, b):
@@ -28,6 +29,15 @@ def test_istask():
 d = {':x': 1,
      ':y': (inc, ':x'),
      ':z': (add, ':x', ':y')}
+
+
+def test_preorder_traversal():
+    t = (add, 1, 2)
+    assert list(preorder_traversal(t)) == [add, 1, 2]
+    t = (add, (add, 1, 2), (add, 3, 4))
+    assert list(preorder_traversal(t)) == [add, add, 1, 2, add, 3, 4]
+    t = (add, (sum, [1, 2]), 3)
+    assert list(preorder_traversal(t)) == [add, sum, list, 1, 2, 3]
 
 
 def test_get():

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -1,8 +1,9 @@
+from itertools import count
 from operator import add, mul
 from toolz import partial, identity
 from dask.utils import raises
 from dask.optimize import (cull, fuse, inline, inline_functions, functions_of,
-        dealias, equivalent, sync_vars, merge_sync)
+        dealias, equivalent, sync_keys, merge_sync)
 
 
 def inc(x):
@@ -226,16 +227,16 @@ def test_equivalence_uncomparable():
     assert not equivalent((add, t1, 0), (add, t2, 0))
 
 
-def test_sync_vars():
+def test_sync_keys():
     dsk1 = {'a': 1, 'b': (add, 'a', 10), 'c': (mul, 'b', 5)}
     dsk2 = {'x': 1, 'y': (add, 'x', 10), 'z': (mul, 'y', 2)}
-    assert sync_vars(dsk1, dsk2) == {'x': 'a', 'y': 'b'}
-    assert sync_vars(dsk2, dsk1) == {'a': 'x', 'b': 'y'}
+    assert sync_keys(dsk1, dsk2) == {'x': 'a', 'y': 'b'}
+    assert sync_keys(dsk2, dsk1) == {'a': 'x', 'b': 'y'}
 
     dsk1 = {'a': 1, 'b': 2, 'c': (add, 'a', 'b'), 'd': (inc, (add, 'a', 'b'))}
     dsk2 = {'x': 1, 'y': 5, 'z': (add, 'x', 'y'), 'w': (inc, (add, 'x', 'y'))}
-    assert sync_vars(dsk1, dsk2) == {'x': 'a'}
-    assert sync_vars(dsk2, dsk1) == {'a': 'x'}
+    assert sync_keys(dsk1, dsk2) == {'x': 'a'}
+    assert sync_keys(dsk2, dsk1) == {'a': 'x'}
 
 
 def test_sync_uncomparable():
@@ -243,17 +244,19 @@ def test_sync_uncomparable():
     t2 = Uncomparable()
     dsk1 = {'a': 1, 'b': t1, 'c': (add, 'a', 'b')}
     dsk2 = {'x': 1, 'y': t2, 'z': (add, 'y', 'x')}
-    assert sync_vars(dsk1, dsk2) == {'x': 'a'}
+    assert sync_keys(dsk1, dsk2) == {'x': 'a'}
 
     dsk2 = {'x': 1, 'y': t1, 'z': (add, 'y', 'x')}
-    assert sync_vars(dsk1, dsk2) == {'x': 'a', 'y': 'b'}
+    assert sync_keys(dsk1, dsk2) == {'x': 'a', 'y': 'b'}
 
 
 def test_merge_sync():
     dsk1 = {'a': 1, 'b': (add, 'a', 10), 'c': (mul, 'b', 5)}
     dsk2 = {'x': 1, 'y': (add, 'x', 10), 'z': (mul, 'y', 2)}
-    assert merge_sync(dsk1, dsk2) == {'a': 1, 'b': (add, 'a', 10),
-            'c': (mul, 'b', 5), 'z': (mul, 'b', 2)}
+    new_dsk, key_map = merge_sync(dsk1, dsk2)
+    assert new_dsk == {'a': 1, 'b': (add, 'a', 10), 'c': (mul, 'b', 5),
+            'z': (mul, 'b', 2)}
+    assert key_map == {'x': 'a', 'y': 'b', 'z': 'z'}
 
     dsk1 = {'g1': 1,
             'g2': 2,
@@ -265,11 +268,27 @@ def test_merge_sync():
             'h3': (add, 'h1', 1),
             'h4': (add, 'h2', 1),
             'h5': (mul, (inc, 'h3'), (inc, 'h4'))}
-    assert merge_sync(dsk1, dsk2) == {'g1': 1,
-                                      'g2': 2,
-                                      'g3': (add, 'g1', 1),
-                                      'g4': (add, 'g2', 1),
-                                      'g5': (mul, (inc, 'g3'), (inc, 'g4')),
-                                      'h2': 5,
-                                      'h4': (add, 'h2', 1),
-                                      'h5': (mul, (inc, 'g3'), (inc, 'h4'))}
+    new_dsk, key_map = merge_sync(dsk1, dsk2)
+    assert new_dsk == {'g1': 1,
+                       'g2': 2,
+                       'g3': (add, 'g1', 1),
+                       'g4': (add, 'g2', 1),
+                       'g5': (mul, (inc, 'g3'), (inc, 'g4')),
+                       'h2': 5,
+                       'h4': (add, 'h2', 1),
+                       'h5': (mul, (inc, 'g3'), (inc, 'h4'))}
+    assert key_map == {'h1': 'g1', 'h2': 'h2', 'h3': 'g3',
+            'h4': 'h4', 'h5': 'h5'}
+
+    # Test merging with name conflict
+    # Reset name count to ensure same numbers
+    merge_sync.names = ("merge_%d" % i for i in count(1))
+    dsk1 = {'g1': 1, 'conflict': (add, 'g1', 2), 'g2': (add, 'conflict', 3)}
+    dsk2 = {'h1': 1, 'conflict': (add, 'h1', 4), 'h2': (add, 'conflict', 3)}
+    new_dsk, key_map = merge_sync(dsk1, dsk2)
+    assert new_dsk == {'g1': 1,
+                       'conflict': (add, 'g1', 2),
+                       'merge_1': (add, 'g1', 4),
+                       'g2': (add, 'conflict', 3),
+                       'h2': (add, 'merge_1', 3)}
+    assert key_map == {'h1': 'g1', 'conflict': 'merge_1', 'h2': 'h2'}


### PR DESCRIPTION
Allows for syncing dasks together, removing terms equivalent modulo
variables. Fixes #37.

This provides two functions: `sync_vars` and `merge_sync`:
- `sync_vars` takes two dasks, and returns a `dict` mapping keys in `dask2` to equivalent keys in `dask1`.
- `merge_sync` takes two dasks, calls `sync_vars`, and then merges the two dasks, applying the substitutions to each task.

If a term doesn't support `==`, it is skipped over.

Example:

```
>>> dsk1 = {'a': 1, 'b': (add, 'a', 10), 'c': (mul, 'b', 5)}
>>> dsk2 = {'x': 1, 'y': (add, 'x', 10), 'z': (mul, 'y', 2)}
>>> sync_vars(dsk1, dsk2)
{'x': 'a', 'y': 'b'}
>>> merge_sync(dsk1, dsk2)
{'a': 1, 'b': (add, 'a', 10), 'c': (mul, 'b', 5), 'z': (mul, 'b', 2)}
```

