### PR TITLE
Turn on linspace and arange tests.

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -122,22 +122,23 @@ def arange(*args, **kwargs):
 
     dtype = kwargs.get('dtype', None)
 
-    num = abs((stop - start) / step)
-    if (num % step) != 0:
+    range_ = stop - start
+    num = int(abs(range_ // step))
+    if (range_ % step) != 0:
         num += 1
 
     # compute blocksizes
     blocksizes = _get_blocksizes(num, blocksize)
 
-    blockstart = start
-
     name = next(arange_names)
     dsk = {}
+    elem_count = 0
 
     for i, bs in enumerate(blocksizes):
-        blockstop = blockstart + (bs * step)
+        blockstart = start + (elem_count * step)
+        blockstop = start + ((elem_count + bs) * step)
         task = (np.arange, blockstart, blockstop, step, dtype)
-        blockstart = blockstop
         dsk[(name, i)] = task
+        elem_count += bs
 
     return Array(dsk, name, blockdims=(blocksizes,), dtype=dtype)

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -1,26 +1,18 @@
 import numpy as np
+from numpy.testing import assert_array_almost_equal
+import pytest
 
-import dask
 import dask.array as da
 
 
 def eq(a, b):
-    if isinstance(a, da.Array):
-        adt = a._dtype
-        a = a.compute(get=dask.get)
-    if isinstance(b, da.Array):
-        bdt = b._dtype
-        b = b.compute(get=dask.get)
-    else:
-        bdt = getattr(b, 'dtype', None)
-
-    if not str(adt) == str(bdt):
-        return False
-
-    c = a == b
-    if isinstance(c, np.ndarray):
-        c = c.all()
-    return c
+    """a is a dask array, b is a numpy array. Checks dtype, shape and value. No
+    `assert` needed.
+    """
+    a = np.array(a)
+    assert a.shape == b.shape
+    assert a.dtype == b.dtype
+    assert_array_almost_equal(a, b)
 
 
 def test_linspace():
@@ -55,25 +47,10 @@ def test_arange():
     eq(darr, nparr)
 
     # negative steps
-    darr = da.arange(5, 53, -3, blocksize=5)
-    nparr = np.arange(5, 53, -3)
+    darr = da.arange(53, 5, -3, blocksize=5)
+    nparr = np.arange(53, 5, -3)
     eq(darr, nparr)
 
-    # non-integer steps
-    darr = da.arange(2, 13, .3, blocksize=4)
-    nparr = np.arange(2, 13, .3)
-    eq(darr, nparr)
-
-    # both non-integer and negative
-    darr = da.arange(1.5, 7.7, -.8, blocksize=3)
-    nparr = np.arange(1.5, 7.7, -.8)
-    eq(darr, nparr)
-
-    darr = da.arange(-9.1, 3.3, -.25, blocksize=3)
-    nparr = np.arange(-9.1, 3.3, -.25)
-    eq(darr, nparr)
-
-    # dtypes
     darr = da.arange(77, blocksize=13, dtype=float)
     nparr = np.arange(77, dtype=float)
     eq(darr, nparr)
@@ -82,10 +59,31 @@ def test_arange():
     nparr = np.arange(2, 13, dtype=int)
     eq(darr, nparr)
 
-    darr = da.arange(1.5, 7.7, -.8, blocksize=3, dtype='f8')
-    nparr = np.arange(1.5, 7.7, -.8, dtype='f8')
+
+def test_arange_working_float_step():
+    """Sometimes floating point step arguments work, but this could be platform
+    dependent.
+    """
+    darr = da.arange(3.3, -9.1, -.25, blocksize=3)
+    nparr = np.arange(3.3, -9.1, -.25)
     eq(darr, nparr)
 
-    darr = da.arange(-9.1, 3.3, -.25, blocksize=3, dtype='i8')
-    nparr = np.arange(-9.1, 3.3, -.25, dtype='i8')
+
+@pytest.mark.xfail(reason="Casting floats to ints is not supported since edge"
+                          "behavior is not specified or guaranteed by NumPy.")
+def test_arange_cast_float_int_step():
+    darr = da.arange(3.3, -9.1, -.25, blocksize=3, dtype='i8')
+    nparr = np.arange(3.3, -9.1, -.25, dtype='i8')
+    eq(darr, nparr)
+
+
+@pytest.mark.xfail(reason="arange with a floating point step value can fail"
+                          "due to numerical instability.")
+def test_arange_float_step():
+    darr = da.arange(2., 13., .3, blocksize=4)
+    nparr = np.arange(2., 13., .3)
+    eq(darr, nparr)
+
+    darr = da.arange(7.7, 1.5, -.8, blocksize=3)
+    nparr = np.arange(7.7, 1.5, -.8)
     eq(darr, nparr)


### PR DESCRIPTION
PR #115 with the tests broken so nothing was actually tested. This turns the tests on and fixes bugs that the tests uncovered. However there are issues with `dask.array.arange` matching `numpy.arange` in edge cases that are not specified or supported by NumPy. Tests where these edge cases come up were marked as expected failures.

The edge cases come up when arange is passed a floating point `step` argument. The step argument is added repeatedly, which might result in points near the end of the interval being included when they should not.