### PR TITLE
Pseudorandom dataframe split

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -24,7 +24,7 @@ from ..array.core import partial_by_order
 from ..async import get_sync
 from ..threaded import get as get_threaded
 from ..compatibility import unicode, apply
-from ..utils import repr_long_list, IndexCallable
+from ..utils import repr_long_list, IndexCallable, pseudorandom
 
 
 def _concat(args):
@@ -153,6 +153,28 @@ class _Frame(object):
 
         return type(self)(merge(dsk, self.dask), name,
                           columns, self.divisions)
+
+    def random_split(self, p, seed=None):
+        """ Pseudorandomly split dataframe into different pieces row-wise
+
+        50/50 split
+        >>> a, b = df.random_split([0.5, 0.5])  # doctest: +SKIP
+
+        80/10/10 split, consistent seed
+        >>> a, b = df.random_split([0.8, 0.1, 0.1], seed=123)  # doctest: +SKIP
+        """
+        if seed is not None:
+            np.random.seed(seed)
+        seeds = np.random.randint(0, 2**31, self.npartitions)
+        dsks = [dict(((self._name + '-split-%d' % i, j),
+                      (pd_split, (self._name, j), p, i, seed))
+                      for j, seed in enumerate(seeds))
+                      for i in range(len(p))]
+        return [type(self)(merge(self.dask, dsk),
+                           self._name + '-split-%d' % i,
+                           self.column_info,
+                           self.divisions)
+                for i, dsk in enumerate(dsks)]
 
     def head(self, n=10, compute=True):
         """ First n rows of the dataset
@@ -454,11 +476,11 @@ class DataFrame(_Frame):
     def __getattr__(self, key):
         try:
             return object.__getattribute__(self, key)
-        except AttributeError:
+        except AttributeError as e:
             try:
                 return self[key]
             except NotImplementedError:
-                raise AttributeError()
+                raise e
 
     def __dir__(self):
         return sorted(set(list(dir(type(self))) + list(self.columns)))
@@ -803,6 +825,28 @@ def get(dsk, keys, get=get_sync, **kwargs):
     from .optimize import optimize
     dsk2 = optimize(dsk, keys, **kwargs)
     return get(dsk2, keys, **kwargs)  # use synchronous scheduler for now
+
+
+def pd_split(df, p, ind, seed=0):
+    """ Split DataFrame into multiple pieces pseudorandomly
+
+    >>> df = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6],
+    ...                    'b': [2, 3, 4, 5, 6, 7]})
+
+    >>> pd_split(df, [0.5, 0.5], 0, seed=123)  # roughly 50/50 split
+       a  b
+    1  2  3
+    2  3  4
+    5  6  7
+
+    >>> pd_split(df, [0.5, 0.5], 1, seed=123)  # roughly 50/50 split
+       a  b
+    0  1  2
+    3  4  5
+    4  5  6
+    """
+    index = pseudorandom(len(df), p, seed)
+    return df.iloc[index == ind]
 
 
 from .shuffle import set_index, set_partition

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -161,7 +161,7 @@ class _Frame(object):
         >>> a, b = df.random_split([0.5, 0.5])  # doctest: +SKIP
 
         80/10/10 split, consistent seed
-        >>> a, b = df.random_split([0.8, 0.1, 0.1], seed=123)  # doctest: +SKIP
+        >>> a, b, c = df.random_split([0.8, 0.1, 0.1], seed=123)  # doctest: +SKIP
         """
         if seed is not None:
             np.random.seed(seed)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -7,7 +7,7 @@ import numpy as np
 import dask
 from dask.utils import raises
 import dask.dataframe as dd
-from dask.dataframe.core import get, concat
+from dask.dataframe.core import get, concat, pd_split
 
 
 def eq(a, b):
@@ -372,3 +372,11 @@ def test_dataframe_series_are_dillable():
     e = d.groupby(d.a).b.sum()
     f = dill.loads(dill.dumps(e))
     assert eq(e, f)
+
+
+def test_random_partitions():
+    a, b = d.random_split([0.5, 0.5])
+    assert isinstance(a, dd.DataFrame)
+    assert isinstance(b, dd.DataFrame)
+
+    assert len(a.compute()) + len(b.compute()) == len(full)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -193,3 +193,26 @@ def concrete(seq):
 
 def skip(func):
     pass
+
+
+def pseudorandom(n, p, key):
+    """ Pseudorandom array of integer indexes
+
+    >>> pseudorandom(5, [0.5, 0.5], key=123)
+    array([1, 0, 0, 1, 1], dtype=int8)
+
+    >>> pseudorandom(10, [0.5, 0.2, 0.2, 0.1], key=5)
+    array([0, 2, 0, 3, 0, 1, 2, 1, 0, 0], dtype=int8)
+    """
+    import numpy as np
+    cp = np.cumsum([0] + list(p))
+    assert np.allclose(1, cp[-1])
+    assert len(p) < 256
+
+    np.random.seed(key)
+    x = np.random.random(n)
+    out = np.empty(n, dtype='i1')
+
+    for i, (low, high) in enumerate(zip(cp[:-1], cp[1:])):
+        out[(x >= low) & (x < high)] = i
+    return out

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -205,7 +205,8 @@ def pseudorandom(n, p, key):
     array([0, 2, 0, 3, 0, 1, 2, 1, 0, 0], dtype=int8)
     """
     import numpy as np
-    cp = np.cumsum([0] + list(p))
+    p = list(p)
+    cp = np.cumsum([0] + p)
     assert np.allclose(1, cp[-1])
     assert len(p) < 256
 


### PR DESCRIPTION
Fixes #252 

This adds a `random_split` method to `dask.dataframe.DataFrame` that partitions a dataframe into multiple disjoint parts.  One can specify a preferred split (e.g. 80/20 or 33/33/34) as a list of fractions.

Example
------

```python
In [1]: import dask.dataframe as dd

In [2]: df = dd.read_csv('trip_data_1_*.csv')

In [3]: a, b = df.random_split([0.9, 0.1])  # 90/10 split

In [4]: a.head(3)
Out[4]: 
                          medallion                      hack_license  \
0  89D227B655E5C82AECF13C3F540D4CF4  BA96DE419E711691B9445D6A6307C170   
1  0BD7C8F5BA12B88E0B67BED28BEA73D8  9FD8F69F0804BDB5549F40E9DA1BE472   
2  0BD7C8F5BA12B88E0B67BED28BEA73D8  9FD8F69F0804BDB5549F40E9DA1BE472   

  vendor_id  rate_code store_and_fwd_flag      pickup_datetime  \
0       CMT          1                  N  2013-01-01 15:11:48   
1       CMT          1                  N  2013-01-06 00:18:35   
2       CMT          1                  N  2013-01-05 18:49:41   

      dropoff_datetime  passenger_count  trip_time_in_secs  trip_distance  \
0  2013-01-01 15:18:10                4                382            1.0   
1  2013-01-06 00:22:54                1                259            1.5   
2  2013-01-05 18:54:23                1                282            1.1   

   pickup_longitude  pickup_latitude  dropoff_longitude  dropoff_latitude  
0        -73.978165        40.757977         -73.989838         40.751171  
1        -74.006683        40.731781         -73.994499         40.750660  
2        -74.004707        40.737770         -74.009834         40.726002  

In [5]: b.head(3)
Out[5]: 
                           medallion                      hack_license  \
5   20D9ECB2CA0767CF7A01564DF2844A3E  598CCE5B9C1918568DEE71F43CF26CD2   
34  7E3256C342CAFB3C23D3ABB98B9F3FB6  4F7873C913735088F9BEF85C1D054D31   
59  82420BD631D2BB88E2F213A8CA15BECE  213779F7AA40E58009B3457E3FA7089D   

   vendor_id  rate_code store_and_fwd_flag      pickup_datetime  \
5        CMT          1                  N  2013-01-07 15:27:48   
34       CMT          1                  N  2013-01-05 03:00:46   
59       CMT          1                  N  2013-01-08 10:38:22   

       dropoff_datetime  passenger_count  trip_time_in_secs  trip_distance  \
5   2013-01-07 15:38:37                1                648            1.7   
34  2013-01-05 03:23:28                1               1361            5.5   
59  2013-01-08 10:56:19                1               1076            3.1   

    pickup_longitude  pickup_latitude  dropoff_longitude  dropoff_latitude  
5         -73.966743        40.764252         -73.983322         40.743763  
34        -73.965500        40.711113         -73.918327         40.758671  
59        -73.967682        40.751221         -73.995232         40.717422  
```

The resulting split dataframes share the same graph so, if you compute them together you'll benefit from single pass computation (depending on the scheduler handling this well.)

cc @diehl

cc @jreback you might find the pd_split function of use