### PR TITLE
conda recipe and binstar builds

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,0 +1,29 @@
+package: dask
+user: blaze
+
+platform: 
+  - linux-64
+  - linux-32
+  - osx-64
+  - win-32
+  - win-64
+
+engine:
+  - python=2.6
+  - python=2.7
+  - python=3.3
+  - python=3.4
+
+before_script:
+  - python -V
+
+script:
+  - conda build conda.recipe
+
+iotimeout: 120
+
+build_targets: conda
+
+notifications:
+  email:
+    recipients: ['mrocklin@continuum.io', 'bgriffith@continuum.io']

--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+pip install git+https://github.com/blosc/bcolz --upgrade
+$PYTHON setup.py install

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,41 @@
+package:
+  name: dask
+  version: {{ environ.get('GIT_DESCRIBE_TAG') }}
+
+build:
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  {% if environ.get('GIT_DESCRIBE_NUMBER', '0') == '0' %}string: py{{ environ.get('PY_VER').replace('.', '') }}_0
+  {% else %}string: py{{ environ.get('PY_VER').replace('.', '') }}_{{ environ.get('GIT_BUILD_STR', 'GIT_STUB') }}{% endif %}
+
+source:
+  path: ../
+
+requirements:
+  build:
+    - python
+    - pip
+    - setuptools
+    - toolz
+    # bcolz is a runtime dependency but since it is installed with pip, we have
+    # to install it in the build.sh. So we install its dependencies now.
+    - cython  # to compile bcolz
+    - numpy   # bcolz dependency
+
+  run:
+    - python
+    - toolz
+    - numpy
+    - pandas
+    - pyzmq
+    - dill
+    - psutil
+    - chest
+
+test:
+  requires:
+    - pytest
+
+about:
+  home: https://github.com/ContinuumIO/dask
+  summary: Task scheduling and blocked algorithms for parallel processing.
+  license: BSD

--- a/conda.recipe/run_test.py
+++ b/conda.recipe/run_test.py
@@ -1,0 +1,6 @@
+from os import environ, path
+
+import pytest
+
+
+pytest.main(['-vv', path.join(environ['SRC_DIR'],'dask')])

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -1,6 +1,9 @@
-from dask.async import *
 from operator import add
 from copy import deepcopy
+
+import pytest
+
+from dask.async import *
 
 
 fib_dask = {'f0': 0, 'f1': 1, 'f2': 1, 'f3': 2, 'f4': 3, 'f5': 5, 'f6': 8}
@@ -74,7 +77,7 @@ def test_finish_task():
 
 
 def test_state_to_networkx():
-    import networkx as nx
+    nx = pytest.importorskip("networkx")
     dsk = {'x': 1, 'y': 1, 'a': (add, 'x', 'y'), 'b': (inc, 'x')}
     state = start_state_from_dask(dsk)
     g = state_to_networkx(dsk, state)

--- a/dask/tests/test_dot.py
+++ b/dask/tests/test_dot.py
@@ -1,7 +1,11 @@
-import networkx as nx
-from functools import partial
-from dask.dot import to_networkx, dot_graph, lower
 import os
+from functools import partial
+
+import pytest
+
+nx = pytest.importorskip("networkx")
+
+from dask.dot import to_networkx, dot_graph, lower
 
 
 def add(x, y):


### PR DESCRIPTION
You can try out the conda package:

```bash
$ conda install -c cowlicks dask
```

Note that I had to use the `build.sh` script to install from bcolz master. This works but it is a dirty hack. It should be removed and bcolz should be added in the `meta.yml`'s `run` field whenever there is a working (with dask) bcolz conda package.

I tried submitting the binstar build but it said no workers were available, so CI is probably not working yet? I have binstar build authorized to test gh/cowlicks/dask. I'm not sure if it is supposed to tests PR's or pushes or if I'm supposed to see a thing like travis-ci has or what. We would need to authorize binstar build to access gh/ContinuumIO/dask to do its thing.