### PR TITLE
Scheduler.close_workers waits on out-queue

### DIFF
--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -162,6 +162,7 @@ class Scheduler(object):
                 while not self.send_to_workers_queue.empty():
                     msg = self.send_to_workers_queue.get()
                     self.to_workers.send_multipart(msg)
+                    self.send_to_workers_queue.task_done()
 
             if self.to_workers in socks:
                 address, header, payload = self.to_workers.recv_multipart()
@@ -526,6 +527,8 @@ class Scheduler(object):
         header = {'function': 'close'}
         for w in self.workers:
             self.send_to_worker(w, header, {})
+        self.workers.clear()
+        self.send_to_workers_queue.join()
 
     def _close(self, header, payload):
         self.close()

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -200,7 +200,12 @@ def test_close_workers():
         assert a.status != 'closed'
 
         s.close_workers()
-        sleep(0.05)
+        assert not s.workers
+        for i in range(100):
+            if a.status == 'closed' and b.status == 'closed':
+                break
+            else:
+                sleep(0.01)
         assert a.status == 'closed'
         assert b.status == 'closed'
 


### PR DESCRIPTION
This should prevent Scheduler.close from killing its outgoing thread
before worker-close messages can make it out.

cc @cowlicks 