### PR TITLE
Repeated insert

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1496,8 +1496,9 @@ def insert(arr, obj, values, axis):
     values_breaks = np.cumsum(counts[counts > 0])
     split_values = split_at_breaks(values, values_breaks, axis)
 
-    interleaved = interleave([split_arr, split_values])
-    return concatenate(list(interleaved), axis=axis)
+    interleaved = list(interleave([split_arr, split_values]))
+    interleaved = [i for i in interleaved if i.nbytes]
+    return concatenate(interleaved, axis=axis)
 
 
 @wraps(chunk.broadcast_to)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -560,7 +560,7 @@ class Array(object):
         self.dask = dask
         self.name = name
         self.chunks = normalize_chunks(chunks, shape)
-        if isinstance(dtype, (str, list)):
+        if dtype is not None:
             dtype = np.dtype(dtype)
         self._dtype = dtype
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -465,6 +465,8 @@ def test_insert():
     assert raises(IndexError, lambda: insert(a, [3], -1, axis=2))
     assert raises(IndexError, lambda: insert(a, [3], -1, axis=-3))
 
+
+def test_multi_insert():
     z = np.random.randint(10, size=(1, 2))
     c = from_array(z, chunks=(1, 2))
     assert eq(np.insert(np.insert(z, [0, 1], -1, axis=0), [1], -1, axis=1),

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -894,3 +894,8 @@ def test_size():
 def test_nbytes():
     x = da.ones((10, 2), chunks=(3, 1))
     assert x.nbytes == np.array(x).nbytes
+
+
+def test_Array_normalizes_dtype():
+    x = da.ones((3,), chunks=(1,), dtype=int)
+    assert isinstance(x.dtype, np.dtype)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -465,6 +465,11 @@ def test_insert():
     assert raises(IndexError, lambda: insert(a, [3], -1, axis=2))
     assert raises(IndexError, lambda: insert(a, [3], -1, axis=-3))
 
+    z = np.random.randint(10, size=(1, 2))
+    c = from_array(z, chunks=(1, 2))
+    assert eq(np.insert(np.insert(z, [0, 1], -1, axis=0), [1], -1, axis=1),
+              insert(insert(c, [0, 1], -1, axis=0), [1], -1, axis=1))
+
 
 def test_broadcast_to():
     x = np.random.randint(10, size=(5, 1, 6))


### PR DESCRIPTION
Fixes #165 

I haven't decided yet if I want to normalize out zero-sized chunks from all dask.arrays.  This feels a bit aggressive.  I can't think of a case where someone would want these chunks, but still, if someone gives them explicitly it seems odd to remove them.  Instead I've corrected the `insert` function to not make zero-sized chunks.