### PR TITLE
Fix bottom up to traverse inside literal list

### DIFF
--- a/dask/rewrite.py
+++ b/dask/rewrite.py
@@ -358,12 +358,11 @@ def _top_level(net, term):
 
 
 def _bottom_up(net, term):
-    if not istask(term):
-        return net._rewrite(term)
-    else:
-        new_args = tuple(_bottom_up(net, t) for t in args(term))
-        new_term = (head(term),) + new_args
-    return net._rewrite(new_term)
+    if istask(term):
+        term = (head(term),) + tuple(_bottom_up(net, t) for t in args(term))
+    elif isinstance(term, list):
+        term = [_bottom_up(net, t) for t in args(term)]
+    return net._rewrite(term)
 
 
 strategies = {'top_level': _top_level,

--- a/dask/tests/test_rewrite.py
+++ b/dask/tests/test_rewrite.py
@@ -128,9 +128,10 @@ def test_matches():
 
 
 def test_rewrite():
+    # Rewrite inside list
     term = (sum, [(add, 1, 1), (add, 1, 1), (add, 1, 1)])
     new_term = rs.rewrite(term)
-    assert new_term == (add, (add, (add, 1, 1), (add, 1, 1)), (add, 1, 1))
+    assert new_term == (add, (add, (inc, 1), (inc, 1)), (inc, 1))
     # Rules aren't applied to exhaustion, this can be further simplified
     new_term = rs.rewrite(new_term)
     assert new_term == (add, (add, (double, 1), 2), (inc, 1))


### PR DESCRIPTION
Now rewriting will traverse into lists on bottom_up rewriting. Fixed
incorrect test as well, which now covers new behavior. Closes #330.