### PR TITLE
Added diag to dask array

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -25,4 +25,4 @@ from .wrap import ones, zeros, empty, full
 from .rechunk import rechunk
 from ..context import set_options
 from .optimization import optimize
-from .creation import arange, linspace
+from .creation import arange, linspace, diag

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -149,7 +149,9 @@ def arange(*args, **kwargs):
 def diag(v):
     """Construct a diagonal array, with ``v`` on the diagonal.
 
-    TODO: implement diagonal extraction, and the ``k``th diagonal keyword arg.
+    Currently only implements diagonal array creation on the zeroth diagonal.
+    Support for the ``k``th diagonal or diagonal extraction, as per the numpy
+    interface, is not yet implemented.
 
     Parameters
     ----------
@@ -158,6 +160,14 @@ def diag(v):
     Returns
     -------
     out_array : dask array
+
+    Examples
+    --------
+
+    >>> diag(arange(3, chunks=3)).compute()
+    array([[0, 0, 0],
+           [0, 1, 0],
+           [0, 0, 2]])
     """
     if not isinstance(v, Array):
         raise TypeError("v must be a dask array")

--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -186,4 +186,4 @@ def diag(v):
                 dsk[key] = (np.diag, blocks[i])
             else:
                 dsk[key] = (np.zeros, (m, n))
-    return Array(dsk, name, (chunks_1d, chunks_1d), dtype=v.dtype)
+    return Array(dsk, name, (chunks_1d, chunks_1d), dtype=v._dtype)

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -94,3 +94,20 @@ def test_arange_float_step():
     darr = da.arange(7.7, 1.5, -.8, chunks=3)
     nparr = np.arange(7.7, 1.5, -.8)
     eq(darr, nparr)
+
+
+def test_diag():
+    v = da.arange(11, chunks=3)
+    darr = da.diag(v)
+    nparr = np.diag(v)
+    eq(darr, nparr)
+
+    v = v + v + 3
+    darr = da.diag(v)
+    nparr = np.diag(v)
+    eq(darr, nparr)
+
+    v = da.arange(11, chunks=11)
+    darr = da.diag(v)
+    nparr = np.diag(v)
+    eq(darr, nparr)


### PR DESCRIPTION
Allows for creating diagonal arrays from a 1d dask array. Support for
the ``k``th diagonal kwarg, or diagonal extraction (as provided by the
numpy interface) is not yet supported.

Fixes #285.