### PR TITLE
Fix slicing bug where slice.stop == 0

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -352,6 +352,8 @@ def rec_concatenate(arrays, axis=0):
            [1, 2, 1, 2],
            [1, 2, 1, 2]])
     """
+    if not arrays:
+        return np.array([])
     if isinstance(arrays, Iterator):
         arrays = list(arrays)
     if isinstance(arrays[0], Iterator):

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -317,7 +317,7 @@ def _slice_1d(dim_shape, lengths, index):
     step = index.step or 1
     if step > 0:
         start = index.start or 0
-        stop = index.stop or dim_shape
+        stop = index.stop if index.stop is not None else dim_shape
     else:
         start = index.start or dim_shape - 1
         start = dim_shape - 1 if start >= dim_shape else start

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -1,9 +1,21 @@
 import dask
 import dask.array as da
+from dask.array import Array
 from dask.array.slicing import slice_array, _slice_1d, take
 from operator import getitem
 import numpy as np
-from pprint import pprint
+
+
+def eq(a, b):
+    if isinstance(a, da.Array):
+        a = a.compute(get=dask.get)
+    if isinstance(b, da.Array):
+        b = b.compute(get=dask.get)
+
+    c = a == b
+    if isinstance(c, np.ndarray):
+        c = c.all()
+    return c
 
 
 def test_slice_1d():
@@ -324,3 +336,10 @@ def test_slicing_and_blockdims():
     o = da.ones((24, 16), blockdims=((4, 8, 8, 4), (2, 6, 6, 2)))
     t = o[4:-4, 2:-2]
     assert t.blockdims == ((8, 8), (6, 6))
+
+
+def test_slice_stop_0():
+    # from gh-125
+    a = da.ones(10, blockshape=(10,))[:0].compute()
+    b = np.ones(10)[:0]
+    assert eq(a, b)


### PR DESCRIPTION
This closes #125 

After this was fixed it also revealed a bug were `dask.Array.compute()` would fail if the dask array was empty. This is fixed in 4a93a47.