### PR TITLE
Raise NotImplementedError when operating with numpy arrays 

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1416,16 +1416,11 @@ def elemwise(op, *args, **kwargs):
                    for arg in args)
     expr_inds = tuple(range(out_ndim))[::-1]
 
-    arrays = []
-    other = []
-    for i, arg in enumerate(args):
-        if isinstance(arg, np.ndarray):
-            raise NotImplementedError
-        elif isinstance(arg, Array):
-            arrays.append(arg)
-        else:
-            other.append((i, arg))
-
+    arrays = [arg for arg in args if isinstance(arg, Array)]
+    other = [(i, a) for i, a in enumerate(args) if not isinstance(a, Array)]
+    if any(isinstance(arg, np.ndarray) for arg in args):
+        raise NotImplementedError("Dask.array operations only work on dask "
+                                  "arrays, not numpy arrays.")
     if 'dtype' in kwargs:
         dt = kwargs['dtype']
     elif not all(a._dtype is not None for a in arrays):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1416,8 +1416,15 @@ def elemwise(op, *args, **kwargs):
                    for arg in args)
     expr_inds = tuple(range(out_ndim))[::-1]
 
-    arrays = [arg for arg in args if isinstance(arg, Array)]
-    other = [(i, arg) for i, arg in enumerate(args) if not isinstance(arg, Array)]
+    arrays = []
+    other = []
+    for i, arg in enumerate(args):
+        if isinstance(arg, np.ndarray):
+            raise NotImplementedError
+        elif isinstance(arg, Array):
+            arrays.append(arg)
+        else:
+            other.append((i, arg))
 
     if 'dtype' in kwargs:
         dt = kwargs['dtype']

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -7,6 +7,7 @@ from operator import add
 
 from toolz import merge
 from toolz.curried import identity
+from numpy.testing import assert_raises
 
 import dask
 import dask.array as da
@@ -1058,3 +1059,10 @@ def test_map_blocks3():
 
     assert eq(da.core.map_blocks(lambda a, b: a+2*b, d, f, dtype=d.dtype),
               x + 2*z)
+
+
+def test_numpy_compat_is_notimplemented():
+    a = np.arange(10)
+    x = da.from_array(a, chunks=5)
+
+    assert_raises(NotImplementedError, add, x, a)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -692,7 +692,7 @@ def test_dtype_complex():
     assert eq(b.std()._dtype, b.std().dtype)
     assert eq(a.argmin(axis=0)._dtype, a.argmin(axis=0).dtype)
 
-    assert eq(da.sin(z)._dtype, np.sin(c).dtype)
+    assert eq(da.sin(c)._dtype, np.sin(z).dtype)
     assert eq(da.exp(b)._dtype, np.exp(y).dtype)
     assert eq(da.floor(a)._dtype, np.floor(x).dtype)
     assert eq(da.isnan(b)._dtype, np.isnan(y).dtype)


### PR DESCRIPTION
Closes #290

This also fixes a test which had the numpy array and dask array flipped.