### PR TITLE
da.store uses duck typing and no longer has a return value

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -477,25 +477,21 @@ def store(sources, targets, **kwargs):
 
     >>> store([x, y, z], [dset1, dset2, dset3])  # doctest: +SKIP
     """
-    single_output = True
-    if not isinstance(sources, (list, tuple)):
+    if isinstance(sources, Array):
         sources = [sources]
-    if not isinstance(targets, (list, tuple)):
         targets = [targets]
-        single_output = False
+
+    if any(not isinstance(s, Array) for s in sources):
+        raise ValueError("All sources must be dask array objects")
 
     if len(sources) != len(targets):
         raise ValueError("Different number of sources [%d] and targets [%d]"
-                        % (len(sources), len(targets)))
+                         % (len(sources), len(targets)))
 
     updates = [insert_to_ooc(tgt, src) for tgt, src in zip(targets, sources)]
     dsk = merge([src.dask for src in sources] + updates)
     keys = [key for u in updates for key in u]
     get(dsk, keys, **kwargs)
-
-    if single_output:
-        targets = targets[0]
-    return targets
 
 
 def blockdims_from_blockshape(shape, blockshape):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -599,6 +599,8 @@ def test_store():
     assert (bt == 3).all()
 
     assert raises(ValueError, lambda: store([a], [at, bt]))
+    assert raises(ValueError, lambda: store(at, at))
+    assert raises(ValueError, lambda: store([at, bt], [at, bt]))
 
 
 def test_np_array_with_zero_dimensions():


### PR DESCRIPTION
It's not very friendly (or expected) to use isinstance checks for list/tuple
in a function that claims it supports sequences.

I also didn't see a point to giving this function a return value when it
explicitly modifies the data in-place. Note also that I'm pretty sure the
`single_output` logic was broken in the existing function.