### PR TITLE
Slicing with sorted lists maintains block structure

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -408,7 +408,10 @@ def take_sorted(outname, inname, blockdims, index, axis=0):
 
     where the index, ``[1, 3, 5, 10]`` is sorted in non-decreasing order.
 
-    >>> take('y', 'x', [(20, 20, 20, 20)], [1, 3, 5, 47], axis=0)  # doctest: +SKIP
+    >>> blockdims, dsk = take('y', 'x', [(20, 20, 20, 20)], [1, 3, 5, 47], axis=0)
+    >>> blockdims
+    ((3, 1),)
+    >>> dsk  # doctest: +SKIP
     {('y', 0): (getitem, ('x', 0), ([1, 3, 5],)),
      ('y', 1): (getitem, ('x', 2), ([7],))}
 
@@ -449,7 +452,10 @@ def take(outname, inname, blockdims, index, axis=0):
 
     Mimics ``np.take``
 
-    >>> take('y', 'x', [(20, 20, 20, 20)], [5, 1, 47, 3], axis=0)  # doctest: +SKIP
+    >>> blockdims, dsk = take('y', 'x', [(20, 20, 20, 20)], [5, 1, 47, 3], axis=0)
+    >>> blockdims
+    ((4,),)
+    >>> dsk  # doctest: +SKIP
     {('y', 0): (getitem, (np.concatenate, [(getitem, ('x', 0), ([1, 3, 5],)),
                                            (getitem, ('x', 2), ([7],))],
                                           0),
@@ -457,7 +463,10 @@ def take(outname, inname, blockdims, index, axis=0):
 
     When list is sorted we retain original block structure
 
-    >>> take('y', 'x', [(20, 20, 20, 20)], [1, 3, 5, 47], axis=0)  # doctest: +SKIP
+    >>> blockdims, dsk = take('y', 'x', [(20, 20, 20, 20)], [1, 3, 5, 47], axis=0)
+    >>> blockdims
+    ((3, 1),)
+    >>> dsk  # doctest: +SKIP
     {('y', 0): (getitem, ('x', 0), ([1, 3, 5],)),
      ('y', 2): (getitem, ('x', 2), ([7],))}
     """


### PR DESCRIPTION
Previously indexing with a list would form one large block.  Out of
order elements in the list were handled by concatenating many block
slices together, then indexing again.

Now, if that list is sorted, we can index per block without shuffling
data around.  This stops giant-blocks from occurring and should improve
memory performance.

Example
-------

    In [1]: import dask.array as da
    In [2]: x = da.ones(10, blockshape=(5,))

Unordered case, slice, concatenate, slice

    In [3]: x[[1, 9, 2, 8]].dask
    Out[3]:
    {('wrapped_1', 0): (<function numpy.core.numeric.ones>, (5,)),
     ('wrapped_1', 1): (<function numpy.core.numeric.ones>, (5,)),
     ('x_1', 0): (<function operator.getitem>,
      (<function numpy.core.multiarray.concatenate>,
       (list,
        [(<function operator.getitem>, ('wrapped_1', 0), ([1, 2],)),
         (<function operator.getitem>, ('wrapped_1', 1), ([3, 4],))]),
        0),
      ([0, 3, 1, 2],))}

Ordered case, just straight slicing

    In [4]: x[[1, 2, 8, 9]].dask
    Out[4]:
    {('wrapped_1', 0): (<function numpy.core.numeric.ones>, (5,)),
     ('wrapped_1', 1): (<function numpy.core.numeric.ones>, (5,)),
     ('x_2', 0): (<function operator.getitem>, ('wrapped_1', 0), ([1, 2],)),
     ('x_2', 1): (<function operator.getitem>, ('wrapped_1', 1), ([3, 4],))}

Fixes #137