### PR TITLE
Fix hangs w/ bag.count/sum with distributed scheduler

### DIFF
--- a/dask/core.py
+++ b/dask/core.py
@@ -234,12 +234,15 @@ def flatten(seq):
     >>> list(flatten((1, 2, [3, 4]))) # support heterogeneous
     [1, 2, 3, 4]
     """
-    for item in seq:
-        if isinstance(item, list):
-            for item2 in flatten(item):
-                yield item2
-        else:
-            yield item
+    if isinstance(seq, str):
+        yield seq
+    else:
+        for item in seq:
+            if isinstance(item, list):
+                for item2 in flatten(item):
+                    yield item2
+            else:
+                yield item
 
 
 def reverse_dict(d):

--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -27,9 +27,11 @@ from ..async import finish_task, start_state_from_dask as dag_state_from_dask
 with open('log.scheduler', 'w') as f:  # delete file
     pass
 
+
 def log(*args):
     with open('log.scheduler', 'a') as f:
-        print(*args, file=f)
+        print('\n', *args, file=f)
+
 
 @contextmanager
 def logerrors():

--- a/dask/distributed/tests/test_distributed.py
+++ b/dask/distributed/tests/test_distributed.py
@@ -1,3 +1,5 @@
+"""Tests that require a running dask.distributed cluster"""
+
 import time
 from subprocess import Popen, PIPE
 
@@ -13,6 +15,7 @@ from IPython.parallel import Client
 
 from dask.distributed import dask_client_from_ipclient
 import dask.array as da
+import dask.bag as db
 
 
 def setup_module():
@@ -68,3 +71,10 @@ def test_dask_client_from_ipclient():
     finally:
         # close the workers
         dask_client.close(close_scheduler=True)
+
+
+def test_gh_248():
+    """bag.sum() and bag.count() would hang with the distributed scheduler"""
+    a = db.from_sequence(range(50), npartitions=2)
+    a.sum().compute()
+    a.count().compute()

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -28,9 +28,11 @@ MAX_DEALERS = 100
 with open('log.workers', 'w') as f:  # delete file
     pass
 
+
 def log(*args):
     with open('log.workers', 'a') as f:
-        print(*args, file=f)
+        print('\n', *args, file=f)
+
 
 log('Hello from worker.py')
 

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -1,24 +1,26 @@
 from __future__ import print_function
 
+import uuid
+import random
 import socket
+import sys
+import traceback
 from threading import Thread, Lock
 from multiprocessing.pool import ThreadPool
 from contextlib import contextmanager
-import traceback
 from datetime import datetime
-import uuid
-import random
-import multiprocessing
-import zmq
 from time import time
-import sys
-from ..compatibility import Queue, unicode
-from .. import core
+
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
-import dill
+
+import zmq
+
+from ..compatibility import Queue, unicode
+from .. import core
+
 
 def pickle_dumps(obj):
     return pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -130,7 +130,7 @@ def test_get_stack_limit():
 
 def test_flatten():
     assert list(flatten(())) == []
-    assert list(flatten('foo')) == 'foo'
+    assert list(flatten('foo')) == ['foo']
 
 
 def test_subs():

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -130,6 +130,7 @@ def test_get_stack_limit():
 
 def test_flatten():
     assert list(flatten(())) == []
+    assert list(flatten('foo')) == 'foo'
 
 
 def test_subs():


### PR DESCRIPTION
closes #248 

The main fix is 017241f basicall dask.core.flatten would do this
```python
>>> flatten('foo')
['f', 'o', 'o']
```
Now it does this
```python
>>>flatten('foo')
['foo']
```

I renamed `test_ipython_utils` to `test_distributed` and made it the place for tests that require a dask.distributed cluster to be running. 