### PR TITLE
Index one array with another boolean dask.array

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -998,3 +998,18 @@ def test_bincount_raises_informative_error_on_missing_minlength_kwarg():
         assert 'minlength' in str(e)
     else:
         assert False
+
+
+def test_fancy_indexing_with_another_dask_array():
+    x = np.array([2, 1, 5, 2, 1])
+    d = da.from_array(x, chunks=2)
+
+    assert eq(d[d > 1],
+              x[x > 1])
+
+
+    x = np.array([[2, 1], [1, 2]])
+    d = da.from_array(x, chunks=1)
+
+    assert eq(np.sort(d[d > 1]),
+              np.sort(x[x > 1]))


### PR DESCRIPTION
This allows for fancy indexing of the following form:

Example
-------

```python
In [1]: import numpy as np

In [2]: import dask.array as da

In [3]: x = np.array([2, 1, 5, 2, 1])

In [4]: d = da.from_array(x, chunks=2)

In [5]: d[d > 1]
Out[5]: array([2, 5, 2])
```

Historically we have avoided operations like this for which we don't
know the shape of the output.  We get around this issue by computing
immediately.  I'm considering extending this approach to other
operations going forwards.