### PR TITLE
Implement dask.array.take

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
 from ..utils import ignoring
-from .core import (Array, stack, concatenate, tensordot, transpose, from_array,
-        choose, where, coarsen, broadcast_to, constant, fromfunction, compute,
-        unique, store)
+from .core import (Array, stack, concatenate, take, tensordot, transpose,
+        from_array, choose, where, coarsen, broadcast_to, constant,
+        fromfunction, compute, unique, store)
 from .core import (arccos, arcsin, arctan, arctanh, arccosh, arcsinh, arctan2,
         ceil, copysign, cos, cosh, degrees, exp, expm1, fabs, floor, fmod,
         frexp, hypot, isinf, isnan, ldexp, log, log10, log1p, modf, radians,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1001,6 +1001,15 @@ def concatenate(seq, axis=0):
     return Array(dsk2, name, shape, blockdims=blockdims, dtype=dt)
 
 
+@wraps(np.take)
+def take(a, indices, axis):
+    if not -a.ndim <= axis < a.ndim:
+        raise ValueError('axis=(%s) out of bounds' % axis)
+    if axis < 0:
+        axis += a.ndim
+    return a[(slice(None),) * axis + (indices,)]
+
+
 @wraps(np.transpose)
 def transpose(a, axes=None):
     axes = axes or tuple(range(a.ndim))[::-1]

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -273,6 +273,15 @@ def test_concatenate():
     assert raises(ValueError, lambda: concatenate([a, b, c], axis=2))
 
 
+def test_take():
+    x = np.arange(400).reshape((20, 20))
+    a = from_array(x, blockshape=(5, 5))
+
+    assert eq(np.take(x, 3, axis=0), take(a, 3, axis=0))
+    assert eq(np.take(x, [3, 4, 5], axis=-1), take(a, [3, 4, 5], axis=-1))
+    assert raises(ValueError, lambda: take(a, 3, axis=2))
+
+
 def test_binops():
     a = Array(dict((('a', i), '') for i in range(3)),
               'a', blockdims=((10, 10, 10),))


### PR DESCRIPTION
In principle, we could use a fast path here instead of invoking normal
indexing (like np.take itself), but it didn't seem work the trouble for now.