### PR TITLE
Support empty dict in rechunk function

### DIFF
--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -11,7 +11,8 @@ from itertools import count, product, chain
 from operator import getitem, add
 import numpy as np
 from toolz import merge, accumulate
-from dask.array.core import rec_concatenate, Array, normalize_chunks
+
+from .core import rec_concatenate, Array, normalize_chunks
 
 
 rechunk_names  = ('rechunk-%d' % i for i in count(1))
@@ -191,11 +192,13 @@ def rechunk(x, chunks):
     chunks:  the new block dimensions to create
     """
     if isinstance(chunks, dict):
-        if isinstance(next(iter(chunks.values())), int):
+        if not chunks or isinstance(next(iter(chunks.values())), int):
             chunks = blockshape_dict_to_tuple(x.chunks, chunks)
         else:
             chunks = blockdims_dict_to_tuple(x.chunks, chunks)
     chunks = normalize_chunks(chunks, x.shape)
+    if not len(chunks) == x.ndim or tuple(map(sum, chunks)) != x.shape:
+        raise ValueError("Provided chunks are not consistent with shape")
 
     crossed = intersect_chunks(x.chunks, chunks)
     x2 = dict()

--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -3,6 +3,7 @@ import numpy as np
 from dask.array.rechunk import intersect_chunks, rechunk, normalize_chunks
 from dask.array.rechunk import cumdims_label, _breakpoints, _intersect_1d
 import dask.array as da
+from dask.utils import raises
 
 
 def test_rechunk_internals_1():
@@ -154,3 +155,9 @@ def test_rechunk_with_dict():
     x = da.ones((24, 24), chunks=(4, 8))
     y = x.rechunk(chunks={0: (12, 12)})
     assert y.chunks == ((12, 12), (8, 8, 8))
+
+
+def test_rechunk_with_empty_input():
+    x = da.ones((24, 24), chunks=(4, 8))
+    assert x.rechunk(chunks={}).chunks == x.chunks
+    assert raises(ValueError, lambda: x.rechunk(chunks=()))


### PR DESCRIPTION
Fixes #178 cc @shoyer

This also checks that the given chunks are consistent with the shape
of the array.