### PR TITLE
map_blocks supports chunks as blockshape

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -417,8 +417,8 @@ def map_blocks(func, *arrs, **kwargs):
                 "   or:   da.map_blocks(function, x, y, z)" %
                 type(func).__name__)
     dtype = kwargs.get('dtype')
-    chunks = kwargs.get('chunks')
     assert all(isinstance(arr, Array) for arr in arrs)
+
     inds = [tuple(range(x.ndim))[::-1] for x in arrs]
     args = list(concat(zip(arrs, inds)))
 
@@ -437,6 +437,11 @@ def map_blocks(func, *arrs, **kwargs):
         for k in core.flatten(result._keys()):
             result.dask[k] = (partial(func, block_id=k[1:]),) + result.dask[k][1:]
 
+    # Assert user specified chunks
+    chunks = kwargs.get('chunks')
+    if chunks is not None and chunks and not isinstance(chunks[0], tuple):
+        chunks = tuple([nb * (bs,)
+                        for nb, bs in zip(result.numblocks, chunks)])
     if chunks is not None:
         result.chunks = chunks
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1043,7 +1043,7 @@ def test_concatenate3():
                          [ 9, 10, 11,  9, 10, 11,  9, 10, 11]]]))
 
 
-def test_map_blocks():
+def test_map_blocks3():
     x = np.arange(10)
     y = np.arange(10) * 2
 


### PR DESCRIPTION
This allows the use of 

```python
>>> x.map_blocks(func, chunks=(1, 2, 3))
```

Rather than requiring the entire chunks tuple-of-tuples (which is hard to produce).  This assumes uniform chunk size.  This was actually a regression from #261 . 