### PR TITLE
da.compute always returns a tuple, never a single array

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -577,6 +577,9 @@ def test_compute():
     assert eq(A, d + 1)
     assert eq(B, d + 2)
 
+    A, = compute(a)
+    assert eq(A, d + 1)
+
 
 def test_coerce():
     d = da.from_array(np.array([1]), blockshape=(1,))


### PR DESCRIPTION
The current implementation of the compute function has an unpredictable
signature when provided with a programmatically determined sequence of arrays.
For example, `da.compute(*my_arrays)` returns a list of numpy arrays, except
when `my_arrays` has length one, in which case it returns a single array.

This sort of thing not only leads to all sorts of bugs, but also meant that
there was no way to reliable compute multiple dask arrays at once short of
using isinstance checks.

I considered trying to do something clever, like using `da.compute(my_arrays)`
(no `*`) as an indication that the result should always be returned a sequence,
and while that arguably makes the final API nice to use (nobody ever has to
type `*`!) it's not really worth the added complexity.

This solution is simpler: `da.compute` always returns a tuple of numpy arrays.
To return a single array, use `my_array.compute()`.