### PR TITLE
Add "nearest" kwarg to ghost boundary

### DIFF
--- a/dask/array/ghost.py
+++ b/dask/array/ghost.py
@@ -140,8 +140,15 @@ def trim_internal(x, axes=None):
         chunk.trim
         map_blocks
     """
-    chunks = tuple([tuple([d - axes.get(i, 0)*2 for d in bd])
-                       for i, bd in enumerate(x.chunks)])
+    olist = []
+    for i, bd in enumerate(x.chunks):
+        ilist = []
+        for d in bd:
+            ilist.append(d - axes.get(i, 0) * 2)
+        olist.append(tuple(ilist))
+
+    chunks = tuple(olist)
+
     return map_blocks(x, partial(chunk.trim, axes=axes), chunks=chunks)
 
 

--- a/dask/array/ghost.py
+++ b/dask/array/ghost.py
@@ -183,6 +183,24 @@ def reflect(x, axis, depth):
 
     return concatenate([l, x, r], axis=axis)
 
+def nearest(x, axis, depth):
+    """ Each reflect each boundary value outwards
+
+    This mimics what the skimage.filters.gaussian_filter(... mode="nearest")
+    does.
+    """
+    left =  ((slice(None, None, None),) * axis
+           + (slice(0, 1),)
+           + (slice(None, None, None),) * (x.ndim - axis - 1))
+    right = ((slice(None, None, None),) * axis
+           + (slice(-1, -2, -1),)
+           + (slice(None, None, None),) * (x.ndim - axis - 1))
+    l = [x[left]] * depth
+    r = [x[right]] * depth
+
+    return concatenate(l + [x] + r, axis=axis)
+
+
 
 def constant(x, axis, depth, value):
     """ Add constant slice to either side of array """
@@ -214,6 +232,8 @@ def boundaries(x, depth=None, kind=None):
             x = periodic(x, i, depth[i])
         elif kind.get(i) == 'reflect':
             x = reflect(x, i, depth[i])
+        elif kind.get(i) == 'nearest':
+            x = nearest(x, i, depth[i])
         elif i in kind:
             x = constant(x, i, depth[i], kind[i])
 

--- a/dask/array/tests/test_ghost.py
+++ b/dask/array/tests/test_ghost.py
@@ -1,7 +1,9 @@
 import dask.array as da
 import numpy as np
 import dask
-from dask.array.ghost import *
+from dask.array.ghost import (Array, fractional_slice, getitem, trim_internal,
+                              ghost_internal, nearest, constant, boundaries,
+                              reflect, periodic, ghost)
 from dask.core import get
 
 

--- a/dask/array/tests/test_ghost.py
+++ b/dask/array/tests/test_ghost.py
@@ -85,6 +85,19 @@ def test_reflect():
     assert eq(e, expected)
 
 
+def test_nearest():
+    x = np.arange(10)
+    d = da.from_array(x, chunks=(5, 5))
+
+    e = nearest(d, axis=0, depth=2)
+    expected = np.array([0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 9])
+    assert eq(e, expected)
+
+    e = nearest(d, axis=0, depth=1)
+    expected = np.array([0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9])
+    assert eq(e, expected)
+
+
 def test_constant():
     x = np.arange(64).reshape((8, 8))
     d = da.from_array(x, chunks=(4, 4))


### PR DESCRIPTION
This adds a "nearest" as a boundary mode for ghosting. This is needed for compatibility with skimage.

