### PR TITLE
Fix Bag for some NLP use cases

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -51,7 +51,7 @@ def lazify_task(task, start=True):
     if not istask(task):
         return task
     head, tail = task[0], task[1:]
-    if not start and head is list:
+    if not start and head in (list, reify):
         task = task[1]
         return lazify_task(*tail, start=False)
     else:
@@ -221,7 +221,7 @@ class Bag(object):
         name = next(names)
         if takes_multiple_arguments(func):
             func = curry(apply, func)
-        dsk = dict(((name, i), (list, (map, func, (self.name, i))))
+        dsk = dict(((name, i), (reify, (map, func, (self.name, i))))
                         for i in range(self.npartitions))
         return Bag(merge(self.dask, dsk), name, self.npartitions)
 
@@ -241,7 +241,7 @@ class Bag(object):
         [0, 2, 4]
         """
         name = next(names)
-        dsk = dict(((name, i), (list, (filter, predicate, (self.name, i))))
+        dsk = dict(((name, i), (reify, (filter, predicate, (self.name, i))))
                         for i in range(self.npartitions))
         return Bag(merge(self.dask, dsk), name, self.npartitions)
 
@@ -967,3 +967,11 @@ def robust_wraps(wrapper):
         wrapped.__doc__ = wrapper.__doc__
         return wrapped
     return _
+
+
+def reify(seq):
+    if isinstance(seq, Iterator):
+        seq = list(seq)
+    if seq and isinstance(seq[0], Iterator):
+        seq = list(map(list, seq))
+    return seq

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -929,8 +929,8 @@ class StringAccessor(object):
     def __dir__(self):
         return sorted(set(dir(type(self)) + dir(str)))
 
-    def _strmap(self, func, *args, **kwargs):
-        return self._bag.map(lambda s: func(s, *args, **kwargs))
+    def _strmap(self, key, *args, **kwargs):
+        return self._bag.map(lambda s: getattr(s, key)(*args, **kwargs))
 
     def __getattr__(self, key):
         try:
@@ -938,7 +938,7 @@ class StringAccessor(object):
         except AttributeError:
             if key in dir(str):
                 func = getattr(str, key)
-                return robust_wraps(func)(partial(self._strmap, func))
+                return robust_wraps(func)(partial(self._strmap, key))
             else:
                 raise
 

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -572,8 +572,8 @@ class Bag(object):
         results = get(self.dask, self._keys(), **kwargs)
         if isinstance(results[0], Iterable):
             results = toolz.concat(results)
-        if not isinstance(results, Iterator):
-            results = iter(results)
+        if isinstance(results, Iterator):
+            results = list(results)
         return results
 
     def concat(self):
@@ -591,7 +591,8 @@ class Bag(object):
                         for i in range(self.npartitions))
         return Bag(merge(self.dask, dsk), name, self.npartitions)
 
-    __iter__ = compute
+    def __iter__(self):
+        return iter(self.compute())
 
     def groupby(self, grouper, npartitions=None):
         """ Group collection by key function

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -386,6 +386,12 @@ def test_string_namespace():
     assert raises(AttributeError, lambda: b.str.sfohsofhf)
 
 
+def test_string_namespace_with_unicode():
+    b = db.from_sequence([u'Alice Smith', u'Bob Jones', 'Charlie Smith'],
+                         npartitions=2)
+    assert list(b.str.lower()) == ['alice smith', 'bob jones', 'charlie smith']
+
+
 def test_stream_decompress():
     data = 'abc\ndef\n123'.encode()
     assert [s.strip() for s in stream_decompress('', data)] == \

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -392,6 +392,14 @@ def test_string_namespace_with_unicode():
     assert list(b.str.lower()) == ['alice smith', 'bob jones', 'charlie smith']
 
 
+def test_str_empty_split():
+    b = db.from_sequence([u'Alice Smith', u'Bob Jones', 'Charlie Smith'],
+                         npartitions=2)
+    assert list(b.str.split()) == [['Alice', 'Smith'],
+                                   ['Bob', 'Jones'],
+                                   ['Charlie', 'Smith']]
+
+
 def test_stream_decompress():
     data = 'abc\ndef\n123'.encode()
     assert [s.strip() for s in stream_decompress('', data)] == \

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -7,7 +7,7 @@ from toolz import (merge, join, pipe, filter, identity, merge_with, take,
         partial)
 import math
 from dask.bag.core import (Bag, lazify, lazify_task, fuse, map, collect,
-        reduceby, bz2_stream, stream_decompress)
+        reduceby, bz2_stream, stream_decompress, reify)
 from dask.utils import filetexts, tmpfile, raises
 import dask
 from pbag import PBag
@@ -51,7 +51,7 @@ def test_keys():
 
 def test_map():
     c = b.map(inc)
-    expected = merge(dsk, dict(((c.name, i), (list, (map, inc, (b.name, i))))
+    expected = merge(dsk, dict(((c.name, i), (reify, (map, inc, (b.name, i))))
                                for i in range(b.npartitions)))
     assert c.dask == expected
 
@@ -64,7 +64,7 @@ def test_map_function_with_multiple_arguments():
 def test_filter():
     c = b.filter(iseven)
     expected = merge(dsk, dict(((c.name, i),
-                                (list, (filter, iseven, (b.name, i))))
+                                (reify, (filter, iseven, (b.name, i))))
                                for i in range(b.npartitions)))
     assert c.dask == expected
 
@@ -150,16 +150,16 @@ def test_map_partitions():
 
 
 def test_lazify_task():
-    task = (sum, (list, (map, inc, [1, 2, 3])))
+    task = (sum, (reify, (map, inc, [1, 2, 3])))
     assert lazify_task(task) == (sum, (map, inc, [1, 2, 3]))
 
-    task = (list, (map, inc, [1, 2, 3]))
+    task = (reify, (map, inc, [1, 2, 3]))
     assert lazify_task(task) == task
 
-    a = (list, (map, inc,
-                     (list, (filter, iseven, 'y'))))
-    b = (list, (map, inc,
-                            (filter, iseven, 'y')))
+    a = (reify, (map, inc,
+                      (reify, (filter, iseven, 'y'))))
+    b = (reify, (map, inc,
+                              (filter, iseven, 'y')))
     assert lazify_task(a) == b
 
 
@@ -167,11 +167,11 @@ f = lambda x: x
 
 
 def test_lazify():
-    a = {'x': (list, (map, inc,
-                           (list, (filter, iseven, 'y')))),
+    a = {'x': (reify, (map, inc,
+                            (reify, (filter, iseven, 'y')))),
          'a': (f, 'x'), 'b': (f, 'x')}
-    b = {'x': (list, (map, inc,
-                                  (filter, iseven, 'y'))),
+    b = {'x': (reify, (map, inc,
+                                    (filter, iseven, 'y'))),
          'a': (f, 'x'), 'b': (f, 'x')}
     assert lazify(a) == b
 
@@ -414,3 +414,15 @@ def test_stream_decompress():
             compressed = f.read()
     assert [s.strip() for s in stream_decompress('gz', compressed)] == \
             [b'abc', b'def', b'123']
+
+
+def test_map_with_iterator_function():
+    b = db.from_sequence([[1, 2, 3], [4, 5, 6]], npartitions=2)
+
+    def f(L):
+        for x in L:
+            yield x + 1
+
+    c = b.map(f)
+
+    assert list(c) == [[2, 3, 4], [5, 6, 7]]

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -426,3 +426,9 @@ def test_map_with_iterator_function():
     c = b.map(f)
 
     assert list(c) == [[2, 3, 4], [5, 6, 7]]
+
+
+def test_ensure_compute_output_is_concrete():
+    b = db.from_sequence([1, 2, 3])
+    result = b.map(lambda x: x + 1).compute()
+    assert not isinstance(result, Iterator)


### PR DESCRIPTION
@chdoig and I ran through a trivial ngram counting example and ran into a few usability bugs


Fixes:

1.  Map with iterator functions reifies results in process if necessary (so that we don't accidentally try to send back an iterator)
2.   `str` namespace works well with strings or unicode