### PR TITLE
From_array includes lock kwarg

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -940,3 +940,11 @@ def test_from_array_with_lock():
 
     assert isinstance(tasks[0][3], thread.LockType)
     assert len(set(task[3] for task in tasks)) == 1
+
+    assert eq(d, x)
+
+    lock = Lock()
+    e = da.from_array(x, chunks=5, lock=lock)
+    f = da.from_array(x, chunks=5, lock=lock)
+
+    assert eq(e + f, x + x)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -929,3 +929,14 @@ def test_args():
     x = da.ones((10, 2), chunks=(3, 1), dtype='i4') + 1
     y = Array(*x._args)
     assert eq(x, y)
+
+
+def test_from_array_with_lock():
+    import thread
+    x = np.arange(10)
+    d = da.from_array(x, chunks=5, lock=True)
+
+    tasks = [v for k, v in d.dask.items() if k[0] == d.name]
+
+    assert isinstance(tasks[0][3], thread.LockType)
+    assert len(set(task[3] for task in tasks)) == 1

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -932,13 +932,12 @@ def test_args():
 
 
 def test_from_array_with_lock():
-    import thread
     x = np.arange(10)
     d = da.from_array(x, chunks=5, lock=True)
 
     tasks = [v for k, v in d.dask.items() if k[0] == d.name]
 
-    assert isinstance(tasks[0][3], thread.LockType)
+    assert isinstance(tasks[0][3], type(Lock()))
     assert len(set(task[3] for task in tasks)) == 1
 
     assert eq(d, x)


### PR DESCRIPTION
This allows getarray calls to coordinate around a lock if necessary
when the underlying data store does not support concurrent reads.

Usage

    >>> a = da.from_array(x, chunks=(1000, 1000), lock=True)

or coordinate between arrays

    >>> lock = threading.Lock()
    >>> a = da.from_array(x, chunks=(1000, 1000), lock=lock)
    >>> b = da.from_array(y, chunks=(1000, 1000), lock=lock)

cc @kastnerkyle  https://twitter.com/kastnerkyle/status/593835454581108736