### PR TITLE
[WIP] - Distributed cleanup

### DIFF
--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import zmq
 import socket
+import sys
 import dill
 import uuid
 from collections import defaultdict
@@ -13,12 +14,14 @@ from threading import Thread, Lock
 from contextlib import contextmanager
 from toolz import curry, partial
 from time import sleep
-from ..compatibility import Queue, unicode
+import traceback
+
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
 
+from ..compatibility import Queue, unicode
 from ..core import get_dependencies, flatten
 from .. import core
 from ..async import finish_task, start_state_from_dask as dag_state_from_dask
@@ -35,7 +38,10 @@ def logerrors():
     try:
         yield
     except Exception as e:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        tb = ''.join(traceback.format_tb(exc_traceback))
         log('Error!', str(e))
+        log('Traceback', str(tb))
         raise
 
 class Scheduler(object):

--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -40,7 +40,7 @@ def logerrors():
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
         tb = ''.join(traceback.format_tb(exc_traceback))
-        log('Error!', str(e))
+        log('Error!', type(e).__name__, str(e))
         log('Traceback', str(tb))
         raise
 
@@ -491,13 +491,16 @@ class Scheduler(object):
             self.queues[queue].put(key)
 
     def close_workers(self):
+        log(self.address_to_workers, 'Closing workers', self.workers)
         header = {'function': 'close'}
         for w in self.workers:
             self.send_to_worker(w, header, {})
 
     def close(self):
         """ Close Scheduler """
+        log(self.address_to_workers, 'Close scheduler')
         self.status = 'closed'
+        self.context.destroy(linger=3)
 
     def schedule(self, dsk, result, **kwargs):
         """ Execute dask graph against workers

--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -483,6 +483,11 @@ class Scheduler(object):
         if queue:
             self.queues[queue].put(key)
 
+    def close_workers(self):
+        header = {'function': 'close'}
+        for w in self.workers:
+            self.send_to_worker(w, header, {})
+
     def close(self):
         """ Close Scheduler """
         self.status = 'closed'

--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -500,7 +500,8 @@ class Scheduler(object):
         """ Close Scheduler """
         log(self.address_to_workers, 'Close scheduler')
         self.status = 'closed'
-        self.context.destroy(linger=3)
+        with self.lock:
+            self.context.destroy(linger=3)
 
     def schedule(self, dsk, result, **kwargs):
         """ Execute dask graph against workers

--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -136,8 +136,11 @@ class Scheduler(object):
     def _listen_to_workers(self):
         """ Event loop: Listen to worker router """
         while self.status != 'closed':
-            if not self.to_workers.poll(100):
-                continue
+            try:
+                if not self.to_workers.poll(100):
+                    continue
+            except zmq.ZMQError:
+                break
             address, header, payload = self.to_workers.recv_multipart()
 
             header = pickle.loads(header)
@@ -155,8 +158,11 @@ class Scheduler(object):
     def _listen_to_clients(self):
         """ Event loop: Listen to client router """
         while self.status != 'closed':
-            if not self.to_clients.poll(100):
-                continue
+            try:
+                if not self.to_clients.poll(100):
+                    continue
+            except zmq.ZMQError:
+                break
             address, header, payload = self.to_clients.recv_multipart()
             header = pickle.loads(header)
             if 'address' not in header:

--- a/dask/distributed/singlenode.py
+++ b/dask/distributed/singlenode.py
@@ -1,0 +1,34 @@
+from .scheduler import Scheduler
+from .worker import Worker
+from .client import Client
+from multiprocessing import Pool
+
+from time import sleep
+import psutil
+
+ncpus = psutil.cpu_count()
+pool = Pool()
+
+def get(dsk, keys, nworkers=ncpus):
+    """ Single node get function using ZeroMQ distributed scheduler
+
+    This creates a small cluster of workers on the local machine, uses it to
+    compute a result in parallel, then tears it down.
+
+    See also:
+        dask.multiprocessing
+        dask.threaded
+    """
+    s = Scheduler(hostname='localhost')
+    for p in pool._pool:
+        pool.apply_async(Worker, (s.address_to_workers,), {'block': True})
+    c = Client(s.address_to_clients)
+    sleep(0.05)
+
+    try:
+        result = c.get(dsk, keys)
+    finally:
+        s.close_workers()
+        s.close()
+
+    return result

--- a/dask/distributed/singlenode.py
+++ b/dask/distributed/singlenode.py
@@ -5,11 +5,6 @@ from multiprocessing import Pool
 
 from time import sleep
 
-try:
-    pool = Pool()
-except AssertionError:
-    pass
-
 def get(dsk, keys):
     """ Single node get function using ZeroMQ distributed scheduler
 
@@ -20,6 +15,7 @@ def get(dsk, keys):
         dask.multiprocessing
         dask.threaded
     """
+    pool = Pool()
     s = Scheduler(hostname='localhost')
     futures = [pool.apply_async(Worker, (s.address_to_workers,), {'block': True})
                for p in pool._pool]

--- a/dask/distributed/singlenode.py
+++ b/dask/distributed/singlenode.py
@@ -7,6 +7,7 @@ from time import sleep
 import psutil
 
 ncpus = psutil.cpu_count()
+pool = Pool()
 
 def get(dsk, keys, nworkers=ncpus):
     """ Single node get function using ZeroMQ distributed scheduler
@@ -18,7 +19,6 @@ def get(dsk, keys, nworkers=ncpus):
         dask.multiprocessing
         dask.threaded
     """
-    pool = Pool()
     s = Scheduler(hostname='localhost')
     futures = [pool.apply_async(Worker, (s.address_to_workers,), {'block': True})
                for p in pool._pool]

--- a/dask/distributed/singlenode.py
+++ b/dask/distributed/singlenode.py
@@ -4,12 +4,13 @@ from .client import Client
 from multiprocessing import Pool
 
 from time import sleep
-import psutil
 
-ncpus = psutil.cpu_count()
-pool = Pool()
+try:
+    pool = Pool()
+except AssertionError:
+    pass
 
-def get(dsk, keys, nworkers=ncpus):
+def get(dsk, keys):
     """ Single node get function using ZeroMQ distributed scheduler
 
     This creates a small cluster of workers on the local machine, uses it to

--- a/dask/distributed/tests/test_client.py
+++ b/dask/distributed/tests/test_client.py
@@ -13,6 +13,8 @@ def scheduler_and_workers(n=2):
     s = Scheduler()
     workers = [Worker(s.address_to_workers) for i in range(n)]
     try:
+        while len(s.workers) < n:
+            sleep(0.1)
         yield s, workers
     finally:
         s.close()

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -169,3 +169,14 @@ def test_random_names():
         assert re.match('\w+://[\w-]+:\d+', s.address_to_workers.decode('utf-8'))
     finally:
         s.close()
+
+
+def test_close_workers():
+    with scheduler_and_workers(n=2) as (s, (a, b)):
+        sleep(0.05)
+        assert a.status != 'closed'
+
+        s.close_workers()
+        sleep(0.05)
+        assert a.status == 'closed'
+        assert b.status == 'closed'

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -10,6 +10,7 @@ import pickle
 import re
 
 import zmq
+from dask.compatibility import Queue
 
 context = zmq.Context()
 
@@ -64,6 +65,8 @@ def scheduler_and_workers(n=2):
     with scheduler() as s:
         workers = [Worker(s.address_to_workers) for i in range(n)]
         try:
+            while len(s.workers) < n:
+                sleep(0.1)
             yield s, workers
         finally:
             for w in workers:
@@ -90,6 +93,8 @@ def test_compute_cycle():
     with scheduler_and_workers(n=2) as (s, (a, b)):
         sleep(0.1)
         assert s.available_workers.qsize() == 2
+
+        s.queues['queue-key'] = Queue()
 
         dsk = {'a': (add, 1, 2), 'b': (inc, 'a')}
         s.trigger_task(dsk, 'a', 'queue-key')

--- a/dask/distributed/tests/test_singlenode.py
+++ b/dask/distributed/tests/test_singlenode.py
@@ -1,0 +1,4 @@
+from dask.distributed.single import get
+
+def test_get():
+    assert get({'x': 1, 'y': (lambda x: x + 1, 'x')}, 'y') == 2

--- a/dask/distributed/tests/test_singlenode.py
+++ b/dask/distributed/tests/test_singlenode.py
@@ -1,4 +1,4 @@
-from dask.distributed.single import get
+from dask.distributed.singlenode import get
 
 def test_get():
     assert get({'x': 1, 'y': (lambda x: x + 1, 'x')}, 'y') == 2

--- a/dask/distributed/tests/test_singlenode.py
+++ b/dask/distributed/tests/test_singlenode.py
@@ -1,4 +1,5 @@
 from dask.distributed.singlenode import get
+from operator import add
 
 def test_get():
-    assert get({'x': 1, 'y': (lambda x: x + 1, 'x')}, 'y') == 2
+    assert get({'x': 1, 'y': (add, 'x', 1)}, 'y') == 2

--- a/dask/distributed/tests/test_worker.py
+++ b/dask/distributed/tests/test_worker.py
@@ -39,7 +39,7 @@ def worker_and_router(*args, **kwargs):
     if port:
         router.bind('tcp://*:%d' % port)
     else:
-        port = port or router.bind_to_random_port('tcp://*')
+        port = router.bind_to_random_port('tcp://*')
     kwargs['scheduler'] = 'tcp://localhost:%d' % port
     with worker(*args, **kwargs) as w:
         handshake = router.recv_multipart()  # burn initial handshake

--- a/dask/distributed/tests/test_worker.py
+++ b/dask/distributed/tests/test_worker.py
@@ -15,6 +15,10 @@ def add(x, y):
     return x + y
 
 
+with open('log.workers', 'w') as f:  # delete file
+    pass
+
+
 @contextmanager
 def worker(data=None, scheduler='tcp://localhost:5555'):
     if data is None:

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -485,7 +485,8 @@ class Worker(object):
             self.status = 'closed'
             self.pool.close()
             self.pool.join()
-            self.context.destroy(3)
+            with self.lock:
+                self.context.destroy(3)
 
 
 def status():

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -480,14 +480,12 @@ class Worker(object):
         self.close()
 
     def close(self):
+        log(self.address, 'Close', self.pool._state)
         if self.pool._state == multiprocessing.pool.RUN:
-            log(self.address, 'Close')
             self.status = 'closed'
             self.pool.close()
             self.pool.join()
-
-    def __del__(self):
-        self.close()
+            self.context.destroy(3)
 
 
 def status():

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -312,8 +312,11 @@ class Worker(object):
         """
         while self.status != 'closed':
             # Wait on request
-            if not self.to_scheduler.poll(100):
-                continue
+            try:
+                if not self.to_scheduler.poll(100):
+                    continue
+            except zmq.ZMQError:
+                break
             with logerrors():
                 header, payload = self.to_scheduler.recv_multipart()
                 header = pickle.loads(header)
@@ -332,8 +335,11 @@ class Worker(object):
         """
         while self.status != 'closed':
             # Wait on request
-            if not self.to_workers.poll(100):
-                continue
+            try:
+                if not self.to_workers.poll(100):
+                    continue
+            except zmq.ZMQError:
+                break
 
             with logerrors():
                 address, header, payload = self.to_workers.recv_multipart()

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -31,6 +31,7 @@ def log(*args):
     with open('log.workers', 'a') as f:
         print(*args, file=f)
 
+log('Hello from worker.py')
 
 @contextmanager
 def logerrors():
@@ -313,15 +314,16 @@ class Worker(object):
             # Wait on request
             if not self.to_scheduler.poll(100):
                 continue
-            header, payload = self.to_scheduler.recv_multipart()
-            header = pickle.loads(header)
-            log(self.address, 'Receive job from scheduler', header)
-            try:
-                function = self.scheduler_functions[header['function']]
-            except KeyError:
-                log(self.address, 'Unknown function', header)
-            else:
-                future = self.pool.apply_async(function, args=(header, payload))
+            with logerrors():
+                header, payload = self.to_scheduler.recv_multipart()
+                header = pickle.loads(header)
+                log(self.address, 'Receive job from scheduler', header)
+                try:
+                    function = self.scheduler_functions[header['function']]
+                except KeyError:
+                    log(self.address, 'Unknown function', header)
+                else:
+                    future = self.pool.apply_async(function, args=(header, payload))
 
     def listen_to_workers(self):
         """ Listen to communications from workers
@@ -333,18 +335,19 @@ class Worker(object):
             if not self.to_workers.poll(100):
                 continue
 
-            address, header, payload = self.to_workers.recv_multipart()
-            header = pickle.loads(header)
-            if 'address' not in header:
-                header['address'] = address
-            log(self.address, 'Receive job from worker', address, header)
+            with logerrors():
+                address, header, payload = self.to_workers.recv_multipart()
+                header = pickle.loads(header)
+                if 'address' not in header:
+                    header['address'] = address
+                log(self.address, 'Receive job from worker', address, header)
 
-            try:
-                function = self.worker_functions[header['function']]
-            except KeyError:
-                log(self.address, 'Unknown function', header)
-            else:
-                future = self.pool.apply_async(function, args=(header, payload))
+                try:
+                    function = self.worker_functions[header['function']]
+                except KeyError:
+                    log(self.address, 'Unknown function', header)
+                else:
+                    future = self.pool.apply_async(function, args=(header, payload))
 
     def block(self):
         """ Block until listener threads close

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -434,38 +434,40 @@ class Worker(object):
         then compute task and store result into ``self.data``.  Finally report
         back to the scheduler that we're free.
         """
-        # Unpack payload
-        loads = header.get('loads', pickle.loads)
-        payload = loads(payload)
-        locations = payload['locations']
-        key = payload['key']
-        task = payload['task']
+        with logerrors():
+            # Unpack payload
+            loads = header.get('loads', pickle.loads)
+            payload = loads(payload)
+            locations = payload['locations']
+            key = payload['key']
+            task = payload['task']
 
-        # Grab data from peers
-        self.collect(locations)
+            # Grab data from peers
+            if locations:
+                self.collect(locations)
 
-        # Do actual work
-        start = time()
-        status = "OK"
-        log(self.address, "Start computation", key, task)
-        try:
-            result = core.get(self.data, task)
-            end = time()
-        except Exception as e:
-            status = e
-            end = time()
-        else:
-            self.data[key] = result
-        log(self.address, "End computation", key, task, status)
+            # Do actual work
+            start = time()
+            status = "OK"
+            log(self.address, "Start computation", key, task)
+            try:
+                result = core.get(self.data, task)
+                end = time()
+            except Exception as e:
+                status = e
+                end = time()
+            else:
+                self.data[key] = result
+            log(self.address, "End computation", key, task, status)
 
-        # Report finished to scheduler
-        header2 = {'function': 'finished-task'}
-        result = {'key': key,
-                  'duration': end - start,
-                  'status': status,
-                  'dependencies': list(locations),
-                  'queue': payload['queue']}
-        self.send_to_scheduler(header2, result)
+            # Report finished to scheduler
+            header2 = {'function': 'finished-task'}
+            result = {'key': key,
+                      'duration': end - start,
+                      'status': status,
+                      'dependencies': list(locations),
+                      'queue': payload['queue']}
+            self.send_to_scheduler(header2, result)
 
     def close_from_scheduler(self, header, payload):
         log(self.address, 'Close signal from scheduler')

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -106,7 +106,8 @@ class Worker(object):
                                     'compute': self.compute,
                                     'getitem': self.getitem_scheduler,
                                     'delitem': self.delitem,
-                                    'setitem': self.setitem}
+                                    'setitem': self.setitem,
+                                    'close': self.close_from_scheduler}
 
         self.worker_functions = {'getitem': self.getitem_worker,
                                  'getitem-ack': self.getitem_ack,
@@ -350,6 +351,7 @@ class Worker(object):
         """
         self._listen_workers_thread.join()
         self._listen_scheduler_thread.join()
+        log('Unblocked')
 
     def collect(self, locations):
         """ Collect data from peers
@@ -464,6 +466,10 @@ class Worker(object):
                   'dependencies': list(locations),
                   'queue': payload['queue']}
         self.send_to_scheduler(header2, result)
+
+    def close_from_scheduler(self, header, payload):
+        log(self.address, 'Close signal from scheduler')
+        self.close()
 
     def close(self):
         if self.pool._state == multiprocessing.pool.RUN:


### PR DESCRIPTION
While interacting between dask.dataframe and dask.distributed we've exposed and cleaned up a number of small things in dask.distributed.  Namely:

1.  Schedulers can close worker nodes
2.  Better error logging with tracebacks
3.  Add a singlenode get function using the zmq scheduler
4.  Every worker/scheduler has its own context (is this safe?)

Sadly I'm not getting some strange errors.  Have yet to nail this down.