### PR TITLE
Support negative axes in reductions

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -20,6 +20,7 @@ def reduction(x, chunk, aggregate, axis=None, keepdims=None, dtype=None):
         axis = tuple(range(x.ndim))
     if isinstance(axis, int):
         axis = (axis,)
+    axis = tuple(i if i >= 0 else x.ndim + i for i in axis)
 
     chunk2 = partial(chunk, axis=axis, keepdims=True)
     aggregate2 = partial(aggregate, axis=axis, keepdims=keepdims)
@@ -288,6 +289,9 @@ def arg_reduction(a, func, argfunc, axis=0, dtype=None):
                 "For example:\n"
                 "  Before:  x.argmin()\n"
                 "  After:   x.argmin(axis=0)\n")
+
+    if axis < 0:
+        axis = a.ndim + axis
 
     def argreduce(x):
         """ Get both min/max and argmin/argmax of each block """

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -33,8 +33,16 @@ def test_reductions():
 
     assert eq(a.argmin(axis=1), x.argmin(axis=1))
     assert eq(a.argmax(axis=0), x.argmax(axis=0))
-    # assert eq(a.argmin(), x.argmin())
 
+
+def test_reductions_with_negative_axes():
+    x = np.random.random((4, 4, 4))
+    a = da.from_array(x, chunks=2)
+
+    assert eq(a.argmin(axis=-1), x.argmin(axis=-1))
+
+    assert eq(a.sum(axis=-1), x.sum(axis=-1))
+    assert eq(a.sum(axis=(0, -1)), x.sum(axis=(0, -1)))
 
 def test_nan():
     x = np.array([[1, np.nan, 3, 4],


### PR DESCRIPTION
Examples
--------

```python
>>> x.sum(axis=-1)
>>> x.sum(axis=(-1, 2))
```

Fixes #264 cc @alimanfoo