### PR TITLE
Reductions support dtype= keyword argument

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -872,29 +872,29 @@ class Array(object):
         return argmax(self, axis=axis)
 
     @wraps(np.sum)
-    def sum(self, axis=None, keepdims=False):
+    def sum(self, axis=None, dtype=None, keepdims=False):
         from .reductions import sum
-        return sum(self, axis=axis, keepdims=keepdims)
+        return sum(self, axis=axis, dtype=dtype, keepdims=keepdims)
 
     @wraps(np.prod)
-    def prod(self, axis=None, keepdims=False):
+    def prod(self, axis=None, dtype=None, keepdims=False):
         from .reductions import prod
-        return prod(self, axis=axis, keepdims=keepdims)
+        return prod(self, axis=axis, dtype=dtype, keepdims=keepdims)
 
     @wraps(np.mean)
-    def mean(self, axis=None, keepdims=False):
+    def mean(self, axis=None, dtype=None, keepdims=False):
         from .reductions import mean
-        return mean(self, axis=axis, keepdims=keepdims)
+        return mean(self, axis=axis, dtype=dtype, keepdims=keepdims)
 
     @wraps(np.std)
-    def std(self, axis=None, keepdims=False, ddof=0):
+    def std(self, axis=None, dtype=None, keepdims=False, ddof=0):
         from .reductions import std
-        return std(self, axis=axis, keepdims=keepdims, ddof=ddof)
+        return std(self, axis=axis, dtype=dtype, keepdims=keepdims, ddof=ddof)
 
     @wraps(np.var)
-    def var(self, axis=None, keepdims=False, ddof=0):
+    def var(self, axis=None, dtype=None, keepdims=False, ddof=0):
         from .reductions import var
-        return var(self, axis=axis, keepdims=keepdims, ddof=ddof)
+        return var(self, axis=axis, dtype=dtype, keepdims=keepdims, ddof=ddof)
 
     def vnorm(self, ord=None, axis=None, keepdims=False):
         """ Vector norm """

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -53,3 +53,10 @@ def test_nan():
     assert eq(np.nanargmax(x, axis=0), da.nanargmax(d, axis=0))
     with ignoring(AttributeError):
         assert eq(np.nanprod(x), da.nanprod(d))
+
+
+def test_dtype():
+    x = np.array([[1, 1], [2, 2], [3, 3]], dtype='i1')
+    d = da.from_array(x, chunks=2)
+
+    assert eq(d.sum(dtype='i1', axis=1), x.sum(dtype='i1', axis=1))


### PR DESCRIPTION
This follows the NumPy API to enable users to specify the output dtype
of reduction operations.

Example
-------

```python
In [1]: import dask.array as da

In [2]: x = da.ones((4, 4), chunks=2)

In [3]: x.sum(axis=1, dtype='i1')
Out[3]: dask.array<x_2, shape=(4,), chunks=((2, 2)), dtype=int8>

In [4]: x.sum(axis=1, dtype='i1').compute()
Out[4]: array([4, 4, 4, 4], dtype=int8)
```

Fixes #270  cc @alimanfoo 