### PR TITLE
failing test case for repeated insertion

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -465,6 +465,11 @@ def test_insert():
     assert raises(IndexError, lambda: insert(a, [3], -1, axis=2))
     assert raises(IndexError, lambda: insert(a, [3], -1, axis=-3))
 
+    z = np.random.randint(10, size=(1, 2))
+    c = from_array(z, chunks=(1, 2))
+    assert eq(np.insert(np.insert(z, [0, 1], -1, axis=0), [1], -1, axis=1),
+              insert(insert(c, [0, 1], -1, axis=0), [1], -1, axis=1))
+
 
 def test_broadcast_to():
     x = np.random.randint(10, size=(5, 1, 6))


### PR DESCRIPTION
Just stumbled upon this with the xray test suite -- it's almost certainly related to the last round of slicing fixes.