### PR TITLE
Check run test exit value, and workaround conda-build bug

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: dask
-  version: {{ environ.get('GIT_DESCRIBE_TAG') }}
+  version: {{ environ.get('GIT_DESCRIBE_TAG', '0.4.0') }}
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}

--- a/conda.recipe/run_test.py
+++ b/conda.recipe/run_test.py
@@ -1,6 +1,8 @@
+import sys
 from os import environ, path
 
 import pytest
 
 
-pytest.main(['-vv', path.join(environ['SRC_DIR'],'dask')])
+out = pytest.main(['-vv', path.join(environ['SRC_DIR'], 'dask')])
+sys.exit(out)


### PR DESCRIPTION
When conda build ran `run_tests.py` our test script was giving a `0` exit value even if the tests failed. This is fixed. An example of the failure is here:
https://binstar.org/blaze/dask/builds/20/9

And in our `meta.yaml` we try using `GIT_DESCRIBE_TAG` to get the version of our package, but we seem to be effected by [this bug](https://github.com/conda/conda-build/issues/357). So this works around it. Example:
https://binstar.org/blaze/dask/builds/20/4#L2269