### PR TITLE
Callbacks for get_async

### DIFF
--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -1,7 +1,6 @@
 from ..optimize import cull, fuse
 from ..core import flatten
-from ..async import inline_functions
-from ..optimize import dealias
+from ..optimize import dealias, inline_functions
 from .core import getarray
 from operator import getitem
 from dask.rewrite import RuleSet, RewriteRule

--- a/dask/async.py
+++ b/dask/async.py
@@ -488,12 +488,14 @@ def apply_sync(func, args=(), kwds={}):
     """ A naive synchronous version of apply_async """
     return func(*args, **kwds)
 
+def get_id():
+    return None
 
 def get_sync(dsk, keys, **kwargs):
     from .compatibility import Queue
     queue = Queue()
     return get_async(apply_sync, 1, dsk, keys, queue=queue,
-            raise_on_exception=True, **kwargs)
+            get_id=get_id, raise_on_exception=True, **kwargs)
 
 
 '''

--- a/dask/async.py
+++ b/dask/async.py
@@ -266,7 +266,7 @@ def execute_task(key, task, data, queue, raise_on_exception=False,
         _execute_task - actually execute task
     """
     try:
-        with execute_cm(key):
+        with execute_cm(key, task):
             result = _execute_task(task, data)
             result = key, result, None
     except Exception as e:
@@ -412,7 +412,8 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
         at that tick.
     execute_cm : function, optional
         A context manager that wraps the execution of a task. Receives the key
-        of the current task. This is useful for profiling task execution.
+        and task of the current task. This is useful for profiling task
+        execution.
 
     See Also
     --------

--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -9,8 +9,12 @@ from .async import get_async # TODO: get better get
 from .context import _globals
 
 
+def _process_get_id():
+    return multiprocessing.current_process().ident
+
+
 def get(dsk, keys, optimizations=[], num_workers=None,
-        func_loads=None, func_dumps=None):
+        func_loads=None, func_dumps=None, **kwargs):
     """ Multiprocessed get function appropriate for Bags
 
     Parameters
@@ -49,7 +53,7 @@ def get(dsk, keys, optimizations=[], num_workers=None,
     try:
         # Run
         result = get_async(apply_async, len(pool._pool), dsk3, keys,
-                           queue=queue)
+                           queue=queue, get_id=_process_get_id, **kwargs)
     finally:
         if cleanup:
             pool.close()

--- a/dask/threaded.py
+++ b/dask/threaded.py
@@ -14,7 +14,7 @@ from .context import _globals
 default_pool = ThreadPool()
 
 
-def get(dsk, result, cache=None, debug_counts=None, **kwargs):
+def get(dsk, result, cache=None, **kwargs):
     """ Threaded cached implementation of dask.get
 
     Parameters
@@ -28,8 +28,6 @@ def get(dsk, result, cache=None, debug_counts=None, **kwargs):
         The number of threads to use in the ThreadPool that will actually execute tasks
     cache: dict-like (optional)
         Temporary storage of results
-    debug_counts: integer or None
-        This integer tells how often the scheduler should dump debugging info
 
     Examples
     --------
@@ -47,7 +45,6 @@ def get(dsk, result, cache=None, debug_counts=None, **kwargs):
 
     queue = Queue()
     results = get_async(pool.apply_async, len(pool._pool), dsk, result,
-                        cache=cache, debug_counts=debug_counts,
-                        queue=queue, **kwargs)
+                        cache=cache, queue=queue, **kwargs)
 
     return results

--- a/dask/threaded.py
+++ b/dask/threaded.py
@@ -6,12 +6,17 @@ See async.py
 from __future__ import absolute_import, division, print_function
 
 from multiprocessing.pool import ThreadPool
+from threading import current_thread
 from .async import get_async, inc, add
 from .compatibility import Queue
 from .context import _globals
 
 
 default_pool = ThreadPool()
+
+
+def _thread_get_id():
+    return current_thread().ident
 
 
 def get(dsk, result, cache=None, **kwargs):
@@ -45,6 +50,7 @@ def get(dsk, result, cache=None, **kwargs):
 
     queue = Queue()
     results = get_async(pool.apply_async, len(pool._pool), dsk, result,
-                        cache=cache, queue=queue, **kwargs)
+                        cache=cache, queue=queue, get_id=_thread_get_id,
+                        **kwargs)
 
     return results


### PR DESCRIPTION
Two callbacks:

- `execute_cm` is a context manager that wraps actual execution of each
  task. Gets the task key as a parameter. Can be used for profiling,
  getting thread information, etc...

- `scheduler_callback` is a callback executed each tick of the
  scheduler. Gets the dask and the state as parameters. Useful for
  visualizing execution state through the scheduler.

Still no tests or docs, and I'm not happy with the parameter names, but
I think this is the right level of granularity.

Fixes #346.