### PR TITLE
Add a to_hdf5 method to dask.arrays

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1611,3 +1611,38 @@ def unique(x):
     dsk = dict(((name, i), (np.unique, key)) for i, key in enumerate(x._keys()))
     parts = get(merge(dsk, x.dask), list(dsk.keys()))
     return np.unique(np.concatenate(parts))
+
+
+def to_hdf5(x, fn, datapath, **kwargs):
+    import h5py
+    f = h5py.File(fn)
+    if 'chunks' not in kwargs:
+        kwargs['chunks'] = tuple([c[0] for c in x.chunks])
+    d = f.require_dataset(x.shape, x.dtype, **kwargs)
+
+    f.close()
+
+    locs = [[0] + list(accumulate(add, bl)) for bl in arr.chunks]
+
+    name = next(names)
+    dsk = dict(((name,
+
+def write_hdf5_chunk(fn, datapath, index, data):
+    with h5py.File(fn) as f:
+        d = f[datapath]
+        d[index] = data
+
+
+        def insert_to_ooc(out, arr):
+
+    locs = [[0] + list(accumulate(add, bl)) for bl in arr.chunks]
+
+    def store(x, *args):
+        with lock:
+            ind = tuple([slice(loc[i], loc[i+1]) for i, loc in zip(args, locs)])
+            out[ind] = np.asanyarray(x)
+        return None
+
+    name = 'store-%s' % arr.name
+    return dict(((name,) + t[1:], (store, t) + t[1:])
+                for t in core.flatten(arr._keys()))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -8,7 +8,7 @@ from toolz.curried import identity
 import dask
 import dask.array as da
 from dask.array.core import *
-from dask.utils import raises, ignoring
+from dask.utils import raises, ignoring, tmpfile
 
 
 inc = lambda x: x + 1

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -620,6 +620,22 @@ def test_store():
     assert raises(ValueError, lambda: store([at, bt], [at, bt]))
 
 
+def test_to_hdf5():
+    try:
+        import h5py
+    except ImportError:
+        return
+    x = da.ones((4, 4), chunks=(2, 2))
+
+    with tmpfile('.hdf5') as fn:
+        x.to_hdf5(fn, '/x')
+        f = h5py.File(fn)
+        d = f['/x']
+
+        assert eq(d[:], x)
+        assert d.chunks == (2, 2)
+
+
 def test_np_array_with_zero_dimensions():
     d = da.ones((4, 4), chunks=(2, 2))
     assert eq(np.array(d.sum()), np.array(d.compute().sum()))


### PR DESCRIPTION
This is multiprocess safe because it opens the h5py dataset in each task.  This seems to be fairly fast.

Hopefully HDF5 is multiprocess safe?  By default we use the dask.array's chunk size so, in normal operation this shouldn't matter.

Examples
-------

```python
>>> x.to_hdf5('myfile.hdf5', '/x') 
```

Optionally provide arguments as though to ``h5py.File.create_dataset``

```python
>>> x.to_hdf5('myfile.hdf5', '/x', compression='lzf', shuffle=True)
```