### PR TITLE
fit/predict functions for scikit learn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - conda install pytest numpy into pip coverage toolz pandas cython
+  - conda install pytest numpy into pip coverage toolz pandas cython scikit-learn
   - conda install -c blaze blaze
   - pip install coveralls dill --use-mirrors
   - pip install git+https://github.com/ContinuumIO/chest

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -19,7 +19,7 @@ from .reductions import (sum, prod, mean, std, var, any, all, min, max, vnorm,
 from .percentile import percentile
 with ignoring(ImportError):
     from .reductions import nanprod
-from . import random, linalg, ghost
+from . import random, linalg, ghost, learn
 from .wrap import ones, zeros, empty
 from .reblock import reblock
 from ..context import set_options

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 from ..utils import ignoring
 from .core import (Array, stack, concatenate, take, tensordot, transpose,
         from_array, choose, where, coarsen, insert, broadcast_to, constant,
-        fromfunction, compute, unique, store)
+        fromfunction, compute, unique, store, squeeze)
 from .core import (logaddexp, logaddexp2, conj, exp, log, log2, log10, log1p,
         expm1, sqrt, square, sin, cos, tan, arcsin, arccos, arctan, arctan2,
         hypot, sinh, cosh, tanh, arcsinh, arccosh, arctanh, deg2rad, rad2deg,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -417,6 +417,23 @@ def map_blocks(x, func, blockshape=None, blockdims=None, dtype=None):
     return Array(merge(dsk, x.dask), name, blockdims=blockdims, dtype=dtype)
 
 
+@wraps(np.squeeze)
+def squeeze(a, axis=None):
+    if axis is None:
+        axis = tuple(i for i, d in enumerate(a.shape) if d == 1)
+    b = a.map_blocks(partial(np.squeeze, axis=axis), dtype=a.dtype)
+    blockdims = tuple(bd for bd in b.blockdims if bd != (1,))
+    old_keys = list(product([b.name], *[range(len(bd)) for bd in b.blockdims]))
+    new_keys = list(product([b.name], *[range(len(bd)) for bd in blockdims]))
+
+    dsk = b.dask.copy()
+    for o, n in zip(old_keys, new_keys):
+        dsk[n] = dsk[o]
+        del dsk[o]
+
+    return Array(dsk, b.name, blockdims=blockdims, dtype=a.dtype)
+
+
 def compute(*args, **kwargs):
     """ Evaluate several dask arrays at once
 
@@ -778,6 +795,9 @@ class Array(object):
         return map_blocks(self, func, blockshape=blockshape,
                           blockdims=blockdims, dtype=dtype)
 
+    @wraps(squeeze)
+    def squeeze(self):
+        return squeeze(self)
 
     def reblock(self, blockdims=None, blockshape=None):
         from .reblock import reblock

--- a/dask/array/learn.py
+++ b/dask/array/learn.py
@@ -1,0 +1,100 @@
+from .core import names
+from .. import threaded
+from toolz import merge, partial
+
+
+def _partial_fit(model, x, y, kwargs=None):
+    kwargs = kwargs or dict()
+    model.partial_fit(x, y, **kwargs)
+    return model
+
+
+def fit(model, x, y, get=threaded.get, **kwargs):
+    """ Fit scikit learn model against dask arrays
+
+    Model must support the ``partial_fit`` interface for online or batch
+    learning.
+
+    This method will be called on dask arrays in sequential order.  Ideally
+    your rows are independent and identically distributed.
+
+    Parameters
+    ----------
+    model: sklearn model
+        Any model supporting partial_fit interface
+    x: dask Array
+        Two dimensional array, likely tall and skinny
+    y: dask Array
+        One dimensional array with same blockdims as x's rows
+    kwargs:
+        options to pass to partial_fit
+
+    Example
+    -------
+
+    >>> import dask.array as da
+    >>> X = da.random.random((10, 3), blockshape=(5, 3))
+    >>> y = da.random.random(10, blockshape=(5,))
+
+    >>> from sklearn.linear_model import SGDClassifier
+    >>> sgd = SGDClassifier()
+
+    >>> da.learn.fit(sgd, X, y, classes=[1, 0])
+    SGDClassifier(alpha=0.0001, class_weight=None, epsilon=0.1, eta0=0.0,
+           fit_intercept=True, l1_ratio=0.15, learning_rate='optimal',
+           loss='hinge', n_iter=5, n_jobs=1, penalty='l2', power_t=0.5,
+           random_state=None, shuffle=False, verbose=0, warm_start=False)
+
+    This passes all of X and y through the classifier sequentially.  We can use
+    the classifier as normal on in-memory data
+
+    >>> import numpy as np
+    >>> sgd.predict(np.random.random((4, 3)))  # doctest: +SKIP
+    array([1, 0, 0, 1])
+
+    Or predict on a larger dataset
+
+    >>> z = da.random.random((400, 3), blockshape=(100, 3))
+    >>> da.learn.predict(sgd, z)  # doctest: +SKIP
+    dask.array<x_11, shape=(400,), blockdims=((100, 100, 100, 100),), dtype=int64>
+    """
+    assert x.ndim == 2
+    assert y.ndim == 1
+    assert x.blockdims[0] == y.blockdims[0]
+    assert hasattr(model, 'partial_fit')
+    if len(x.blockdims[1]) > 1:
+        x = x.reblock(blockdims=(x.blockdims[0], sum(x.blockdims[1])))
+
+    nblocks = len(x.blockdims[0])
+
+    name = next(names)
+    dsk = {(name, -1): model}
+    dsk.update({(name, i): (_partial_fit, (name, i - 1),
+                                          (x.name, i, 0),
+                                          (y.name, i),
+                                          kwargs)
+                    for i in range(nblocks)})
+
+    return get(merge(x.dask, y.dask, dsk), (name, nblocks - 1))
+
+
+def _predict(model, x):
+    return model.predict(x)[:, None]
+
+
+def predict(model, x):
+    """ Predict with a scikit learn model
+
+    Parameters
+    ----------
+
+    model: scikit learn classifier
+    x: dask Array
+
+    See docstring for ``da.learn.fit``
+    """
+    assert x.ndim == 2
+    if len(x.blockdims[1]) > 1:
+        x = x.reblock(blockdims=(x.blockdims[0], sum(x.blockdims[1])))
+    func = partial(_predict, model)
+    return x.map_blocks(func, blockdims=(x.blockdims[0], (1,))).squeeze()

--- a/dask/array/learn.py
+++ b/dask/array/learn.py
@@ -69,11 +69,11 @@ def fit(model, x, y, get=threaded.get, **kwargs):
 
     name = next(names)
     dsk = {(name, -1): model}
-    dsk.update({(name, i): (_partial_fit, (name, i - 1),
+    dsk.update(dict(((name, i), (_partial_fit, (name, i - 1),
                                           (x.name, i, 0),
                                           (y.name, i),
-                                          kwargs)
-                    for i in range(nblocks)})
+                                          kwargs))
+                    for i in range(nblocks)))
 
     return get(merge(x.dask, y.dask, dsk), (name, nblocks - 1))
 

--- a/dask/array/learn.py
+++ b/dask/array/learn.py
@@ -39,7 +39,8 @@ def fit(model, x, y, get=threaded.get, **kwargs):
     >>> from sklearn.linear_model import SGDClassifier
     >>> sgd = SGDClassifier()
 
-    >>> da.learn.fit(sgd, X, y, classes=[1, 0])
+    >>> sgd = da.learn.fit(sgd, X, y, classes=[1, 0])
+    >>> sgd  # doctest: +SKIP
     SGDClassifier(alpha=0.0001, class_weight=None, epsilon=0.1, eta0=0.0,
            fit_intercept=True, l1_ratio=0.15, learning_rate='optimal',
            loss='hinge', n_iter=5, n_jobs=1, penalty='l2', power_t=0.5,

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -832,3 +832,11 @@ def test_optimize():
     result = optimize(expr.dask, expr._keys())
     assert isinstance(result, dict)
     assert all(key in result for key in expr._keys())
+
+
+def test_squeeze():
+    x = da.ones((10, 1), blockshape=(3, 1))
+
+    assert eq(x.squeeze(), x.compute().squeeze())
+
+    assert x.squeeze().blockdims == ((3, 3, 3, 1),)

--- a/dask/array/tests/test_learn.py
+++ b/dask/array/tests/test_learn.py
@@ -1,0 +1,38 @@
+from sklearn.linear_model import SGDClassifier
+import dask.array as da
+import numpy as np
+import dask
+
+
+x = np.array([[1, 0],
+              [2, 0],
+              [3, 0],
+              [4, 0],
+              [0, 1],
+              [0, 2],
+              [3, 3],
+              [4, 4]])
+
+y = np.array([1, 1, 1, 1, -1, -1, 0, 0])
+
+z = np.array([[1, -1],
+              [-1, 1],
+              [10, -10],
+              [-10, 10]])
+
+X = da.from_array(x, blockshape=(3, 2))
+Y = da.from_array(y, blockshape=(3,))
+Z = da.from_array(z, blockshape=(2, 2))
+
+def test_fit():
+    sgd = SGDClassifier()
+
+    sgd = da.learn.fit(sgd, X, Y, get=dask.get, classes=[-1, 1])
+
+    result = sgd.predict(z)
+    assert result.tolist() == [1, -1, 1, -1]
+
+    result = da.learn.predict(sgd, Z)
+    assert result.blockdims == ((2, 2),)
+    assert result.compute(get=dask.get).tolist() == [1, -1, 1, -1]
+


### PR DESCRIPTION
This builds on work by @PeterDSteinberg .  It leverages the `partial_fit` method of various sklearn classes, pushing blocks of dask arrays through this method sequentially.  This should allow large dask arrays to leverage a decent subset of scikit-learn relatively smoothly.

Example
-------

```python
>>> import dask.array as da
>>> X = da.random.random((10, 3), blockshape=(5, 3))   # very small (but potentially big!) data
>>> y = da.random.random(10, blockshape=(5,))

>>> from sklearn.linear_model import SGDClassifier  # some possibly online classifier
>>> sgd = SGDClassifier()

>>> da.learn.fit(sgd, X, y, classes=[1, 0])    # fit!
SGDClassifier(alpha=0.0001, class_weight=None, epsilon=0.1, eta0=0.0,
       fit_intercept=True, l1_ratio=0.15, learning_rate='optimal',
       loss='hinge', n_iter=5, n_jobs=1, penalty='l2', power_t=0.5,
       random_state=None, shuffle=False, verbose=0, warm_start=False)
```

This passes all of X and y through the classifier sequentially.  We can use the classifier as normal on in-memory data, consuming and producing numpy arrays.

```python
>>> import numpy as np
>>> sgd.predict(np.random.random((4, 3)))  # doctest: +SKIP
array([1, 0, 0, 1])
```

Or predict on a larger dataset, consuming and producing dask arrays.

```python
>>> z = da.random.random((400, 3), blockshape=(100, 3))
>>> da.learn.predict(sgd, z)  # doctest: +SKIP
dask.array<x_11, shape=(400,), blockdims=((100, 100, 100, 100),), dtype=int64>
```

I haven't actually used this code on anything non-trivial so I probably have some large conceptual gaps.  Feedback welcome.