### PR TITLE
Add dask.array.bincount

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 from ..utils import ignoring
 from .core import (Array, stack, concatenate, take, tensordot, transpose,
         from_array, choose, where, coarsen, insert, broadcast_to,
-        fromfunction, compute, unique, store, squeeze, topk)
+        fromfunction, compute, unique, store, squeeze, topk, bincount)
 from .core import (logaddexp, logaddexp2, conj, exp, log, log2, log10, log1p,
         expm1, sqrt, square, sin, cos, tan, arcsin, arccos, arctan, arctan2,
         hypot, sinh, cosh, tanh, arcsinh, arccosh, arctanh, deg2rad, rad2deg,

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -970,3 +970,31 @@ def test_topk():
 
     assert e.chunks == ((2,),)
     assert eq(e, np.sort(x)[-1:-3:-1])
+
+
+def test_bincount():
+    x = np.array([2, 1, 5, 2, 1])
+    d = da.from_array(x, chunks=2)
+
+    assert eq(da.bincount(d, minlength=6), np.bincount(x, minlength=6))
+
+
+def test_bincount_with_weights():
+    x = np.array([2, 1, 5, 2, 1])
+    d = da.from_array(x, chunks=2)
+    weights = np.array([1, 2, 1, 0.5, 1])
+
+    dweights = da.from_array(weights, chunks=2)
+    assert eq(da.bincount(d, weights=dweights, minlength=6),
+              np.bincount(x, weights=dweights, minlength=6))
+
+
+def test_bincount_raises_informative_error_on_missing_minlength_kwarg():
+    x = np.array([2, 1, 5, 2, 1])
+    d = da.from_array(x, chunks=2)
+    try:
+        da.bincount(d)
+    except Exception as e:
+        assert 'minlength' in str(e)
+    else:
+        assert False


### PR DESCRIPTION
The implementation is fairly simple.  We call np.bincount on each chunk
followed by a sum on the result.  We also support the `weights=` kwarg
and **require** the `minlength=` kwarg.

Example
-------
```python
In [1]: import dask.array as da

In [2]: x = da.random.binomial(100, 0.2, size=10000000, chunks=100000)

In [3]: %time da.bincount(x, minlength=100).compute()
CPU times: user 2.26 s, sys: 44.2 ms, total: 2.31 s
Wall time: 2.24 s
Out[3]:
array([     0,      0,      0,      6,     44,    136,    584,   2064,
         5938,  14772,  33084,  68568, 127704, 215525, 336015, 479691,
       637366, 790564, 911322, 979063, 993400, 944096, 849693, 719470,
       576965, 438738, 315740, 217278, 141412,  87920,  51906,  29428,
        15835,   8183,   4072,   1899,    878,     383,    164,    51,
           26,     12,      5,      0,      0,       0,      0,     0,
            0,      0,      0,      0,      0,       0,      0,     0,
            0,      0,      0,      0,      0,       0,      0,     0,
            0,      0,      0,      0,      0,       0,      0,     0,
            0,      0,      0,      0,      0,       0,      0,     0,
            0,      0,      0,      0,      0,       0,      0,     0,
            0,      0,      0,      0,      0,       0,      0,     0,
            0,      0,      0,      0])
```