### PR TITLE
Stable parallel computation of generalized moments

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -906,18 +906,18 @@ class Array(object):
         Parameters
         ----------
         order : int
-            Order of the moment that is returned
+            Order of the moment that is returned, must be >= 2.
         axis : int, optional
             Axis along which the central moment is computed. The default is to
             compute the moment of the flattened array.
         dtype : data-type, optional
             Type to use in computing the moment. For arrays of integer type the
-            default is float32; for arrays of float types it is the same as the
+            default is float64; for arrays of float types it is the same as the
             array type.
         keepdims : bool, optional
             If this is set to True, the axes which are reduced are left in the
             result as dimensions with size one. With this option, the result
-            will broadcast correctly against the original arr.
+            will broadcast correctly against the original array.
         ddof : int, optional
             "Delta Degrees of Freedom": the divisor used in the calculation is
             N - ddof, where N represents the number of elements. By default

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -900,6 +900,37 @@ class Array(object):
         from .reductions import var
         return var(self, axis=axis, dtype=dtype, keepdims=keepdims, ddof=ddof)
 
+    def moment(self, order, axis=None, dtype=None, keepdims=False, ddof=0):
+        """Calculate the nth centralized moment.
+
+        Parameters
+        ----------
+        order : int
+            Order of the moment that is returned
+        axis : int, optional
+            Axis along which the central moment is computed. The default is to
+            compute the moment of the flattened array.
+        dtype : data-type, optional
+            Type to use in computing the moment. For arrays of integer type the
+            default is float32; for arrays of float types it is the same as the
+            array type.
+        keepdims : bool, optional
+            If this is set to True, the axes which are reduced are left in the
+            result as dimensions with size one. With this option, the result
+            will broadcast correctly against the original arr.
+        ddof : int, optional
+            "Delta Degrees of Freedom": the divisor used in the calculation is
+            N - ddof, where N represents the number of elements. By default
+            ddof is zero.
+
+        Returns
+        -------
+        moment : ndarray
+        """
+
+        from .reductions import moment
+        return moment(self, order, axis=axis, dtype=dtype, keepdims=keepdims, ddof=ddof)
+
     def vnorm(self, ord=None, axis=None, keepdims=False):
         """ Vector norm """
         from .reductions import vnorm

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -926,6 +926,13 @@ class Array(object):
         Returns
         -------
         moment : ndarray
+
+        References
+        ----------
+        .. [1] Pebay, Philippe (2008), "Formulas for Robust, One-Pass Parallel
+        Computation of Covariances and Arbitrary-Order Statistical Moments"
+        (PDF), Technical Report SAND2008-6212, Sandia National Laboratories
+        
         """
 
         from .reductions import moment

--- a/dask/array/numpy_compat.py
+++ b/dask/array/numpy_compat.py
@@ -17,3 +17,37 @@ except AttributeError:
                                       "to Numpy 1.8 or greater for support.")
         return np.multiply(fill_value, np.ones(shape, dtype=dtype),
                            dtype=dtype)
+
+
+# Taken from scikit-learn:
+# https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/utils/fixes.py#L84
+try:
+    if (not np.allclose(np.divide(.4, 1, casting="unsafe"),
+                        np.divide(.4, 1, casting="unsafe", dtype=np.float))
+            or not np.allclose(np.divide(.4, 1), .4)):
+        raise TypeError('Divide not working with dtype: '
+                        'https://github.com/numpy/numpy/issues/3484')
+    divide = np.divide
+
+except TypeError:
+    # Divide with dtype doesn't work on Python 3
+    def divide(x1, x2, out=None, dtype=None):
+        """Implementation of numpy.divide that works with dtype kwarg.
+
+        Temporary compatibility fix for a bug in numpy's version. See
+        https://github.com/numpy/numpy/issues/3484 for the relevant issue."""
+
+        out_orig = out
+        if out is None:
+            out = np.asarray(x1, dtype=dtype)
+            if out is x1:
+                out = x1.copy()
+        else:
+            if out is not x1:
+                out[:] = x1
+        if dtype is not None and out.dtype != dtype:
+            out = out.astype(dtype)
+        out /= x2
+        if out_orig is None and np.isscalar(x1):
+            out = np.asscalar(out)
+        return out

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -258,6 +258,8 @@ def moment_agg(data, order=2, ddof=0, dtype='f8', **kwargs):
 
 
 def moment(a, order, axis=None, dtype=None, keepdims=False, ddof=0):
+    if not isinstance(order, int) or order < 2:
+        raise ValueError("Order must be an integer >= 2")
     if dtype is not None:
         dt = dtype
     elif a._dtype is not None:

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 from functools import partial, wraps
+from math import factorial
 from toolz import compose, curry
 import inspect
 
@@ -10,6 +11,14 @@ from .slicing import insert_many
 from ..core import flatten
 from . import chunk
 from ..utils import ignoring
+
+
+def getargspec(func):
+    """Version of inspect.getargspec that works for functools.partial objects"""
+    if isinstance(func, partial):
+        return inspect.getargspec(func.func)
+    else:
+        return inspect.getargspec(func)
 
 
 def reduction(x, chunk, aggregate, axis=None, keepdims=None, dtype=None):
@@ -23,9 +32,9 @@ def reduction(x, chunk, aggregate, axis=None, keepdims=None, dtype=None):
         axis = (axis,)
     axis = tuple(i if i >= 0 else x.ndim + i for i in axis)
 
-    if dtype and 'dtype' in inspect.getargspec(chunk).args:
+    if dtype and 'dtype' in getargspec(chunk).args:
         chunk = partial(chunk, dtype=dtype)
-    if dtype and 'dtype' in inspect.getargspec(aggregate).args:
+    if dtype and 'dtype' in getargspec(aggregate).args:
         aggregate = partial(aggregate, dtype=dtype)
 
     chunk2 = partial(chunk, axis=axis, keepdims=True)
@@ -206,37 +215,69 @@ with ignoring(AttributeError):
     nanmean = wraps(chunk.nanmean)(nanmean)
 
 
-def var_chunk(A, sum=chunk.sum, numel=numel, dtype='f8', **kwargs):
+def moment_chunk(A, order=2, sum=chunk.sum, numel=numel, dtype='f8', **kwargs):
+    total = sum(A, dtype=dtype, **kwargs)
     n = numel(A, **kwargs)
-    x = sum(A, dtype=dtype, **kwargs)
-    x2 = sum(A**2, dtype=dtype, **kwargs)
-    result = np.empty(shape=n.shape, dtype=[('x', x.dtype),
-                                            ('x2', x2.dtype),
-                                            ('n', n.dtype)])
-    result['x'] = x
-    result['x2'] = x2
+    u = total/n
+    M = np.empty(shape=n.shape + (order - 1,), dtype=dtype)
+    for i in range(2, order + 1):
+        M[..., i - 2] = sum((A - u)**i, dtype=dtype, **kwargs)
+    result = np.empty(shape=n.shape, dtype=[('total', total.dtype),
+                                            ('n', n.dtype),
+                                            ('M', M.dtype, (order-1,))])
+    result['total'] = total
     result['n'] = n
+    result['M'] = M
     return result
 
-def var_agg(A, ddof=None, **kwargs):
-    x = A['x'].sum(**kwargs)
-    x2 = A['x2'].sum(**kwargs)
-    n = A['n'].sum(**kwargs)
-    result = (x2 / n) - (x / n)**2
-    if ddof:
-        result = result * n / (n - ddof)
+
+def moment_agg(data, order=2, ddof=0, dtype='f8', **kwargs):
+    totals = data['total']
+    ns = data['n']
+    Ms = data['M']
+
+    kwargs['dtype'] = dtype
+    # To properly handle ndarrays, the original dimensions need to be kept for
+    # part of the calculation.
+    keepdim_kw = kwargs.copy()
+    keepdim_kw['keepdims'] = True
+
+    n = ns.sum(**keepdim_kw)
+    mu = np.divide(totals.sum(**keepdim_kw), n, dtype=dtype)
+    inner_term = np.divide(totals, ns, dtype=dtype) - mu
+
+    result = Ms[..., -1].sum(**kwargs)
+
+    for k in range(1, order - 1):
+        coeff = factorial(order)/(factorial(k)*factorial(order - k))
+        result += coeff * (Ms[..., order - k - 2] * inner_term**k).sum(**kwargs)
+
+    result += (ns * inner_term**order).sum(**kwargs)
+    result = np.divide(result, (n.sum(**kwargs) - ddof), dtype=dtype)
     return result
+
+
+def moment(a, order, axis=None, dtype=None, keepdims=False, ddof=0):
+    if dtype is not None:
+        dt = dtype
+    elif a._dtype is not None:
+        dt = np.var(np.ones(shape=(1,), dtype=a._dtype)).dtype
+    else:
+        dt = None
+    return reduction(a, partial(moment_chunk, order=order), partial(moment_agg,
+                     order=order, ddof=ddof), axis=axis, keepdims=keepdims,
+                     dtype=dt)
 
 
 @wraps(chunk.var)
 def var(a, axis=None, dtype=None, keepdims=False, ddof=0):
     if dtype is not None:
         dt = dtype
-    if a._dtype is not None:
+    elif a._dtype is not None:
         dt = np.var(np.ones(shape=(1,), dtype=a._dtype)).dtype
     else:
         dt = None
-    return reduction(a, var_chunk, partial(var_agg, ddof=ddof), axis=axis,
+    return reduction(a, moment_chunk, partial(moment_agg, ddof=ddof), axis=axis,
                      keepdims=keepdims, dtype=dt)
 
 
@@ -247,9 +288,9 @@ def nanvar(a, axis=None, dtype=None, keepdims=False, ddof=0):
         dt = np.var(np.ones(shape=(1,), dtype=a._dtype)).dtype
     else:
         dt = None
-    return reduction(a, partial(var_chunk, sum=chunk.nansum, numel=nannumel),
-                     partial(var_agg, ddof=ddof), axis=axis, keepdims=keepdims,
-                     dtype=dt)
+    return reduction(a, partial(moment_chunk, sum=chunk.nansum, numel=nannumel),
+                     partial(moment_agg, ddof=ddof), axis=axis,
+                     keepdims=keepdims, dtype=dt)
 
 with ignoring(AttributeError):
     nanvar = wraps(chunk.nanvar)(nanvar)

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -4,21 +4,13 @@ import numpy as np
 from functools import partial, wraps
 from math import factorial
 from toolz import compose, curry
-import inspect
 
 from .core import _concatenate2, Array, atop, sqrt, elemwise
 from .slicing import insert_many
+from .numpy_compat import divide
 from ..core import flatten
 from . import chunk
-from ..utils import ignoring
-
-
-def getargspec(func):
-    """Version of inspect.getargspec that works for functools.partial objects"""
-    if isinstance(func, partial):
-        return inspect.getargspec(func.func)
-    else:
-        return inspect.getargspec(func)
+from ..utils import ignoring, getargspec
 
 
 def reduction(x, chunk, aggregate, axis=None, keepdims=None, dtype=None):
@@ -243,8 +235,8 @@ def moment_agg(data, order=2, ddof=0, dtype='f8', **kwargs):
     keepdim_kw['keepdims'] = True
 
     n = ns.sum(**keepdim_kw)
-    mu = np.divide(totals.sum(**keepdim_kw), n, dtype=dtype)
-    inner_term = np.divide(totals, ns, dtype=dtype) - mu
+    mu = divide(totals.sum(**keepdim_kw), n, dtype=dtype)
+    inner_term = divide(totals, ns, dtype=dtype) - mu
 
     result = Ms[..., -1].sum(**kwargs)
 
@@ -253,7 +245,7 @@ def moment_agg(data, order=2, ddof=0, dtype='f8', **kwargs):
         result += coeff * (Ms[..., order - k - 2] * inner_term**k).sum(**kwargs)
 
     result += (ns * inner_term**order).sum(**kwargs)
-    result = np.divide(result, (n.sum(**kwargs) - ddof), dtype=dtype)
+    result = divide(result, (n.sum(**kwargs) - ddof), dtype=dtype)
     return result
 
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -365,22 +365,6 @@ def test_field_access():
     assert eq(y[['b', 'a']], x[['b', 'a']])
 
 
-def test_reductions():
-    x = np.arange(400).reshape((20, 20))
-    a = from_array(x, chunks=(7, 7))
-
-    assert eq(a.sum(), x.sum())
-    assert eq(a.sum(axis=1), x.sum(axis=1))
-    assert eq(a.sum(axis=1, keepdims=True), x.sum(axis=1, keepdims=True))
-    assert eq(a.mean(), x.mean())
-    assert eq(a.var(axis=(1, 0)), x.var(axis=(1, 0)))
-
-    b = a.sum(keepdims=True)
-    assert b._keys() == [[(b.name, 0, 0)]]
-
-    assert eq(a.std(axis=0, keepdims=True), x.std(axis=0, keepdims=True))
-
-
 def test_tensordot():
     x = np.arange(400).reshape((20, 20))
     a = from_array(x, chunks=(5, 5))
@@ -854,26 +838,6 @@ def test_arithmetic():
     assert eq(l2, r2)
 
     assert eq(da.around(a, -1), np.around(x, -1))
-
-
-def test_reductions():
-    x = np.arange(5).astype('f4')
-    a = da.from_array(x, chunks=(2,))
-
-    assert eq(da.all(a), np.all(x))
-    assert eq(da.any(a), np.any(x))
-    assert eq(da.argmax(a, axis=0), np.argmax(x, axis=0))
-    assert eq(da.argmin(a, axis=0), np.argmin(x, axis=0))
-    assert eq(da.max(a), np.max(x))
-    assert eq(da.mean(a), np.mean(x))
-    assert eq(da.min(a), np.min(x))
-    assert eq(da.nanargmax(a, axis=0), np.nanargmax(x, axis=0))
-    assert eq(da.nanargmin(a, axis=0), np.nanargmin(x, axis=0))
-    assert eq(da.nanmax(a), np.nanmax(x))
-    assert eq(da.nanmin(a), np.nanmin(x))
-    assert eq(da.nansum(a), np.nansum(x))
-    assert eq(da.nanvar(a), np.nanvar(x))
-    assert eq(da.nanstd(a), np.nanstd(x))
 
 
 def test_optimize():

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -27,10 +27,73 @@ def test_arg_reduction():
     assert eq(result, np.array([101, 11, 103]))
 
 
-def test_reductions():
-    x = np.random.random((20, 20))
+def test_reductions_1D():
+    x = np.arange(5).astype('f4')
+    a = da.from_array(x, chunks=(2,))
+
+    assert eq(da.all(a), np.all(x))
+    assert eq(da.any(a), np.any(x))
+    assert eq(da.argmax(a, axis=0), np.argmax(x, axis=0))
+    assert eq(da.argmin(a, axis=0), np.argmin(x, axis=0))
+    assert eq(da.max(a), np.max(x))
+    assert eq(da.mean(a), np.mean(x))
+    assert eq(da.var(a), np.var(x))
+    assert eq(da.min(a), np.min(x))
+    assert eq(da.nanargmax(a, axis=0), np.nanargmax(x, axis=0))
+    assert eq(da.nanargmin(a, axis=0), np.nanargmin(x, axis=0))
+    assert eq(da.nanmax(a), np.nanmax(x))
+    assert eq(da.nanmin(a), np.nanmin(x))
+    assert eq(da.nansum(a), np.nansum(x))
+    assert eq(da.nanvar(a), np.nanvar(x))
+    assert eq(da.nanstd(a), np.nanstd(x))
+
+
+def test_reductions_2D():
+    x = np.arange(400).reshape((20, 20))
     a = da.from_array(x, chunks=(7, 7))
 
+    assert eq(a.sum(), x.sum())
+    assert eq(a.sum(axis=0), x.sum(axis=0))
+    assert eq(a.sum(axis=1), x.sum(axis=1))
+    assert eq(a.sum(axis=1, keepdims=True), x.sum(axis=1, keepdims=True))
+    assert eq(a.sum(axis=(1, 0)), x.sum(axis=(1, 0)))
+
+    assert eq(a.mean(), x.mean())
+    assert eq(a.mean(axis=0), x.mean(axis=0))
+    assert eq(a.mean(axis=1), x.mean(axis=1))
+    assert eq(a.mean(axis=1, keepdims=True), x.mean(axis=1, keepdims=True))
+    assert eq(a.mean(axis=(1, 0)), x.mean(axis=(1, 0)))
+
+    assert eq(a.var(), x.var())
+    assert eq(a.var(axis=0), x.var(axis=0))
+    assert eq(a.var(axis=1), x.var(axis=1))
+    assert eq(a.var(axis=1, keepdims=True), x.var(axis=1, keepdims=True))
+    assert eq(a.var(axis=(1, 0)), x.var(axis=(1, 0)))
+    # Poorly conditioned
+    narr = np.array([1., 2., 3.]*10).reshape((3, 10)) + 1e8
+    darr = da.from_array(narr, chunks=5)
+    assert eq(darr.var(), narr.var())
+
+    assert eq(a.std(), x.std())
+    assert eq(a.std(axis=0), x.std(axis=0))
+    assert eq(a.std(axis=1), x.std(axis=1))
+    assert eq(a.std(axis=1, keepdims=True), x.std(axis=1, keepdims=True))
+    assert eq(a.std(axis=(1, 0)), x.std(axis=(1, 0)))
+
+    def moment(x, n, axis=None):
+        return ((x - x.mean(axis=axis, keepdims=True))**n).sum(
+                axis=axis)/np.ones_like(x).sum(axis=axis)
+
+    assert eq(a.moment(3), moment(x, 3))
+    assert eq(a.moment(4), moment(x, 4))
+    assert eq(a.moment(4, axis=1), moment(x, 4, axis=1))
+    assert eq(a.moment(4, axis=(1, 0)), moment(x, 4, axis=(1, 0)))
+
+    b = a.sum(keepdims=True)
+    assert b._keys() == [[(b.name, 0, 0)]]
+
+    x = np.random.random((20, 20))
+    a = da.from_array(x, chunks=(7, 7))
     assert eq(a.argmin(axis=1), x.argmin(axis=1))
     assert eq(a.argmax(axis=0), x.argmax(axis=0))
 
@@ -43,6 +106,7 @@ def test_reductions_with_negative_axes():
 
     assert eq(a.sum(axis=-1), x.sum(axis=-1))
     assert eq(a.sum(axis=(0, -1)), x.sum(axis=(0, -1)))
+
 
 def test_nan():
     x = np.array([[1, np.nan, 3, 4],

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -2,10 +2,12 @@ from __future__ import absolute_import, division, print_function
 
 from collections import Iterator
 from contextlib import contextmanager
+from functools import partial
 import os
 import shutil
 import gzip
 import tempfile
+import inspect
 
 from .compatibility import unicode
 
@@ -217,3 +219,11 @@ def pseudorandom(n, p, key):
     for i, (low, high) in enumerate(zip(cp[:-1], cp[1:])):
         out[(x >= low) & (x < high)] = i
     return out
+
+
+def getargspec(func):
+    """Version of inspect.getargspec that works for functools.partial objects"""
+    if isinstance(func, partial):
+        return inspect.getargspec(func.func)
+    else:
+        return inspect.getargspec(func)


### PR DESCRIPTION
Adds support for computing generalized moments for a dask array. This results in a more stable computation than that in current master, and allows for computing higher order moments as well.

```python
>>> import dask.array as da
>>> import numpy as np

# Poorly conditioned dataset
>>> a = np.array([1., 2., 3.]*100) + 1e8
>>> d = da.from_array(a, chunks=50)

# numpy answer
>>> a.var()
0.66666666666666663

# current master
>>>  d.var().compute()
0.0

# this PR
>>> d.var().compute()
0.66666666655540463

# Higher order moments
>>> from scipy.stats import moment
>>> da.arange(100, chunks=5).moment(4).compute()
1249583.3625
>>> moment(np.arange(100), 4)
1249583.3625
```

Fixes #78.