### PR TITLE
Add variadic map_blocks function

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import, division, print_function
 from ..utils import ignoring
 from .core import (Array, stack, concatenate, take, tensordot, transpose,
         from_array, choose, where, coarsen, insert, broadcast_to,
-        fromfunction, compute, unique, store, squeeze, topk, bincount)
+        fromfunction, compute, unique, store, squeeze, topk, bincount,
+        map_blocks)
 from .core import (logaddexp, logaddexp2, conj, exp, log, log2, log10, log1p,
         expm1, sqrt, square, sin, cos, tan, arcsin, arccos, arctan, arctan2,
         hypot, sinh, cosh, tanh, arcsinh, arccosh, arctanh, deg2rad, rad2deg,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -411,6 +411,11 @@ def map_blocks(func, *arrs, **kwargs):
     >>> def func(block, block_id=None):
     ...     pass
     """
+    if not callable(func):
+        raise TypeError("First argument must be callable function, not %s\n"
+                "Usage:   da.map_blocks(function, x)\n"
+                "   or:   da.map_blocks(function, x, y, z)" %
+                type(func).__name__)
     dtype = kwargs.get('dtype')
     chunks = kwargs.get('chunks')
     assert all(isinstance(arr, Array) for arr in arrs)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -377,7 +377,7 @@ def _concatenate2(arrays, axes=[]):
     return np.concatenate(arrays, axis=axes[0])
 
 
-def map_blocks(x, func, chunks=None, dtype=None):
+def map_blocks(func, *arrs, **kwargs):
     """ Map a function across all blocks of a dask array
 
     You must also specify the chunks of the resulting array.  If you don't then
@@ -385,45 +385,57 @@ def map_blocks(x, func, chunks=None, dtype=None):
     input.
 
     >>> import dask.array as da
-    >>> x = da.ones((8,), chunks=(4,))
+    >>> x = da.arange(6, chunks=3)
 
-    >>> np.array(x.map_blocks(lambda x: x + 1))
-    array([ 2.,  2.,  2.,  2.,  2.,  2.,  2.,  2.])
+    >>> x.map_blocks(lambda x: x + 1).compute()
+    array([ 0.,  2.,  4.,  6.,  8., 10.])
 
-    If function changes shape of the blocks provide a chunks
+    The ``da.map_blocks`` function can also accept multiple arrays
 
-    >>> y = x.map_blocks(lambda x: x[::2], chunks=(2,))
+    >>> d = da.arange(5, chunks=2)
+    >>> e = da.arange(5, chunks=2)
 
-    Or, if the result is ragged, provide a chunks
+    >>> f = map_blocks(lambda a, b: a + b**2, d, e)
+    >>> f.compute()
+    array([ 0,  2,  6, 12, 20])
+
+    If function changes shape of the blocks then please provide chunks
+    explicitly.
 
     >>> y = x.map_blocks(lambda x: x[::2], chunks=((2, 2),))
 
     Your block function can learn where in the array it is if it supports a
-    block_id keyword argument.  This will receive entries like (2, 0, 1), the
-    position of the block in the dask array.
+    ``block_id`` keyword argument.  This will receive entries like (2, 0, 1),
+    the position of the block in the dask array.
 
     >>> def func(block, block_id=None):
     ...     pass
     """
-    if not chunks:
-        chunks = x.chunks
-    elif not isinstance(chunks[0], tuple):
-        chunks = tuple([nb * (bs,)
-                            for nb, bs in zip(x.numblocks, chunks)])
+    dtype = kwargs.get('dtype')
+    chunks = kwargs.get('chunks')
+    assert all(isinstance(arr, Array) for arr in arrs)
+    inds = [tuple(range(x.ndim))[::-1] for x in arrs]
+    args = list(concat(zip(arrs, inds)))
 
-    name = next(names)
+    out = next(names)
+    out_ind = tuple(range(max(x.ndim for x in arrs)))[::-1]
 
+    result = atop(func, out, out_ind, *args, dtype=dtype)
+
+    # If func has block_id as an argument then swap out func
+    # for func with block_id partialed in
     try:
         spec = inspect.getargspec(func)
     except:
         spec = None
     if spec and 'block_id' in spec.args:
-        dsk = dict(((name,) + k[1:], (partial(func, block_id=k[1:]), k))
-                    for k in core.flatten(x._keys()))
-    else:
-        dsk = dict(((name,) + k[1:], (func, k)) for k in core.flatten(x._keys()))
+        for k in core.flatten(result._keys()):
+            result.dask[k] = (partial(func, block_id=k[1:]),) + result.dask[k][1:]
 
-    return Array(merge(dsk, x.dask), name, chunks, dtype=dtype)
+    if chunks is not None:
+        result.chunks = chunks
+
+    return result
 
 
 @wraps(np.squeeze)
@@ -886,7 +898,7 @@ class Array(object):
 
     @wraps(map_blocks)
     def map_blocks(self, func, chunks=None, dtype=None):
-        return map_blocks(self, func, chunks, dtype=dtype)
+        return map_blocks(func, self, chunks=chunks, dtype=dtype)
 
     def map_overlap(self, func, depth, boundary=None, trim=True, **kwargs):
         """ Map a function over blocks of the array with some overlap
@@ -1502,7 +1514,7 @@ modf.__doc__ = np.modf
 
 @wraps(np.around)
 def around(x, decimals=0):
-    return map_blocks(x, partial(np.around, decimals=decimals), dtype=x.dtype)
+    return map_blocks(partial(np.around, decimals=decimals), x, dtype=x.dtype)
 
 
 def isnull(values):
@@ -1829,32 +1841,3 @@ def concatenate3(arrays):
         result[idx] = arr
 
     return result
-
-
-def map_blocks_many(func, *arrs, **kwargs):
-    """ A variadic version of map_blocks
-
-    This accepts a function and multiple dask arrays.  It maps that function
-    across those dask arrays, respecting broadcasting rules in the event that
-    the arrays do not share the same dimension.
-
-    This does not offer some of the nice features of map_blocks like informing
-    the function of the ``block_id``
-
-    >>> import dask.array as da
-    >>> d = da.arange(5, chunks=2)
-    >>> e = da.arange(5, chunks=2)
-
-    >>> f = map_blocks_many(lambda a, b: a + b**2, d, e)
-    >>> f.compute()
-    array([ 0,  2,  6, 12, 20])
-    """
-    dtype = kwargs.get('dtype')
-    assert all(isinstance(arr, Array) for arr in arrs)
-    inds = [tuple(range(x.ndim))[::-1] for x in arrs]
-    args = list(concat(zip(arrs, inds)))
-
-    out = next(names)
-    out_ind = tuple(range(max(x.ndim for x in arrs)))[::-1]
-
-    return atop(func, out, out_ind, *args, dtype=dtype)

--- a/dask/array/ghost.py
+++ b/dask/array/ghost.py
@@ -161,7 +161,7 @@ def trim_internal(x, axes):
 
     chunks = tuple(olist)
 
-    return map_blocks(x, partial(chunk.trim, axes=axes), chunks=chunks)
+    return map_blocks(partial(chunk.trim, axes=axes), x, chunks=chunks)
 
 
 def periodic(x, axis, depth):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1041,3 +1041,20 @@ def test_concatenate3():
                          [ 9, 10, 11,  9, 10, 11,  9, 10, 11],
                          [ 6,  7,  8,  6,  7,  8,  6,  7,  8],
                          [ 9, 10, 11,  9, 10, 11,  9, 10, 11]]]))
+
+
+def test_map_blocks():
+    x = np.arange(10)
+    y = np.arange(10) * 2
+
+    d = da.from_array(x, chunks=5)
+    e = da.from_array(y, chunks=5)
+
+    assert eq(da.core.map_blocks_many(lambda a, b: a+2*b, d, e, dtype=d.dtype),
+              x + 2*y)
+
+    z = np.arange(100).reshape((10, 10))
+    f = da.from_array(z, chunks=5)
+
+    assert eq(da.core.map_blocks_many(lambda a, b: a+2*b, d, f, dtype=d.dtype),
+              x + 2*z)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1050,11 +1050,11 @@ def test_map_blocks():
     d = da.from_array(x, chunks=5)
     e = da.from_array(y, chunks=5)
 
-    assert eq(da.core.map_blocks_many(lambda a, b: a+2*b, d, e, dtype=d.dtype),
+    assert eq(da.core.map_blocks(lambda a, b: a+2*b, d, e, dtype=d.dtype),
               x + 2*y)
 
     z = np.arange(100).reshape((10, 10))
     f = da.from_array(z, chunks=5)
 
-    assert eq(da.core.map_blocks_many(lambda a, b: a+2*b, d, f, dtype=d.dtype),
+    assert eq(da.core.map_blocks(lambda a, b: a+2*b, d, f, dtype=d.dtype),
               x + 2*z)


### PR DESCRIPTION
This adds a multi-array `map_blocks` function to `dask.array`.  This doesn't yet do everything that the single-argument map_blocks function did (notably no support for `block_id` (does anyone use this?))

It's also a good example of using `atop` to solve an annoying problem.  Just a reminder to people that `atop` and `top` manage a lot of complex logic if you can drive them correctly.  I often forget about them.

```python
>>> import dask.array as da
>>> d = da.arange(5, chunks=2)
>>> e = da.arange(5, chunks=2)

>>> f = map_blocks_many(lambda a, b: a + b**2, d, e)
>>> f.compute()
array([ 0,  2,  6, 12, 20])
```

I would like eventually to merge this into the full `map_blocks` function.