### PR TITLE
Keep series name in mean on SeriesGroupBy

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -748,9 +748,11 @@ class SeriesGroupBy(object):
             g = df.groupby(level=0)
             x = g.agg({(self.key, 'sum'): 'sum',
                        (self.key, 'count'): 'sum'})
-            return 1.0 * x[self.key]['sum'] / x[self.key]['count']
+            result = 1.0 * x[self.key]['sum'] / x[self.key]['count']
+            result.name = self.key
+            return result
         return aca([self.frame, self.index],
-                   chunk=chunk, aggregate=agg, columns=[])
+                   chunk=chunk, aggregate=agg, columns=[self.key])
 
 
 def apply_concat_apply(args, chunk=None, aggregate=None, columns=None):


### PR DESCRIPTION
Due to a new pandas release, `test_split_apply_combine_on_series` in `test_dataframe.py` was failing on a mean of a SeriesGroupBy. The name of the series was being dropped in the computation. This fixes it, but there may be a better way.