### PR TITLE
dask.multiprocessing supports loads/dumps options

### DIFF
--- a/dask/context.py
+++ b/dask/context.py
@@ -17,6 +17,9 @@ class set_options(object):
     Valid keyword arguments currently include:
 
         get - the scheduler to use
+        pool - a thread or process pool
+        func_loads/func_dumps - loads/dumps functions for serialization of data
+            likely to contain functions.  Defaults to dill.loads/dill.dumps
 
     Example
     -------

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -11,7 +11,24 @@ from .context import _globals
 
 def get(dsk, keys, optimizations=[fuse], num_workers=None,
         func_loads=None, func_dumps=None):
-    """ Multiprocessed get function appropriate for Bags """
+    """ Multiprocessed get function appropriate for Bags
+
+    Parameters
+    ----------
+
+    dsk: dict
+        dask graph
+    keys: object or list
+        Desired results from graph
+    optimizations: list of functions
+        optimizations to perform on graph before execution
+    num_workers: int
+        Number of worker processes (defaults to number of cores)
+    func_dumps: function
+        Function to use for function serialization (defaults to dill.dumps)
+    func_loads: function
+        Function to use for function deserialization (defaults to dill.loads)
+    """
     pool = _globals['pool']
     if pool is None:
         pool = multiprocessing.Pool(num_workers)

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -58,7 +58,7 @@ def test_reuse_pool():
 
 
 def test_dumps_loads():
-    with set_options(dumps=pickle.dumps, loads=pickle.loads):
+    with set_options(func_dumps=pickle.dumps, func_loads=pickle.loads):
         assert get({'x': 1, 'y': (add, 'x', 2)}, 'y') == 3
 
         # Ensure we're using pickle by triggering a known failure of pickle

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -60,7 +60,3 @@ def test_reuse_pool():
 def test_dumps_loads():
     with set_options(func_dumps=pickle.dumps, func_loads=pickle.loads):
         assert get({'x': 1, 'y': (add, 'x', 2)}, 'y') == 3
-
-        # Ensure we're using pickle by triggering a known failure of pickle
-        dsk = {'x': 1, 'y': (lambda x, y: x + y, 'x', 2)}
-        assert raises(pickle.PicklingError, lambda: get(dsk, 'y'))


### PR DESCRIPTION
You can now specify loads/dumps functions with `set_options` to control function serialization

```python
import pickle
import dask
from dask.multiprocessing import get
with dask.set_options(func_dumps=pickle.dumps, func_loads=pickle.loads):
    print(get({'x': 1, 'y': (add, 'x', 1)}, 'y'))

or

    >>> get({'x': 1, 'y': (add, 'x', 1)}, 'y', func_loads=pickle.loads, func_dumps=pickle.dumps)
```

In particular this allows users to select between `pickle`, `dill`, and `cloudpickle` (or whatever else comes up.)