### PR TITLE
Make scheduler test robust to slow runner

### DIFF
--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -7,7 +7,7 @@ PY2 = sys.version_info[0] == 2
 
 if PY3:
     import builtins
-    from queue import Queue
+    from queue import Queue, Empty
     from itertools import zip_longest
     from io import StringIO
     unicode = str
@@ -16,7 +16,7 @@ if PY3:
         return func(*args)
 else:
     import __builtin__ as builtins
-    from Queue import Queue
+    from Queue import Queue, Empty
     import operator
     from itertools import izip_longest as zip_longest
     from StringIO import StringIO

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -150,9 +150,16 @@ def test_schedule():
 
         # No worker still has the unnecessary intermediate variable
         assert not s.who_has['x']
-        assert 'x' not in a.data and 'x' not in b.data
-        sleep(0.05)
-        assert 'y' not in a.data and 'y' not in b.data
+
+        # Neither worker has the result after computation
+        # We don't have a way to block on worker completion here
+        # Instead we poll and sleep.  This is a bit of a hack
+        for i in range(10):
+            if a.data or b.data:
+                sleep(0.1)
+            else:
+                break
+        assert not a.data and not b.data
 
 
 def test_gather():


### PR DESCRIPTION
Some scheduler tests have race conditions that should resolve
themselves very very quickly (e.g. sleep(0.001)).  Of course this
approach is fraught and fails on very slow machines (like travis.ci
and binstar-build).

In many cases we have blocking logic built into the Scheduler/Worker
In some cases adding this just doesn't make sense.

This commit adds a poll/sleep loop to a scheduler test

Fixes https://travis-ci.org/ContinuumIO/dask/jobs/62286888#L862