### PR TITLE
Various fixes for dask.distributed

### DIFF
--- a/dask/distributed/tests/test_distributed.py
+++ b/dask/distributed/tests/test_distributed.py
@@ -12,13 +12,14 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal
 
 from IPython.parallel import Client
+from contextlib import contextmanager
 
 from dask.distributed import dask_client_from_ipclient
 import dask.array as da
 import dask.bag as db
 
 
-def setup_module():
+def setup_cluster():
     start_cmd = ['ipcluster', 'start', '-n', '4']
     cp = Popen(start_cmd, stdout=PIPE, stderr=PIPE)
     tic = time.time()
@@ -33,7 +34,7 @@ def setup_module():
         time.sleep(0.1)
 
 
-def teardown_module():
+def teardown_cluster():
     kill_cmd = ['ipcluster', 'stop']
     cp = Popen(kill_cmd, stdout=PIPE, stderr=PIPE)
     tic = time.time()
@@ -46,31 +47,39 @@ def teardown_module():
             break
         time.sleep(0.1)
 
+@contextmanager
+def ipcluster():
+    setup_cluster()
+    try:
+        c = Client()
+        yield c
+    finally:
+        teardown_cluster()
 
 def test_dask_client_from_ipclient():
-    c = Client()
-    dask_client = dask_client_from_ipclient(c)
+    with ipcluster() as c:
+        dask_client = dask_client_from_ipclient(c)
 
-    # data
-    a = np.arange(100).reshape(10, 10)
-    d = da.from_array(a, ((5, 5), (5, 5)))
+        # data
+        a = np.arange(100).reshape(10, 10)
+        d = da.from_array(a, ((5, 5), (5, 5)))
 
-    try:
-        # test array.mean
-        expected = a.mean(axis=0)
-        d1 = d.mean(axis=0)
-        result = d1.compute(get=dask_client.get)
-        assert_array_almost_equal(result, expected)
+        try:
+            # test array.mean
+            expected = a.mean(axis=0)
+            d1 = d.mean(axis=0)
+            result = d1.compute(get=dask_client.get)
+            assert_array_almost_equal(result, expected)
 
-        # test ghosting
-        d2 = da.ghost.ghost(d, depth=1, boundary='reflect')
-        d3 = da.ghost.trim_internal(d2, {0: 1, 1: 1})
-        result1 = d3.compute(get=dask_client.get)
-        assert_array_almost_equal(result1, a)
+            # test ghosting
+            d2 = da.ghost.ghost(d, depth=1, boundary='reflect')
+            d3 = da.ghost.trim_internal(d2, {0: 1, 1: 1})
+            result1 = d3.compute(get=dask_client.get)
+            assert_array_almost_equal(result1, a)
 
-    finally:
-        # close the workers
-        dask_client.close(close_scheduler=True)
+        finally:
+            # close the workers
+            dask_client.close(close_scheduler=True)
 
 
 def test_gh_248():

--- a/dask/distributed/tests/test_distributed.py
+++ b/dask/distributed/tests/test_distributed.py
@@ -56,6 +56,7 @@ def ipcluster():
     finally:
         teardown_cluster()
 
+@pytest.mark.slow
 def test_dask_client_from_ipclient():
     with ipcluster() as c:
         dask_client = dask_client_from_ipclient(c)

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -74,6 +74,8 @@ def test_status_client():
 def scheduler_and_workers(n=2):
     with scheduler() as s:
         workers = [Worker(s.address_to_workers) for i in range(n)]
+        while(len(s.workers) < n):
+            sleep(0.01)
         try:
             yield s, workers
         finally:
@@ -83,7 +85,6 @@ def scheduler_and_workers(n=2):
 
 def test_cluster():
     with scheduler_and_workers() as (s, (a, b)):
-        sleep(0.1)
         assert a.address in s.workers
         assert b.address in s.workers
         assert a.scheduler == s.address_to_workers
@@ -99,7 +100,6 @@ def add(x, y):
 
 def test_compute_cycle():
     with scheduler_and_workers(n=2) as (s, (a, b)):
-        sleep(0.1)
         assert s.available_workers.qsize() == 2
 
         dsk = {'a': (add, 1, 2), 'b': (inc, 'a')}
@@ -191,7 +191,6 @@ def test_random_names():
 
 def test_close_workers():
     with scheduler_and_workers(n=2) as (s, (a, b)):
-        sleep(0.05)
         assert a.status != 'closed'
 
         s.close_workers()

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -91,6 +91,12 @@ def test_cluster():
         assert b.scheduler == s.address_to_workers
 
 
+def test_pid():
+    with scheduler_and_workers() as (s, (a, b)):
+        assert isinstance(s.workers[a.address]['pid'], int)
+        assert isinstance(s.workers[b.address]['pid'], int)
+
+
 def inc(x):
     return x + 1
 

--- a/dask/distributed/tests/test_worker.py
+++ b/dask/distributed/tests/test_worker.py
@@ -35,7 +35,7 @@ def worker(data=None, scheduler='tcp://localhost:5555'):
 @contextmanager
 def worker_and_router(*args, **kwargs):
     router = context.socket(zmq.ROUTER)
-    router.RCVTIMEO = 10000
+    router.RCVTIMEO = 100000
     port = kwargs.get('port')
     if port:
         router.bind('tcp://*:%d' % port)

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -4,6 +4,7 @@ import uuid
 import random
 import socket
 import sys
+import os
 import traceback
 from threading import Thread, Lock
 from multiprocessing.pool import ThreadPool
@@ -110,7 +111,7 @@ class Worker(object):
 
         self.to_scheduler.setsockopt(zmq.IDENTITY, self.address)
         self.to_scheduler.connect(scheduler)
-        self.send_to_scheduler({'function': 'register'}, {})
+        self.send_to_scheduler({'function': 'register'}, {'pid': os.getpid()})
 
         self.scheduler_functions = {'status': self.status_to_scheduler,
                                     'compute': self.compute,


### PR DESCRIPTION
1.  Extend timeout in tests from 10 to 100 seconds
2.  Sleep until all workers report in in tests accordingly
3.  Workers send pid to scheduler

cc @cowlicks