### PR TITLE
Add test coverage to dask.bag.core

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -619,9 +619,6 @@ class Array(object):
         return ("dask.array<%s, shape=%s, chunks=%s, dtype=%s>" %
                 (self.name, self.shape, chunks, self._dtype))
 
-    def _get_block(self, *args):
-        return core.get(self.dask, (self.name,) + args)
-
     @property
     def ndim(self):
         return len(self.shape)

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -28,7 +28,7 @@ from pbag import PBag
 from ..multiprocessing import get as mpget
 from ..core import istask
 from ..optimize import fuse, cull
-from ..compatibility import apply, StringIO, unicode
+from ..compatibility import apply, BytesIO, unicode
 from ..context import _globals
 
 names = ('bag-%d' % i for i in itertools.count(1))
@@ -746,12 +746,13 @@ def from_hdfs(path, hdfs=None, host='localhost', port='50070', user_name=None):
 
 
 def stream_decompress(fmt, data):
+    """ Decompress a block of compressed bytes into a stream of strings """
     if fmt == 'gz':
-        return gzip.GzipFile(fileobj=StringIO(data))
+        return gzip.GzipFile(fileobj=BytesIO(data))
     if fmt == 'bz2':
         return bz2_stream(data)
     else:
-        return StringIO(data)
+        return map(bytes.decode, BytesIO(data))
 
 
 def bz2_stream(compressed, chunksize=100000):

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -391,8 +391,9 @@ def test_stream_decompress():
     assert [s.strip() for s in stream_decompress('bz2', bz2.compress(data))] == \
             ['abc', 'def', '123']
     with tmpfile() as fn:
-        with gzip.open(fn, 'wb') as f:
-            f.write(data)
+        f = gzip.open(fn, 'wb')
+        f.write(data)
+        f.close()
         with open(fn, 'rb') as f:
             compressed = f.read()
     assert [s.strip() for s in stream_decompress('gz', compressed)] == \

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -396,4 +396,4 @@ def test_stream_decompress():
         with open(fn, 'rb') as f:
             compressed = f.read()
     assert [s.strip() for s in stream_decompress('gz', compressed)] == \
-            ['abc', 'def', '123']
+            [b'abc', b'def', b'123']

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -9,7 +9,7 @@ if PY3:
     import builtins
     from queue import Queue, Empty
     from itertools import zip_longest
-    from io import StringIO
+    from io import StringIO, BytesIO
     unicode = str
     long = int
     def apply(func, args):
@@ -20,6 +20,7 @@ else:
     import operator
     from itertools import izip_longest as zip_longest
     from StringIO import StringIO
+    BytesIO = StringIO
     unicode = unicode
     long = long
     apply = apply

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 from collections import Iterator
 from contextlib import contextmanager
 import os
+import shutil
 import gzip
 import tempfile
 


### PR DESCRIPTION
This takes the file from 85 to 96%  It was previously our worst offender.  This uncovered surprisingly few errors.