### PR TITLE
Fix py2.7 always passing on travis bug.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,10 @@ install:
   - python setup.py install
 
 script:
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then coverage run $(which py.test) dask pframe pbag --doctest-modules --verbose; coverage report --show-missing; else py.test dask pframe pbag --verbose; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then coverage run $(which py.test) dask pframe pbag --doctest-modules --verbose; else py.test dask pframe pbag --verbose; fi
 
 after_success:
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install coveralls ; coveralls ; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then coverage report --show-missing; pip install coveralls ; coveralls ; fi
 
 notifications:
   email: false


### PR DESCRIPTION
In this travis-ci run you can see that the py2.7 build fails with this patch. (and a deliberately failing test).

https://travis-ci.org/cowlicks/dask/jobs/66322652

And in this build you can see that coverage is still working. Coveralls fails to upload but that is because travis is building from my fork.

https://travis-ci.org/cowlicks/dask/jobs/66323148#L1040