### PR TITLE
threadsafe pseudorandom function

### DIFF
--- a/dask/utils.py
+++ b/dask/utils.py
@@ -212,8 +212,7 @@ def pseudorandom(n, p, key):
     assert np.allclose(1, cp[-1])
     assert len(p) < 256
 
-    np.random.seed(key)
-    x = np.random.random(n)
+    x = np.random.RandomState(key).random_sample(n)
     out = np.empty(n, dtype='i1')
 
     for i, (low, high) in enumerate(zip(cp[:-1], cp[1:])):


### PR DESCRIPTION
Previously we were using

    np.random.seed(...)
    x = np.random.random(...)

But this would have failed if another call to a random function occured
between those two calls.

Now we use RandomState to handle this cleanly

Fixes https://github.com/ContinuumIO/dask/issues/315

cc @cowlicks @cpcloud 