### PR TITLE
Dot error and docs

### DIFF
--- a/dask/dot.py
+++ b/dask/dot.py
@@ -60,7 +60,11 @@ def to_networkx(d, data_attributes=None, function_attributes=None):
 
 def write_networkx_to_dot(dg, filename='mydask'):
     import os
-    p = nx.to_pydot(dg)
+    try:
+        p = nx.to_pydot(dg)
+    except AttributeError:
+        raise ImportError("Can not find pydot module. Please install.\n"
+                          "    pip install pydot")
     p.set_rankdir('BT')
     with open(filename + '.dot', 'w') as f:
         f.write(p.to_string())

--- a/docs/source/frame-design.rst
+++ b/docs/source/frame-design.rst
@@ -27,9 +27,9 @@ Note that all dask.array operations produce new dask arrays without having to lo
 
 *  A dask graph
 *  A name
-*  A blockdims tuple like ``((8, 8, 8, 8), (5, 5, 5))`` to encode dimension, shape, and blockshape.
+*  A chunks tuple like ``((8, 8, 8, 8), (5, 5, 5))`` to encode dimension, shape, and blockshape.
 
-That ``blockdims`` is sufficient metadata to make dask.array closed under NumPy operations is key to its success.  What is the equivalent set of metadata for frames?
+That ``chunks`` is sufficient metadata to make dask.array closed under NumPy operations is key to its success.  What is the equivalent set of metadata for frames?
 
 
 DataFrame Metadata
@@ -40,10 +40,10 @@ DataFrame Metadata
    :align: right
    :alt: A dask frame
 
-*We separate blocks over the index.  Our new equivalent of ``blockdims``
+*We separate blocks over the index.  Our new equivalent of ``chunks``
 involves ranges of index values, not locations.*
 
-The ``blockdims`` tuple represents the block structure of a dask array in all dimensions.  In Frames we have only one dimension (simpler) but that dimension may be within other ordered dimensions like time or text.  Additionally there is no clear way to determine how many elements may be within two bounds from the metadata alone (e.g. how many records in the month of July).
+The ``chunks`` tuple represents the block structure of a dask array in all dimensions.  In Frames we have only one dimension (simpler) but that dimension may be within other ordered dimensions like time or text.  Additionally there is no clear way to determine how many elements may be within two bounds from the metadata alone (e.g. how many records in the month of July).
 
 We define a Frame as a sequence of blocks, where each block is a Pandas DataFrame.  This sequence is sorted along an index column so that the index of all records in block ``i`` is less than the index of all records in block ``i+1``.  We store this information in a ``divisions`` attribute.  In the example to the right we index our frame by time and separate blocks by month.  Note that blocks may be of varying size.
 

--- a/docs/source/ghost.rst
+++ b/docs/source/ghost.rst
@@ -45,13 +45,13 @@ ghost function:
    >>> import numpy as np
 
    >>> x = np.arange(64).reshape((8, 8))
-   >>> d = da.from_array(x, blockshape=(4, 4))
-   >>> d.blockdims
+   >>> d = da.from_array(x, chunks=(4, 4))
+   >>> d.chunks
    ((4, 4), (4, 4))
 
    >>> g = da.ghost.ghost(d, depth={0: 2, 1: 1},
    ...                       boundary={0: 100, 1: 'reflect'})
-   >>> g.blockdims
+   >>> g.chunks
    ((8, 8), (6, 6))
 
    >>> np.array(g)
@@ -114,12 +114,13 @@ While in this case we used a SciPy function above this could have been any
 arbitrary function.  This is a good interaction point with Numba_.
 
 If your function does not preserve the shape of the block then you will need to
-provide either a ``blockshape`` if your block sizes are regular or
-``blockdims`` keyword argument if your block sizes are irregular
+provide a ``chunks`` keyword argument.  If your block sizes are regular  then
+this can be a blockshape, e.g. ``(1000, 1000)`` or if your blocks are irregular
+then this must be a full chunks tuple, e.g. ``((1000, 700, 1000), (200, 300))``.
 
 .. code-block:: python
 
-   >>> g.map_blocks(myfunc, blockshape=(5, 5))
+   >>> g.map_blocks(myfunc, chunks=(5, 5))
 
 If your function needs to know the location of the block on which it operates
 you can give your function a keyword argument ``block_id``
@@ -144,7 +145,7 @@ given to ``ghost``.
 
 .. code-block:: python
 
-   >>> x.blockdims
+   >>> x.chunks
    ((10, 10, 10, 10), (10, 10, 10, 10))
 
    >>> da.ghost.trim_internal(x, {0: 2, 1: 1})

--- a/docs/source/inspect.rst
+++ b/docs/source/inspect.rst
@@ -18,7 +18,7 @@ The first step is to look at the ``.dask`` attribute of an array
 .. code-block:: python
 
    >>> import dask.array as da
-   >>> x = da.ones((5, 15), blockshape=(5, 5))
+   >>> x = da.ones((5, 15), chunks=(5, 5))
    >>> x.dask
    {('wrapped_1', 0, 0): (ones, (5, 5)),
     ('wrapped_1', 0, 1): (ones, (5, 5)),

--- a/docs/source/random.rst
+++ b/docs/source/random.rst
@@ -3,7 +3,7 @@ dask.array.random
 
 ``dask.array`` copies the ``numpy.random`` module for all univariate
 distributions.  The interface to each function is identical except for the
-addition of a new ``blockshape=`` keyword argument.
+addition of a new ``chunks=`` keyword argument.
 
 .. code-block:: python
 
@@ -11,4 +11,4 @@ addition of a new ``blockshape=`` keyword argument.
    x = np.random.normal(10, 0.1, size=(10, 10))
 
    import dask.array as da
-   x = da.random.normal(10, 0.1, size=(10, 10), blockshape=(5, 5))
+   x = da.random.normal(10, 0.1, size=(10, 10), chunks=(5, 5))

--- a/docs/source/shared.rst
+++ b/docs/source/shared.rst
@@ -56,7 +56,7 @@ The quickest/simplest test we can do it to use IPython's ``timeit`` magic.
 
    In [1]: import dask.array as da
 
-   In [2]: x = da.ones(1000, blockshape=(2,)).sum()
+   In [2]: x = da.ones(1000, chunks=(2,)).sum()
 
    In [3]: len(x.dask)
    Out[3]: 1001
@@ -68,7 +68,7 @@ Around 500 microseconds per task.  About 100ms of this is from overhead
 
 .. code-block:: python
 
-   In [6]: x = da.ones(1000, blockshape=(1000,)).sum()
+   In [6]: x = da.ones(1000, chunks=(1000,)).sum()
    In [7]: %timeit x.compute()
    10 loops, best of 3: 103 ms per loop
 

--- a/docs/source/slicing.rst
+++ b/docs/source/slicing.rst
@@ -31,7 +31,7 @@ portion of the output.
 .. code-block:: python
 
    >>> Trillion element array of ones, in 1000 by 1000 blocks
-   >>> x = da.ones((1000000, 1000000), blockshape=(1000, 1000))
+   >>> x = da.ones((1000000, 1000000), chunks=(1000, 1000))
 
    >>> da.exp(x)[:1500, :1500]
    ...

--- a/docs/source/stack.rst
+++ b/docs/source/stack.rst
@@ -17,7 +17,7 @@ as we go.
 .. code-block:: python
 
    >>> import dask.array as da
-   >>> data = [from_array(np.ones((4, 4)), blockshape=(2, 2))
+   >>> data = [from_array(np.ones((4, 4)), chunks=(2, 2))
    ...          for i in range(3)]  # A small stack of dask arrays
 
    >>> x = da.stack(data, axis=0)
@@ -43,7 +43,7 @@ existing dimension
    >>> import dask.array as da
    >>> import numpy as np
 
-   >>> data = [from_array(np.ones((4, 4)), blockshape=(2, 2))
+   >>> data = [from_array(np.ones((4, 4)), chunks=(2, 2))
    ...          for i in range(3)]  # small stack of dask arrays
 
    >>> x = da.concatenate(data, axis=0)


### PR DESCRIPTION
Two fixes

1.  We raise a more informative errors to guide users to install pydot if they try to visualize a graph
2.  We replace mentions of blockshape/blockdims with chunks in docs

Fixes #255 
cc @koldunovn