### PR TITLE
Series.quantile robust to empty input

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -884,6 +884,8 @@ def quantiles(f, q, **kwargs):
         Iterable of numbers ranging from 0 to 100 for the desired quantiles
     """
     assert len(f.columns) == 1
+    if not len(q):
+        return da.zeros((0,), chunks=((0,),))
     from dask.array.percentile import _percentile, merge_percentiles
     name = next(names)
     val_dsk = dict(((name, i), (_percentile, (getattr, key, 'values'), q))
@@ -898,7 +900,6 @@ def quantiles(f, q, **kwargs):
 
     dsk = merge(f.dask, val_dsk, len_dsk, merge_dsk)
     return da.Array(dsk, name3, chunks=((len(q),),))
-
 
 
 def get(dsk, keys, get=threaded.get, **kwargs):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -291,6 +291,10 @@ def test_quantiles():
     assert 3 < result[1] < 7
 
 
+def test_empty_quantiles():
+    assert d.b.quantiles([]).compute().tolist() == []
+
+
 def test_index():
     assert eq(d.index, full.index)
 


### PR DESCRIPTION
This happens when you build a dask.dataframe from a small dataset
and then use set_index

cc @quasiben