### PR TITLE
Remove `#` comment from gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ docs/build
 build/
 dist/
 .idea/
-log.*  # log files created when testing dask distributed
+log.*


### PR DESCRIPTION
The proper syntax is that a comment starts with # at the beginning of a
line.