### PR TITLE
from_array wraps getitems with calls to np.asarray

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -34,9 +34,10 @@ def getarray(a, b):
     array([1, 2, 3])
     """
     c = a[b]
-    if not isinstance(c, np.ndarray):
+    if type(c) != np.ndarray:
         c = np.asarray(c)
     return c
+
 
 from .optimization import optimize
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -31,16 +31,16 @@ def getem(arr, blockdims=None, blockshape=None, shape=None):
     """ Dask getting various chunks from an array-like
 
     >>> getem('X', blockshape=(2, 3), shape=(4, 6))  # doctest: +SKIP
-    {('X', 0, 0): (getitem, 'X', (slice(0, 2), slice(0, 3))),
-     ('X', 1, 0): (getitem, 'X', (slice(2, 4), slice(0, 3))),
-     ('X', 1, 1): (getitem, 'X', (slice(2, 4), slice(3, 6))),
-     ('X', 0, 1): (getitem, 'X', (slice(0, 2), slice(3, 6)))}
+    {('X', 0, 0): (np.asarray, (getitem, 'X', (slice(0, 2), slice(0, 3)))),
+     ('X', 1, 0): (np.asarray, (getitem, 'X', (slice(2, 4), slice(0, 3)))),
+     ('X', 1, 1): (np.asarray, (getitem, 'X', (slice(2, 4), slice(3, 6)))),
+     ('X', 0, 1): (np.asarray, (getitem, 'X', (slice(0, 2), slice(3, 6))))}
 
     >>> getem('X', blockdims=((2, 2), (3, 3)))  # doctest: +SKIP
-    {('X', 0, 0): (getitem, 'X', (slice(0, 2), slice(0, 3))),
-     ('X', 1, 0): (getitem, 'X', (slice(2, 4), slice(0, 3))),
-     ('X', 1, 1): (getitem, 'X', (slice(2, 4), slice(3, 6))),
-     ('X', 0, 1): (getitem, 'X', (slice(0, 2), slice(3, 6)))}
+    {('X', 0, 0): (np.asarray, (getitem, 'X', (slice(0, 2), slice(0, 3)))),
+     ('X', 1, 0): (np.asarray, (getitem, 'X', (slice(2, 4), slice(0, 3)))),
+     ('X', 1, 1): (np.asarray, (getitem, 'X', (slice(2, 4), slice(3, 6)))),
+     ('X', 0, 1): (np.asarray, (getitem, 'X', (slice(0, 2), slice(3, 6))))}
     """
     if not blockdims:
         blockdims = blockdims_from_blockshape(shape, blockshape)
@@ -51,8 +51,8 @@ def getem(arr, blockdims=None, blockshape=None, shape=None):
     shapes = product(*blockdims)
     starts = product(*cumdims)
 
-    values = ((getitem, arr) + (tuple(slice(s, s+dim)
-                                 for s, dim in zip(start, shape)),)
+    values = ((np.asarray, (getitem, arr) + (tuple(slice(s, s+dim)
+                                 for s, dim in zip(start, shape)),))
                 for start, shape in zip(starts, shapes))
 
     return dict(zip(keys, values))

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -31,7 +31,7 @@ def getarray(a, b):
     """ Mimics getitem but includes call to np.asarray
 
     >>> getarray([1, 2, 3, 4, 5], slice(1, 4))
-    array([1, 2, 3])
+    array([2, 3, 4])
     """
     c = a[b]
     if type(c) != np.ndarray:

--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -37,7 +37,7 @@ def is_full_slice(task):
     False
     """
     return (isinstance(task, tuple) and
-            (task[0] == getitem or task[0] == getarray) and
+            (task[0] in (getitem, getarray) and
             (task[2] == slice(None, None, None) or
              isinstance(task[2], tuple) and
              all(ind == slice(None, None, None) for ind in task[2])))
@@ -86,6 +86,9 @@ def fuse_slice_dict(match):
 
 rewrite_rules = RuleSet(
         RewriteRule((getitem, (getitem, x, a), b),
+                    fuse_slice_dict,
+                    (a, b, x)),
+        RewriteRule((getarray, (getitem, x, a), b),
                     fuse_slice_dict,
                     (a, b, x)),
         RewriteRule((getarray, (getarray, x, a), b),

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -860,3 +860,7 @@ def test_slicing_with_non_ndarrays():
     x = da.from_array(ARangeSlicable(10), blockshape=(4,))
 
     assert eq((x + 1).sum(), (np.arange(10) + 1).sum())
+
+
+def test_getarray():
+    assert type(getarray(np.matrix([[1]]), 0)) == np.ndarray

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -13,10 +13,10 @@ inc = lambda x: x + 1
 
 def test_getem():
     assert getem('X', blockshape=(2, 3), shape=(4, 6)) == \
-    {('X', 0, 0): (np.asarray, (getitem, 'X', (slice(0, 2), slice(0, 3)))),
-     ('X', 1, 0): (np.asarray, (getitem, 'X', (slice(2, 4), slice(0, 3)))),
-     ('X', 1, 1): (np.asarray, (getitem, 'X', (slice(2, 4), slice(3, 6)))),
-     ('X', 0, 1): (np.asarray, (getitem, 'X', (slice(0, 2), slice(3, 6))))}
+    {('X', 0, 0): (getarray, 'X', (slice(0, 2), slice(0, 3))),
+     ('X', 1, 0): (getarray, 'X', (slice(2, 4), slice(0, 3))),
+     ('X', 1, 1): (getarray, 'X', (slice(2, 4), slice(3, 6))),
+     ('X', 0, 1): (getarray, 'X', (slice(0, 2), slice(3, 6)))}
 
 
 def test_top():
@@ -209,25 +209,25 @@ def test_stack():
 
     assert s.shape == (3, 4, 6)
     assert s.blockdims == ((1, 1, 1), (2, 2), (3, 3))
-    assert s.dask[(s.name, 0, 1, 0)] == (getitem, ('A', 1, 0),
+    assert s.dask[(s.name, 0, 1, 0)] == (getarray, ('A', 1, 0),
                                           (None, colon, colon))
-    assert s.dask[(s.name, 2, 1, 0)] == (getitem, ('C', 1, 0),
+    assert s.dask[(s.name, 2, 1, 0)] == (getarray, ('C', 1, 0),
                                           (None, colon, colon))
 
     s2 = stack([a, b, c], axis=1)
     assert s2.shape == (4, 3, 6)
     assert s2.blockdims == ((2, 2), (1, 1, 1), (3, 3))
-    assert s2.dask[(s2.name, 0, 1, 0)] == (getitem, ('B', 0, 0),
+    assert s2.dask[(s2.name, 0, 1, 0)] == (getarray, ('B', 0, 0),
                                             (colon, None, colon))
-    assert s2.dask[(s2.name, 1, 1, 0)] == (getitem, ('B', 1, 0),
+    assert s2.dask[(s2.name, 1, 1, 0)] == (getarray, ('B', 1, 0),
                                             (colon, None, colon))
 
     s2 = stack([a, b, c], axis=2)
     assert s2.shape == (4, 6, 3)
     assert s2.blockdims == ((2, 2), (3, 3), (1, 1, 1))
-    assert s2.dask[(s2.name, 0, 1, 0)] == (getitem, ('A', 0, 1),
+    assert s2.dask[(s2.name, 0, 1, 0)] == (getarray, ('A', 0, 1),
                                             (colon, colon, None))
-    assert s2.dask[(s2.name, 1, 1, 2)] == (getitem, ('C', 1, 1),
+    assert s2.dask[(s2.name, 1, 1, 2)] == (getarray, ('C', 1, 1),
                                             (colon, colon, None))
 
     assert raises(ValueError, lambda: stack([a, b, c], axis=3))

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -37,7 +37,7 @@ def test_fuse_getitem():
 
              ((getitem, (getitem, 'x', (slice(1000, 2000),)),
                         (slice(5, 10), slice(10, 20))),
-              (getarray, 'x', (slice(1005, 1010), slice(10, 20))))
+              (getitem, 'x', (slice(1005, 1010), slice(10, 20))))
 
         ]
 


### PR DESCRIPTION
Fixes #139
Fixes #105

We coerce slices of inputs array-like objects to numpy arrays if
they weren't already.

cc @shoyer