### PR TITLE
Slicing with lists emits getitem(..., a_list)

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -407,7 +407,7 @@ def take(outname, inname, blockdims, index, axis=0):
 
     colon = slice(None, None, None)
 
-    rev_index = tuple(map(sorted(index).index, index))
+    rev_index = list(map(sorted(index).index, index))
     vals = [(getitem, (np.concatenate,
                   (list, [(getitem, ((inname,) + d[:axis] + (i,) + d[axis+1:]),
                                    ((colon,)*axis + (IL,) + (colon,)*(n-axis-1)))

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -253,7 +253,7 @@ def test_take():
                 [(getitem, ('x', 0), ([1, 3, 5],)),
                  (getitem, ('x', 2), ([7],))]),
                0),
-             ((2, 0, 3, 1),))}
+             ([2, 0, 3, 1],))}
     assert result == expected
 
     result = take('y', 'x', [(20, 20, 20, 20), (20, 20)], [5, 1, 47, 3], axis=0)
@@ -263,7 +263,7 @@ def test_take():
                 [(getitem, ('x', 0, j), ([1, 3, 5], slice(None, None, None))),
                  (getitem, ('x', 2, j), ([7], slice(None, None, None)))]),
                 0),
-              ((2, 0, 3, 1), slice(None, None, None))))
+              ([2, 0, 3, 1], slice(None, None, None))))
             for j in range(2))
     assert result == expected
 
@@ -274,7 +274,7 @@ def test_take():
                 [(getitem, ('x', i, 0), (slice(None, None, None), [1, 3, 5])),
                  (getitem, ('x', i, 1), (slice(None, None, None), [17]))]),
                 1),
-             (slice(None, None, None), (2, 0, 3, 1))))
+             (slice(None, None, None), [2, 0, 3, 1])))
            for i in range(4))
 
     assert result == expected
@@ -295,7 +295,7 @@ def test_slice_lists():
                            ([0], slice(None, None, None))),
                            ]),
                         0),
-                       ((0, 1, 2), slice(None, None, None))))
+                       ([0, 1, 2], slice(None, None, None))))
                 for i in range(4))
 
     assert blockdims == ((3,), (3, 3, 3, 1))
@@ -343,3 +343,10 @@ def test_slice_stop_0():
     a = da.ones(10, blockshape=(10,))[:0].compute()
     b = np.ones(10)[:0]
     assert eq(a, b)
+
+
+def test_slice_list_then_None():
+    x = da.zeros(shape=(5, 5), blockshape=(3, 3))
+    y = x[[2, 1]][None]
+
+    assert eq(y, np.zeros((1, 2, 5)))


### PR DESCRIPTION
When we slice into blocks with lists we used to use tuples as indexers
rather than lists.  This caused havoc with the fuse_slice optimization
which treats the two differently.

Now indexing with lists uses lists and fuse_slice is happy.

Fixes #133