### PR TITLE
Fix unpack singleton

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -840,9 +840,14 @@ def unpack_singleton(x):
 
     >>> unpack_singleton([[[[1]]]])
     1
+    >>> unpack_singleton(np.array(np.datetime64('2000-01-01')))
+    array(datetime.date(2000, 1, 1), dtype='datetime64[D]')
     """
-    while isinstance(x, Iterable):
-        x = x[0]
+    while True:
+        try:
+            x = x[0]
+        except (IndexError, TypeError, KeyError):
+            break
     return x
 
 


### PR DESCRIPTION
It currently breaks on scalar datetime64 arrays, which incorrectly report
that they are Iterable. This is undoubtedly a numpy bug, but we need to
work around it, somehow...