### PR TITLE
Use temporary files for testing.

### DIFF
--- a/pbag/tests/test_serialize.py
+++ b/pbag/tests/test_serialize.py
@@ -1,3 +1,4 @@
+from tempfile import TemporaryFile
 from pbag.serialize import dump, load
 
 
@@ -5,22 +6,22 @@ data = [b'Hello\n', 1, b'world!', None]
 
 
 def test_core():
-    with open('_foo.pack', 'wb') as f:
+    with TemporaryFile(mode='wb+') as f:
         dump(data, f)
-
-    with open('_foo.pack', 'rb') as f:
+        f.seek(0)
         data2 = load(f)
 
     assert data == data2
 
 
 def test_multiple_dumps():
-    with open('_foo.pack', 'wb') as f:
+    with TemporaryFile(mode='wb+') as f:
         dump(1, f)
         dump(data, f)
         dump(2, f)
 
-    with open('_foo.pack', 'rb') as f:
+        f.seek(0)
+
         a = load(f)
         b = load(f)
         c = load(f)


### PR DESCRIPTION
I noticed some `_foo.pak` files appearing in my dask directory from tests. This uses a ephemeral file for testing so we don't leave extraneous files on user's machines.