### PR TITLE
add dask.array.cache

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -24,12 +24,6 @@ from ..compatibility import unicode
 from .. import threaded, core
 from ..context import _globals
 
-try:
-    from chest import Chest as Cache
-except NotImplementedError:
-    Cache = dict
-
-
 
 names = ('x_%d' % i for i in count(1))
 tokens = ('-%d' % i for i in count(1))
@@ -765,7 +759,17 @@ class Array(object):
             self.store(store)
             return from_array(store, chunks=self.chunks)
         if store is None:
-            store = Cache()
+            try:
+                from chest import Chest
+                store = Chest()
+            except ImportError:
+                if self.nbytes <= 1e9:
+                    store = dict()
+                else:
+                    raise ValueError("No out-of-core storage found."
+                        "Either:\n"
+                        "1. Install ``chest``, an out-of-core dictionary\n"
+                        "2. Provide an on-disk array like an h5py.Dataset") # pragma: no cover
         if isinstance(store, MutableMapping):
             name = next(names)
             dsk = dict(((name, k[1:]), (operator.setitem, store, (tuple, list(k)), k))

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -719,6 +719,13 @@ class Array(object):
     def cache(self, store=None, **kwargs):
         """ Evaluate and cache array
 
+        Parameters
+        ----------
+        store: MutableMapping or ndarray-like
+            Place to put computed and cached chunks
+        kwargs:
+            Keyword arguments to pass on to ``get`` function for scheduling
+
         This triggers evaluation and store the result in either
 
         1.  An ndarray object supporting setitem (see da.store)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1034,9 +1034,12 @@ def test_numpy_compat_is_notimplemented():
 def test_cache():
     x = da.arange(15, chunks=5)
     y = 2 * x + 1
-
     z = y.cache()
-
     assert len(z.dask) == 3  # very short graph
+    assert eq(y, z)
 
+    cache = np.empty(15, dtype=y.dtype)
+    z = y.cache(store=cache)
+    assert len(z.dask) < 6  # very short graph
+    assert z.chunks == y.chunks
     assert eq(y, z)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1029,3 +1029,14 @@ def test_numpy_compat_is_notimplemented():
     x = da.from_array(a, chunks=5)
 
     assert raises(NotImplementedError, lambda: x + a)
+
+
+def test_cache():
+    x = da.arange(15, chunks=5)
+    y = 2 * x + 1
+
+    z = y.cache()
+
+    assert len(z.dask) == 3  # very short graph
+
+    assert eq(y, z)


### PR DESCRIPTION
This allows us to evaluate a dask.array, store in some cache,
and then return a new dask array pointing to that precomputed data.

One can specify a cache as either a MutableMapping or as an ndarray

Example
-------

```python
>>> import dask.array as da
>>> x = da.arange(5, chunks=2)
>>> y = 2*x + 1
>>> z = y.cache()  # triggers computation

>>> y.compute()  # Does entire computation
array([1, 3, 5, 7, 9])

>>> z.compute()  # Just pulls from store
array([1, 3, 5, 7, 9])

You might base a cache off of an array like a numpy array or
h5py.Dataset.

>>> cache = np.empty(5, dtype=x.dtype)
>>> z = y.cache(store=cache)
>>> cache
array([1, 3, 5, 7, 9])

Or one might use a MutableMapping like a dict or chest

>>> cache = dict()
>>> z = y.cache(store=cache)
>>> cache  # doctest: +SKIP
{('x', 0): array([1, 3]),
 ('x', 1): array([5, 7]),
 ('x', 2): array([9])}
```

Fixes #293