### PR TITLE
Randomized/compressed SVD implementation

### DIFF
--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -219,6 +219,10 @@ def svd_compressed(data, q, n_power_iter=0, name=None):
         pp. 217-288, June 2011
         http://arxiv.org/abs/0909.4061
 
+    Examples
+    --------
+    >>> u, s, vt = svd_compressed(x, 20)  # doctest: +SKIP
+
     Parameters
     ----------
 
@@ -227,16 +231,23 @@ def svd_compressed(data, q, n_power_iter=0, name=None):
     because of oversampling)
     n_power_iter: number of power iterations, useful when the singular
     values of the input matrix decay very slowly.
+
+    Returns
+    -------
+
+    u:  Array, unitary / orthogonal
+    s:  Array, singular values in decreasing order (largest first)
+    vt:  Array, unitary / orthogonal
     """
     comp = compression_matrix(data, q, n_power_iter=n_power_iter)
     data_compressed = comp.dot(data)
-    v, s, ut = tsqr(data_compressed.T, name, compute_svd=True)
-    u = comp.T.dot(ut)
-    vt = v.T
+    v, s, u = tsqr(data_compressed.T, name, compute_svd=True)
+    u = comp.T.dot(u)
+    v = v.T
     u = u[:, :q]
     s = s[:q]
-    vt = vt[:q, :]
-    return u, s, vt
+    v = v[:q, :]
+    return u, s, v
 
 
 def qr(data, name=None):

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -176,7 +176,7 @@ def compression_matrix(data, q, n_power_iter=0):
 
     As presented in:
 
-        A. Benson, D. Gleich, and J. Demmel.
+        N. Halko, P. G. Martinsson, and J. A. Tropp.
         Finding structure with randomness: Probabilistic algorithms for
         constructing approximate matrix decompositions.
         SIAM Rev., Survey and Review section, Vol. 53, num. 2,
@@ -212,7 +212,7 @@ def svd_compressed(data, q, n_power_iter=0, name=None):
 
     As presented in:
 
-        A. Benson, D. Gleich, and J. Demmel.
+        N. Halko, P. G. Martinsson, and J. A. Tropp.
         Finding structure with randomness: Probabilistic algorithms for
         constructing approximate matrix decompositions.
         SIAM Rev., Survey and Review section, Vol. 53, num. 2,

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -63,14 +63,14 @@ def tsqr(data, name=None, compute_svd=False):
                      numblocks={data.name: numblocks})
     # qr[0]
     name_q_st1 = prefix + 'Q_st1'
-    dsk_q_st1 = dict(((name_q_st1, i, 0),
-                      (operator.getitem, (name_qr_st1, i, 0), 0))
-                     for i in range(numblocks[0]))
+    dsk_q_st1 = {((name_q_st1, i, 0),
+                  (operator.getitem, (name_qr_st1, i, 0), 0))
+                 for i in range(numblocks[0])}
     # qr[1]
     name_r_st1 = prefix + 'R_st1'
-    dsk_r_st1 = dict(((name_r_st1, i, 0),
-                      (operator.getitem, (name_qr_st1, i, 0), 1))
-                     for i in range(numblocks[0]))
+    dsk_r_st1 = {((name_r_st1, i, 0),
+                  (operator.getitem, (name_qr_st1, i, 0), 1))
+                 for i in range(numblocks[0])}
 
     # Stacking for in-core QR computation
     to_stack = [(name_r_st1, i, 0) for i in range(numblocks[0])]
@@ -89,9 +89,9 @@ def tsqr(data, name=None, compute_svd=False):
     block_slices = [(slice(e[0], e[1]), slice(0, n))
                     for e in _cumsum_blocks(q2_block_sizes)]
     name_q_st2 = prefix + 'Q_st2'
-    dsk_q_st2 = dict(((name_q_st2,) + (i, 0),
-                      (operator.getitem, (name_q_st2_aux, 0, 0), b))
-                     for i, b in enumerate(block_slices))
+    dsk_q_st2 = {((name_q_st2,) + (i, 0),
+                  (operator.getitem, (name_q_st2_aux, 0, 0), b))
+                 for i, b in enumerate(block_slices)}
     # qr[1]
     name_r_st2 = prefix + 'R'
     dsk_r_st2 = {(name_r_st2, 0, 0): (operator.getitem, (name_qr_st2, 0, 0), 1)}

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -264,7 +264,7 @@ def svd_compressed(a, k, n_power_iter=0, name=None):
 
     u:  Array, unitary / orthogonal
     s:  Array, singular values in decreasing order (largest first)
-    vt:  Array, unitary / orthogonal
+    v:  Array, unitary / orthogonal
     """
     comp = compression_matrix(a, k, n_power_iter=n_power_iter)
     a_compressed = comp.dot(a)
@@ -277,7 +277,7 @@ def svd_compressed(a, k, n_power_iter=0, name=None):
     return u, s, v
 
 
-def qr(data, name=None):
+def qr(a, name=None):
     """
     Compute the qr factorization of a matrix.
 
@@ -298,10 +298,10 @@ def qr(data, name=None):
     np.linalg.qr : Equivalent NumPy Operation
     dask.array.linalg.tsqr: Actual implementation with citation
     """
-    return tsqr(data, name)
+    return tsqr(a, name)
 
 
-def svd(data, name=None):
+def svd(a, name=None):
     """
     Compute the singular value decomposition of a matrix.
 
@@ -323,4 +323,4 @@ def svd(data, name=None):
     np.linalg.svd : Equivalent NumPy Operation
     dask.array.linalg.tsqr: Actual implementation with citation
     """
-    return tsqr(data, name, compute_svd=True)
+    return tsqr(a, name, compute_svd=True)

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -201,7 +201,7 @@ def compression_matrix(data, q, n_power_iter=0):
 
     data: Array
     q: Size of the desired subspace (the actual size will be bigger,
-    because of oversampling, see :func:`~linalg.compression_level`)
+    because of oversampling, see linalg.compression_level)
     n_power_iter: number of power iterations, useful when the singular
     values of the input matrix decay very slowly.
     """

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -169,14 +169,15 @@ def tsqr(data, name=None, compute_svd=False):
 def compression_level(n, q, oversampling=10, min_subspace_size=20):
     """ Compression level to use in svd_compressed
 
-    Given the size ``n`` of a space, compress that that to one of size ``q``
-    plus oversampling.
+    Given the size ``n`` of a space, compress that that to one of size
+    ``q`` plus oversampling.
 
-    The oversampling allows for greater flexibility in finding an appropriate
-    subspace, a low value is often enough (10 is already a very conservative
-    choice, it can be further reduced).  ``q + oversampling`` should not be
-    larger than ``n``.  In this specific implementation, ``q + oversampling``
-    is at least ``min_subspace_size``.
+    The oversampling allows for greater flexibility in finding an
+    appropriate subspace, a low value is often enough (10 is already a
+    very conservative choice, it can be further reduced).
+    ``q + oversampling`` should not be larger than ``n``.  In this
+    specific implementation, ``q + oversampling`` is at least
+    ``min_subspace_size``.
 
     >>> compression_level(100, 10)
     20
@@ -196,11 +197,11 @@ def compression_matrix(data, q, n_power_iter=0):
 
     data: Array
     q: int
-        Size of the desired subspace (the actual size will be bigger, because
-        of oversampling, see ``da.linalg.compression_level``)
+        Size of the desired subspace (the actual size will be bigger,
+        because of oversampling, see ``da.linalg.compression_level``)
     n_power_iter: int
-        number of power iterations, useful when the singular values of the
-        input matrix decay very slowly.
+        number of power iterations, useful when the singular values of
+        the input matrix decay very slowly.
 
     Algorithm Citation
     ------------------
@@ -228,9 +229,9 @@ def svd_compressed(a, k, n_power_iter=0, name=None):
     """ Randomly compressed rank-k thin Singular Value Decomposition.
 
     This computes the approximate singular value decomposition of a large
-    array.  This algorithm is generally faster than the normal algorithm but
-    does not provide exact results.  One can balance between performance and
-    accuracy with input parameters (see below).
+    array.  This algorithm is generally faster than the normal algorithm
+    but does not provide exact results.  One can balance between
+    performance and accuracy with input parameters (see below).
 
     Parameters
     ----------
@@ -240,9 +241,9 @@ def svd_compressed(a, k, n_power_iter=0, name=None):
     k: int
         Rank of the desired thin SVD decomposition.
     n_power_iter: int
-        Number of power iterations, useful when the singular values decay
-        slowly. Error decreases exponentially as n_power_iter increases. In
-        practice, set n_power_iter <= 4.
+        Number of power iterations, useful when the singular values
+        decay slowly. Error decreases exponentially as n_power_iter
+        increases. In practice, set n_power_iter <= 4.
 
     Algorithm Citation
     ------------------

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -166,8 +166,13 @@ def tsqr(data, name=None, compute_svd=False):
         return u, s, v
 
 
-def compression_level(n, q):
-    return min(max(20, q + 10), n)
+def compression_level(n, q, oversampling=10):
+    """ Given the size n of a space, compress that that to one of
+    size q plus oversampling.
+    q + oversampling should not be larger that n.
+    In this specific implementation, q + oversampling is at least 20.
+    """
+    return min(max(20, q + oversampling), n)
 
 
 def compression_matrix(data, q, n_power_iter=0):

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -62,14 +62,14 @@ def tsqr(data, name=None, compute_svd=False):
                      numblocks={data.name: numblocks})
     # qr[0]
     name_q_st1 = prefix + 'Q_st1'
-    dsk_q_st1 = {((name_q_st1, i, 0),
-                  (operator.getitem, (name_qr_st1, i, 0), 0))
-                 for i in range(numblocks[0])}
+    dsk_q_st1 = dict(((name_q_st1, i, 0),
+                      (operator.getitem, (name_qr_st1, i, 0), 0))
+                     for i in range(numblocks[0]))
     # qr[1]
     name_r_st1 = prefix + 'R_st1'
-    dsk_r_st1 = {((name_r_st1, i, 0),
-                  (operator.getitem, (name_qr_st1, i, 0), 1))
-                 for i in range(numblocks[0])}
+    dsk_r_st1 = dict(((name_r_st1, i, 0),
+                      (operator.getitem, (name_qr_st1, i, 0), 1))
+                     for i in range(numblocks[0]))
 
     # Stacking for in-core QR computation
     to_stack = [(name_r_st1, i, 0) for i in range(numblocks[0])]

--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -204,8 +204,7 @@ def compression_matrix(data, q, n_power_iter=0):
     for j in range(n_power_iter):
         mat_h = data.dot(data.T.dot(mat_h))
     q, _ = tsqr(mat_h)
-    comp = q.T
-    return comp
+    return q.T
 
 
 def svd_compressed(data, q, n_power_iter=0, name=None):

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -48,7 +48,7 @@ def test_tsqr_svd_regular_blocks():
     vt = np.array(vt)
     usvt = np.dot(u, np.dot(np.diag(s), vt))
 
-    s_exact = np.linalg.svd(mat2)[1]
+    s_exact = np.linalg.svd(mat)[1]
 
     assert np.allclose(mat, usvt)  # accuracy check
     assert np.allclose(np.eye(n, n), np.dot(u.T, u))  # u must be orthonormal
@@ -85,7 +85,6 @@ def test_svd_compressed():
     data = from_array(mat, chunks=(10, 10), name='A')
 
     n_iter = int(1e2)
-    usvt = None
     for i in range(n_iter):
         u, s, vt = svd_compressed(data, r)
         u = u[:, :r]
@@ -94,7 +93,7 @@ def test_svd_compressed():
         u = np.array(u)
         s = np.array(s)
         vt = np.array(vt)
-        if usvt is None:
+        if i == 0:
             usvt = np.dot(u, np.dot(np.diag(s), vt))
         else:
             usvt += np.dot(u, np.dot(np.diag(s), vt))
@@ -118,5 +117,5 @@ def test_svd_compressed():
     assert np.allclose(s, s_exact)  # s must contain the singular values
 
 
-# if __name__ == '__main__':
-#     test_svd_compressed()
+if __name__ == '__main__':
+    test_svd_compressed()

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
-# import pytest
-# pytest.importorskip('numpy')
+import pytest
+pytest.importorskip('numpy')
 
 import numpy as np
 from dask.array import from_array
@@ -115,7 +115,3 @@ def test_svd_compressed():
     assert np.allclose(np.eye(r, r), np.dot(u.T, u))  # u must be orthonormal
     assert np.allclose(np.eye(r, r), np.dot(vt, vt.T))  # v must be orthonormal
     assert np.allclose(s, s_exact)  # s must contain the singular values
-
-
-if __name__ == '__main__':
-    test_svd_compressed()

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -87,9 +87,6 @@ def test_svd_compressed():
     n_iter = int(1e2)
     for i in range(n_iter):
         u, s, vt = svd_compressed(data, r)
-        u = u[:, :r]
-        s = s[:r]
-        vt = vt[:r, :]
         u = np.array(u)
         s = np.array(s)
         vt = np.array(vt)

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -84,7 +84,7 @@ def test_svd_compressed():
     mat = mat1.dot(mat2)
     data = from_array(mat, chunks=(10, 10), name='A')
 
-    n_iter = int(1e2)
+    n_iter = 100
     for i in range(n_iter):
         u, s, vt = svd_compressed(data, r)
         u = np.array(u)


### PR DESCRIPTION
- It provides an approximation of the true analytical SVD.
- Using the subsampled Fourier or Hadamard transforms, instead of a Gaussian random matrix, would significantly improve the method's performance.
- Should we create a function called 'thin_svd' that acts like the 'svd' function, providing a generic interface for alternative rank-k SVD implementations?