### PR TITLE
Specify keys to not fuse in dask.optimize.fuse.  See #331.

### DIFF
--- a/dask/optimize.py
+++ b/dask/optimize.py
@@ -19,7 +19,7 @@ def cull(dsk, keys):
     >>> cull(d, 'out')  # doctest: +SKIP
     {'x': 1, 'out': (add, 'x', 10)}
     """
-    if not isinstance(keys, list):
+    if not isinstance(keys, (list, set)):
         keys = [keys]
     nxt = set(flatten(keys))
     seen = nxt
@@ -50,38 +50,42 @@ def fuse(dsk, keys=None):
     >>> fuse(d, keys=['b'])  # doctest: +SKIP
     {'b': (inc, 1), 'c': (inc, 'b')}
     """
-    if isinstance(keys, (set, list)):
-        keys = set(keys)
-    elif keys is not None:
-        keys = set([keys])
+    if keys is not None and not isinstance(keys, set):
+        if not isinstance(keys, list):
+            keys = [keys]
+        keys = set(flatten(keys))
+
     # locate all members of linear chains
-    parents = {}
-    deadbeats = set()
+    child2parent = {}
+    unfusible = set()
     for parent in dsk:
         deps = get_dependencies(dsk, parent, as_list=True)
+        has_many_children = len(deps) > 1
         for child in deps:
-            if child in parents:
-                del parents[child]
-                deadbeats.add(child)
-            elif len(deps) > 1 or (keys is not None and child in keys):
-                deadbeats.add(child)
-            elif child not in deadbeats:
-                parents[child] = parent
+            if keys is not None and child in keys:
+                unfusible.add(child)
+            elif child in child2parent:
+                del child2parent[child]
+                unfusible.add(child)
+            elif has_many_children:
+                unfusible.add(child)
+            elif child not in unfusible:
+                child2parent[child] = parent
 
     # construct the chains from ancestor to descendant
     chains = []
-    children = dict(map(reversed, parents.items()))
-    while parents:
-        child, parent = parents.popitem()
+    parent2child = dict(map(reversed, child2parent.items()))
+    while child2parent:
+        child, parent = child2parent.popitem()
         chain = [child, parent]
-        while parent in parents:
-            parent = parents.pop(parent)
-            del children[parent]
+        while parent in child2parent:
+            parent = child2parent.pop(parent)
+            del parent2child[parent]
             chain.append(parent)
         chain.reverse()
-        while child in children:
-            child = children.pop(child)
-            del parents[child]
+        while child in parent2child:
+            child = parent2child.pop(child)
+            del child2parent[child]
             chain.append(child)
         chains.append(chain)
 
@@ -124,11 +128,11 @@ def inline(dsk, keys=None, inline_constants=True):
     {'x': 1, 'z': (add, 'x', (inc, 'x'))}
     """
     if keys is None:
-        keys  = set()
-    elif isinstance(keys, (set, list)):
-        keys = set(keys)
-    else:
-        keys = set([keys])
+        keys = []
+    elif not isinstance(keys, (list, set)):
+        keys = [keys]
+    keys = set(flatten(keys))
+
     if inline_constants:
         keys.update(k for k, v in dsk.items() if not istask(v))
 

--- a/dask/tests/test_optimize.py
+++ b/dask/tests/test_optimize.py
@@ -93,6 +93,26 @@ def test_fuse():
         'c': (add, 'b', 'b')
     }
 
+
+def test_fuse_keys():
+    assert (fuse({'a': 1, 'b': (inc, 'a'), 'c': (inc, 'b')}, keys=['b'])
+            == {'b': (inc, 1), 'c': (inc, 'b')})
+    assert fuse({
+        'w': (inc, 'x'),
+        'x': (inc, 'y'),
+        'y': (inc, 'z'),
+        'z': (add, 'a', 'b'),
+        'a': 1,
+        'b': 2,
+    }, keys=['x', 'z']) == {
+        'w': (inc, 'x'),
+        'x': (inc, (inc, 'z')),
+        'z': (add, 'a', 'b'),
+        'a': 1,
+        'b': 2,
+    }
+
+
 def test_inline():
     d = {'a': 1, 'b': (inc, 'a'), 'c': (inc, 'b'), 'd': (add, 'a', 'c')}
     assert inline(d) == {'b': (inc, 1), 'c': (inc, 'b'), 'd': (add, 1, 'c')}


### PR DESCRIPTION
Because sometimes we care about intermediate results.