### PR TITLE
WIP Add dask array image module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - conda install pytest numpy pip coverage toolz pandas cython scikit-learn cytoolz dill networkx
+  - conda install pytest numpy pip coverage toolz pandas cython scikit-learn cytoolz dill networkx scipy
   - pip install chest
   - pip install git+https://github.com/blosc/bcolz --upgrade
 

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -19,7 +19,7 @@ from .reductions import (sum, prod, mean, std, var, any, all, min, max, vnorm,
 from .percentile import percentile
 with ignoring(ImportError):
     from .reductions import nanprod
-from . import random, linalg, ghost, learn
+from . import random, linalg, ghost, learn, image
 from .wrap import ones, zeros, empty, full
 from .rechunk import rechunk
 from ..context import set_options

--- a/dask/array/ghost.py
+++ b/dask/array/ghost.py
@@ -167,7 +167,10 @@ def reflect(x, axis, depth):
 
     This is the converse of ``periodic``
     """
-    if depth == 1:
+    if depth == 0:
+        return x
+
+    elif depth == 1:
         left =  ((slice(None, None, None),) * axis
                + (slice(0, 1),)
                + (slice(None, None, None),) * (x.ndim - axis - 1))

--- a/dask/array/image.py
+++ b/dask/array/image.py
@@ -1,0 +1,75 @@
+"""
+A thin wrapper for scipy.ndimage.filters
+"""
+
+def _make_ghost_arr(filt, arr, filter_kwargs):
+
+    def boundary(filter_kwargs):
+        """
+        Create a value for the dask.array.ghost.ghost boundary kwarg from the
+        arguments to the ndimage filter.
+        """
+
+        # every (3) ndimage filte I looked at had reflect as the
+        # default mode. So they all are hopefully like that.
+
+        # ndimage ignores the `cval` when it is set but `mode` not set or
+        # is not `constant`. We mimic this.
+
+        # get the info
+        mode = filter_kwargs.get('mode', 'reflect')
+
+        # for reference:
+        # ours = ['periodic', 'reflect', any-constant]
+        # theirs = ['nearest', 'wrap', 'reflect', 'constant']
+        # translate to our kwargs
+        if mode == 'reflect':
+            return {i : 'reflect' for i in range(arr.ndim)}
+        elif mode == 'constant':
+            cval = filter_kwargs.get('cval', 0.0)
+            return {i : cval for i in range(arr.ndim)}
+        else:
+            raise ValueError("mode argument % not supported, only 'reflect'"
+                             " and 'constant' supported.")
+
+    def depth(filt, filter_kwargs):
+        """
+        create the value for the `depth` kwarg. This should be
+        len(ciel(shape[axis_length]/2.)) for each axis.
+        """
+        pass
+
+
+# filt is a ndimage filter (note filter is a python name)
+def filter_(filt, arr, **filter_kwargs):
+    """Apply a scipy ndimage filter to a dask array
+
+    Parameters
+    ----------
+    filter : scipy.ndimage.filters filter
+    darr : das Array
+        Two dimensional array
+    kwargs :
+        Options to pass to the filter
+    
+    Example
+    -------
+
+    >>> import dask.array as da
+    >>> x = da.random.random((10, 10), chunks=(5, 2))
+
+    >>> from scipy.ndimage.filters import gaussian_filter
+    
+    >>> da.image.filter_(gaussian_filter, x, sigma=1)
+    dask.array<x_??, shape=(10, 10), chunks=((???)), dtype=float64>
+    """
+
+    """
+    TODO
+    inspect the footprint of the filter to determine how much ghosting we need.
+    """
+
+    def wrapped_func(block):
+        return filt(block, **filter_kwargs)
+
+    return arr.map_blocks(wrapped_func)

--- a/dask/array/image.py
+++ b/dask/array/image.py
@@ -26,10 +26,10 @@ def _make_ghost_arr(filt, arr, filter_kwargs):
         # theirs = ['nearest', 'wrap', 'reflect', 'constant']
         # translate to our kwargs
         if mode == 'reflect':
-            return {i : 'reflect' for i in range(arr.ndim)}
+            return dict(i : 'reflect' for i in range(arr.ndim))
         elif mode == 'constant':
             cval = filter_kwargs.get('cval', 0.0)
-            return {i : cval for i in range(arr.ndim)}
+            return dict(i : cval for i in range(arr.ndim))
         else:
             raise ValueError("mode argument % not supported, only 'reflect'"
                              " and 'constant' supported.")
@@ -46,9 +46,10 @@ def _make_ghost_arr(filt, arr, filter_kwargs):
         sigma = filter_kwargs['sigma']
         truncate = filter_kwargs.get('truncate', 4.0)
         depth = int(truncate * float(sigma) + 0.5) + 1
-        return {i : depth for i in range(arr.ndim)}
+        return  dict(i : depth for i in range(arr.ndim))
 
-    return {'depth' : depth(filt, filter_kwargs), 'boundary' : boundary(filter_kwargs)}
+    return {'depth' : depth(filt, filter_kwargs),
+            'boundary' : boundary(filter_kwargs)}
 
 
 # filt is a ndimage filter (note filter is a python name)

--- a/dask/array/tests/test_image.py
+++ b/dask/array/tests/test_image.py
@@ -7,16 +7,42 @@ import dask.array as da
 
 filters = pytest.importorskip('scipy.ndimage.filters')
 
-from scipy.ndimage.filters import (gaussian_filter, gaussian_filter1d)
+from scipy.ndimage.filters import (gaussian_filter, gaussian_filter1d,
+                                   correlate1d, convolve1d)
 
-def test_filters():
-    # make data
-    a = np.random.random((20, 20))
-    d = da.from_array(a, chunks=(10, 10))
 
+# make data
+a = np.random.random((20, 20))
+d = da.from_array(a, chunks=(10, 10))
+
+
+def test_gaussian_filter():
     # apply filter
     sigma = 1
     res = da.image.filter_(gaussian_filter, d, sigma=sigma)
     exp = gaussian_filter(a, sigma=sigma)
+
+    assert_array_almost_equal(np.array(res), exp)
+
+
+def test_gaussian_filter1d():
+    # apply filter
+    sigma = 1
+    res = da.image.filter_(gaussian_filter1d, d, sigma=sigma)
+    exp = gaussian_filter1d(a, sigma=sigma)
+
+    assert_array_almost_equal(np.array(res), exp)
+
+def test_correlate1d():
+    weights = list(range(5))
+    res = da.image.filter_(correlate1d, d, weights=weights)
+    exp = correlate1d(a, weights=weights)
+
+    assert_array_almost_equal(np.array(res), exp)
+
+def test_convolve1d():
+    weights = list(range(5))
+    res = da.image.filter_(convolve1d, d, weights=weights)
+    exp = convolve1d(a, weights=weights)
 
     assert_array_almost_equal(np.array(res), exp)

--- a/dask/array/tests/test_image.py
+++ b/dask/array/tests/test_image.py
@@ -4,7 +4,6 @@ from numpy.testing import assert_array_almost_equal
 import pytest
 
 import dask.array as da
-from dask.array.image import filter_
 
 filters = pytest.importorskip('scipy.ndimage.filters')
 
@@ -12,12 +11,12 @@ from scipy.ndimage.filters import (gaussian_filter)
 
 def test_filters():
     # make data
-    a = np.random.random((10, 10))
-    d = da.from_array(a, chunks=(2, 5))
+    a = np.random.random((50, 50))
+    d = da.from_array(a, chunks=(10, 20))
 
     # apply filter
     sigma = 2
-    res = filter_(gaussian_filter, d, sigma=sigma)
+    res = da.image.filter_(gaussian_filter, d, sigma=sigma)
     exp = gaussian_filter(a, sigma=sigma)
 
     assert_array_almost_equal(np.array(res), exp)

--- a/dask/array/tests/test_image.py
+++ b/dask/array/tests/test_image.py
@@ -1,0 +1,23 @@
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+
+import pytest
+
+import dask.array as da
+from dask.array.image import filter_
+
+filters = pytest.importorskip('scipy.ndimage.filters')
+
+from scipy.ndimage.filters import (gaussian_filter)
+
+def test_filters():
+    # make data
+    a = np.random.random((10, 10))
+    d = da.from_array(a, chunks=(2, 5))
+
+    # apply filter
+    sigma = 2
+    res = filter_(gaussian_filter, d, sigma=sigma)
+    exp = gaussian_filter(a, sigma=sigma)
+
+    assert_array_almost_equal(np.array(res), exp)

--- a/dask/array/tests/test_image.py
+++ b/dask/array/tests/test_image.py
@@ -7,15 +7,15 @@ import dask.array as da
 
 filters = pytest.importorskip('scipy.ndimage.filters')
 
-from scipy.ndimage.filters import (gaussian_filter)
+from scipy.ndimage.filters import (gaussian_filter, gaussian_filter1d)
 
 def test_filters():
     # make data
-    a = np.random.random((50, 50))
-    d = da.from_array(a, chunks=(10, 20))
+    a = np.random.random((20, 20))
+    d = da.from_array(a, chunks=(10, 10))
 
     # apply filter
-    sigma = 2
+    sigma = 1
     res = da.image.filter_(gaussian_filter, d, sigma=sigma)
     exp = gaussian_filter(a, sigma=sigma)
 

--- a/dask/array/tests/test_learn.py
+++ b/dask/array/tests/test_learn.py
@@ -1,7 +1,11 @@
-from sklearn.linear_model import SGDClassifier
-import dask.array as da
 import numpy as np
+
+import pytest
+sklearn = pytest.importorskip('sklearn')
+from sklearn.linear_model import SGDClassifier
+
 import dask
+import dask.array as da
 
 
 x = np.array([[1, 0],


### PR DESCRIPTION
This is an effort to wrap `scipy.ndimage.filters`. The current API is like:
```python
dask.array.image.filter_(ndimage_filter, daskarray, **filter_kwargs)
```

- [ ] convolve
- [x] convolve1d
- [ ] correlate
- [x] correlate1d
- [x] gaussian_filter
- [ ] gaussian_filter1d
- [ ] gaussian_gradient_magnitude
- [ ] gaussian_laplace
- [ ] generic_filter
- [ ] generic_filter1d
- [ ] generic_gradient_magnitude
- [ ] generic_laplace
- [ ] laplace
- [ ] maximum_filter
- [ ] maximum_filter1d
- [ ] median_filter
- [ ] minimum_filter
- [ ] minimum_filter1d
- [ ] percentile_filter
- [ ] prewitt
- [ ] rank_filter
- [ ] sobel
- [ ] uniform_filter
- [ ] uniform_filter1d