### PR TITLE
Multi-dataframe computations

### DIFF
--- a/dask/core.py
+++ b/dask/core.py
@@ -271,12 +271,14 @@ def subs(task, key, val):
     (inc, 1)
     """
     if not istask(task):
-        if task == key:
-            return val
-        elif isinstance(task, list):
+        try:
+            if task == key:
+                return val
+        except ValueError:
+            pass
+        if isinstance(task, list):
             return [subs(x, key, val) for x in task]
-        else:
-            return task
+        return task
     newargs = []
     for arg in task[1:]:
         if istask(arg):

--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -3,3 +3,4 @@ from .core import (DataFrame, Series, Index, _Frame, concat, map_blocks,
 from .io import (read_csv, from_array, from_bcolz, from_array,
                  from_bcolz, from_pandas)
 from .optimize import optimize
+from .multi import merge

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -331,11 +331,11 @@ def from_pandas(data, npartitions):
     data = data.sort_index(ascending=True)
     divisions = tuple(data.index[i]
                       for i in range(0, nrows, chunksize))
-    if divisions[-1] != data.index[-1]:
-        divisions = divisions + (data.index[-1],)
+    divisions = divisions + (data.index[-1],)
     name = 'from_pandas' + next(tokens)
     dsk = dict(((name, i), data.iloc[i * chunksize:(i + 1) * chunksize])
-               for i in range(npartitions))
+               for i in range(npartitions - 1))
+    dsk[(name, npartitions - 1)] = data.iloc[chunksize*(npartitions - 1):]
     return getattr(core, type(data).__name__)(dsk, name, columns, divisions)
 
 

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -1,0 +1,53 @@
+from .core import repartition
+from bisect import bisect_left, bisect_right
+from toolz import merge_sorted, unique
+
+
+def bound(seq, left, right):
+    """ Bound sorted list by left and right values
+
+    >>> bound([1, 3, 4, 5, 8, 10, 12], 4, 10)
+    [4, 5, 8, 10]
+    """
+    return seq[bisect_left(seq, left): bisect_right(seq, right)]
+
+
+def align(*dfs):
+    """ Mutually partition and align DataFrame blocks
+
+    This serves as precursor to multi-dataframe operations like join, concat,
+    or merge.
+
+    Parameters
+    ----------
+    dfs: sequence of dd.DataFrames
+        Sequence of dataframes to be aligned on their index
+
+    Returns
+    -------
+    dfs: sequence of dd.DataFrames
+        These DataFrames have consistent divisions with each other
+    divisions: tuple
+        Full divisions sequence of the entire result
+    result: list
+        A list of lists of keys that show which dataframes exist on which
+        divisions
+
+    """
+    divisions = list(unique(merge_sorted(*[df.divisions for df in dfs])))
+    divisionss = [bound(divisions, df.divisions[0], df.divisions[-1])
+                  for df in dfs]
+    dfs2 = list(map(repartition, dfs, divisionss))
+
+    result = list()
+    inds = [0 for df in dfs]
+    for d in divisions[:-1]:
+        L = list()
+        for i in range(len(dfs)):
+            j = inds[i]
+            divs = dfs2[i].divisions
+            if j < len(divs) - 1 and divs[j] == d:
+                L.append((dfs2[i]._name, inds[i]))
+                inds[i] += 1
+        result.append(L)
+    return dfs2, tuple(divisions), result

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -53,3 +53,48 @@ def align(*dfs):
                 L.append(None)
         result.append(L)
     return dfs2, tuple(divisions), result
+
+
+def require(divisions, parts, required=None):
+    """ Clear out divisions where required components are not present
+
+    In left, right, or inner joins we exclude portions of the dataset if one
+    side or the other is not present.  We can achieve this at the partition
+    level as well
+
+    >>> divisions = [1, 3, 5, 7, 9]
+    >>> parts = [(('a', 0), None),
+    ...          (('a', 1), ('b', 0)),
+    ...          (('a', 2), ('b', 1)),
+    ...          (None, ('b', 2))]
+
+    >>> divisions2, parts2 = require(divisions, parts, required=[0])
+    >>> divisions2
+    (1, 3, 5, 7)
+    >>> parts2  # doctest: +NORMALIZE_WHITESPACE
+    ((('a', 0), None),
+     (('a', 1), ('b', 0)),
+     (('a', 2), ('b', 1)))
+
+    >>> divisions2, parts2 = require(divisions, parts, required=[1])
+    >>> divisions2
+    (3, 5, 7, 9)
+    >>> parts2  # doctest: +NORMALIZE_WHITESPACE
+    ((('a', 1), ('b', 0)),
+     (('a', 2), ('b', 1)),
+     (None, ('b', 2)))
+
+    >>> divisions2, parts2 = require(divisions, parts, required=[0, 1])
+    >>> divisions2
+    (3, 5, 7)
+    >>> parts2  # doctest: +NORMALIZE_WHITESPACE
+    ((('a', 1), ('b', 0)),
+     (('a', 2), ('b', 1)))
+    """
+    if not required:
+        return divisions, parts
+    for i in required:
+        present = [j for j, p in enumerate(parts) if p[i] is not None]
+        divisions = tuple(divisions[min(present): max(present) + 2])
+        parts = tuple(parts[min(present): max(present) + 1])
+    return divisions, parts

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -1,6 +1,7 @@
-from .core import repartition
+from .core import repartition, tokens, DataFrame
 from bisect import bisect_left, bisect_right
-from toolz import merge_sorted, unique
+from toolz import merge_sorted, unique, merge
+import pandas as pd
 
 
 def bound(seq, left, right):
@@ -32,7 +33,6 @@ def align(*dfs):
     result: list
         A list of lists of keys that show which dataframes exist on which
         divisions
-
     """
     divisions = list(unique(merge_sorted(*[df.divisions for df in dfs])))
     divisionss = [bound(divisions, df.divisions[0], df.divisions[-1])
@@ -49,5 +49,7 @@ def align(*dfs):
             if j < len(divs) - 1 and divs[j] == d:
                 L.append((dfs2[i]._name, inds[i]))
                 inds[i] += 1
+            else:
+                L.append(None)
         result.append(L)
     return dfs2, tuple(divisions), result

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -1,4 +1,5 @@
 from itertools import count
+from collections import Iterator
 from math import ceil
 from toolz import merge, accumulate, merge_sorted
 import toolz
@@ -176,10 +177,17 @@ def shuffle(df, index, npartitions=None):
 def partition(df, index, npartitions, p):
     """ Partition a dataframe along a grouper, store partitions to partd """
     rng = pd.Series(np.arange(len(df)))
-    if not isinstance(index, pd.Series):
+    if isinstance(index, Iterator):
+        index = list(index)
+    if not isinstance(index, pd.core.generic.NDFrame):
         index = df[index]
 
-    groups = rng.groupby(index.map(lambda x: abs(hash(x)) % npartitions).values)
+    if isinstance(index, pd.Series):
+        groups = rng.groupby(index.map(lambda x: abs(hash(x)) % npartitions).values)
+    elif isinstance(index, pd.DataFrame):
+        groups = rng.groupby(index.apply(
+                    lambda row: abs(hash(tuple(row))) % npartitions,
+                    axis=1).values)
     d = dict((i, df.iloc[groups.groups[i]]) for i in range(npartitions)
                                             if i in groups.groups)
     p.append(d)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -181,9 +181,11 @@ def partition(df, index, npartitions, p):
     rng = pd.Series(np.arange(len(df)))
     if isinstance(index, Iterator):
         index = list(index)
-    if not isinstance(index, pd.core.generic.NDFrame):
+    if not isinstance(index, (pd.Index, pd.core.generic.NDFrame)):
         index = df[index]
 
+    if isinstance(index, pd.Index):
+        groups = rng.groupby([abs(hash(x)) % npartitions for x in index])
     if isinstance(index, pd.Series):
         groups = rng.groupby(index.map(lambda x: abs(hash(x)) % npartitions).values)
     elif isinstance(index, pd.DataFrame):

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -82,7 +82,6 @@ def set_partition(df, index, divisions):
 
     # Barrier
     barrier_token = 'barrier' + next(tokens)
-    def barrier(args):         return 0
     dsk3 = {barrier_token: (barrier, list(dsk2))}
 
     # Collect groups
@@ -97,6 +96,10 @@ def set_partition(df, index, divisions):
 
     return DataFrame(dsk, name, df.columns, divisions)
 
+
+def barrier(args):
+    list(args)
+    return 0
 
 def _set_partition(df, index, divisions, p):
     """ Shard partition and dump into partd """
@@ -156,7 +159,6 @@ def shuffle(df, index, npartitions=None):
 
     # Barrier
     barrier_token = 'barrier' + next(tokens)
-    def barrier(args):         return 0
     dsk3 = {barrier_token: (barrier, list(dsk2))}
 
     # Collect groups

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -322,6 +322,8 @@ def test_from_pandas_small():
     for i in [1, 2, 30]:
         a = dd.from_pandas(df, i)
         assert len(a.compute()) == 3
+        assert a.divisions[0] == 0
+        assert a.divisions[-1] == 2
 
 
 def test_from_pandas_series():

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -317,6 +317,13 @@ def test_from_pandas_dataframe():
     tm.assert_frame_equal(df, ddf.compute())
 
 
+def test_from_pandas_small():
+    df = pd.DataFrame({'x': [1, 2, 3]})
+    for i in [1, 2, 30]:
+        a = dd.from_pandas(df, i)
+        assert len(a.compute()) == 3
+
+
 def test_from_pandas_series():
     n = 20
     s = pd.Series(np.random.randn(n),

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1,11 +1,11 @@
 import dask.dataframe as dd
 import pandas as pd
-from dask.dataframe.multi import (align, join_indexed_dataframes, hash_join,
-        concat_indexed_dataframes)
+from dask.dataframe.multi import (align_partitions, join_indexed_dataframes,
+        hash_join, concat_indexed_dataframes)
 import pandas.util.testing as tm
 from dask.async import get_sync
 
-def test_align():
+def test_align_partitions():
     A = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6], 'y': list('abdabd')},
                      index=[10, 20, 30, 40, 50, 60])
     a = dd.repartition(A, [10, 40, 60])
@@ -14,7 +14,7 @@ def test_align():
                      index=[30, 70, 80, 100])
     b = dd.repartition(B, [30, 80, 100])
 
-    (aa, bb), divisions, L = align(a, b)
+    (aa, bb), divisions, L = align_partitions(a, b)
     assert isinstance(a, dd.DataFrame)
     assert isinstance(b, dd.DataFrame)
     assert divisions == (10, 30, 40, 60, 80, 100)

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1,6 +1,6 @@
 import dask.dataframe as dd
 import pandas as pd
-from dask.dataframe.multi import align
+from dask.dataframe.multi import align, join_indexed_dataframes
 import pandas.util.testing as tm
 
 def test_align():
@@ -23,3 +23,33 @@ def test_align():
                  [(aa._name, 2), (bb._name, 1)],
                  [None, (bb._name, 2)],
                  [None, (bb._name, 3)]]
+
+
+def test_join_indexed_dataframe_to_indexed_dataframe():
+    A = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6]},
+                     index=[1, 2, 3, 4, 6, 7])
+    a = dd.repartition(A, [1, 4, 7])
+
+    B = pd.DataFrame({'y': list('abcdef')},
+                     index=[1, 2, 4, 5, 6, 8])
+    b = dd.repartition(B, [1, 2, 5, 8])
+
+    c = join_indexed_dataframes(a, b, how='left')
+    assert c.divisions[0] == a.divisions[0]
+    assert c.divisions[-1] == a.divisions[-1]
+    tm.assert_frame_equal(c.compute(), A.join(B))
+
+    c = join_indexed_dataframes(a, b, how='right')
+    assert c.divisions[0] == b.divisions[0]
+    assert c.divisions[-1] == b.divisions[-1]
+    tm.assert_frame_equal(c.compute(), A.join(B, how='right'))
+
+    c = join_indexed_dataframes(a, b, how='inner')
+    assert c.divisions[0] == 1
+    assert c.divisions[-1] == 7
+    tm.assert_frame_equal(c.compute(), A.join(B, how='inner'))
+
+    c = join_indexed_dataframes(a, b, how='outer')
+    assert c.divisions[0] == 1
+    assert c.divisions[-1] == 8
+    tm.assert_frame_equal(c.compute(), A.join(B, how='outer'))

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1,0 +1,28 @@
+import dask.dataframe as dd
+import pandas as pd
+from dask.dataframe.multi import align
+
+
+A = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6], 'y': list('abdabd')},
+                 index=[10, 20, 30, 40, 50, 60])
+a = dd.repartition(A, [10, 40, 60])
+
+B = pd.DataFrame({'x': [1, 2, 3, 4], 'y': list('abda')},
+                 index=[30, 70, 80, 100])
+b = dd.repartition(B, [30, 80, 100])
+
+
+def test_align():
+    (aa, bb), divisions, L = align(a, b)
+    assert isinstance(a, dd.DataFrame)
+    assert isinstance(b, dd.DataFrame)
+    assert divisions == (10, 30, 40, 60, 80, 100)
+    assert isinstance(L, list)
+    assert len(divisions) == 1 + len(L)
+    assert L == [[(aa._name, 0)],
+                 [(aa._name, 1), (bb._name, 0)],
+                 [(aa._name, 2), (bb._name, 1)],
+                 [(bb._name, 2)],
+                 [(bb._name, 3)]]
+
+

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1,28 +1,25 @@
 import dask.dataframe as dd
 import pandas as pd
 from dask.dataframe.multi import align
-
-
-A = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6], 'y': list('abdabd')},
-                 index=[10, 20, 30, 40, 50, 60])
-a = dd.repartition(A, [10, 40, 60])
-
-B = pd.DataFrame({'x': [1, 2, 3, 4], 'y': list('abda')},
-                 index=[30, 70, 80, 100])
-b = dd.repartition(B, [30, 80, 100])
-
+import pandas.util.testing as tm
 
 def test_align():
+    A = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6], 'y': list('abdabd')},
+                     index=[10, 20, 30, 40, 50, 60])
+    a = dd.repartition(A, [10, 40, 60])
+
+    B = pd.DataFrame({'x': [1, 2, 3, 4], 'y': list('abda')},
+                     index=[30, 70, 80, 100])
+    b = dd.repartition(B, [30, 80, 100])
+
     (aa, bb), divisions, L = align(a, b)
     assert isinstance(a, dd.DataFrame)
     assert isinstance(b, dd.DataFrame)
     assert divisions == (10, 30, 40, 60, 80, 100)
     assert isinstance(L, list)
     assert len(divisions) == 1 + len(L)
-    assert L == [[(aa._name, 0)],
+    assert L == [[(aa._name, 0), None],
                  [(aa._name, 1), (bb._name, 0)],
                  [(aa._name, 2), (bb._name, 1)],
-                 [(bb._name, 2)],
-                 [(bb._name, 3)]]
-
-
+                 [None, (bb._name, 2)],
+                 [None, (bb._name, 3)]]

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -33,3 +33,8 @@ def test_default_partitions():
 def test_index_with_non_series():
     tm.assert_frame_equal(shuffle(d, d.b).compute(),
                           shuffle(d, 'b').compute())
+
+def test_index_with_dataframe():
+    assert sorted(shuffle(d, d[['b']]).compute().values.tolist()) ==\
+           sorted(shuffle(d, ['b']).compute().values.tolist()) ==\
+           sorted(shuffle(d, 'b').compute().values.tolist())

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -38,3 +38,12 @@ def test_index_with_dataframe():
     assert sorted(shuffle(d, d[['b']]).compute().values.tolist()) ==\
            sorted(shuffle(d, ['b']).compute().values.tolist()) ==\
            sorted(shuffle(d, 'b').compute().values.tolist())
+
+
+def test_shuffle_from_one_partition_to_one_other():
+    df = pd.DataFrame({'x': [1, 2, 3]})
+    a = dd.from_pandas(df, 1)
+
+    for i in [1, 2]:
+        b = shuffle(a, 'x', i)
+        assert len(a.compute(get=get_sync)) == len(b.compute(get=get_sync))

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -146,3 +146,13 @@ def test_subs_with_unfriendly_eq():
     else:
         task = (np.sum, np.array([1, 2]))
         assert (subs(task, (4, 5), 1) == task) is True
+
+
+def test_subs_with_surprisingly_friendly_eq():
+    try:
+        import pandas as pd
+    except:
+        return
+    else:
+        df = pd.DataFrame()
+        assert subs(df, 'x', 1) is df


### PR DESCRIPTION
Very slowly adding functionality for join, concat, merge and friends.

I haven't yet tried to tackle the pandas interface directly.  For now just implementing joins and concats in various situations.  This is going surprisingly smoothly.

This makes heavy use of `repartition` https://github.com/ContinuumIO/dask/pull/354
### Example

```python
In [1]: import pandas as pd

In [2]: import dask.dataframe as dd

In [3]: A = pd.DataFrame({'x': [1, 2, 3, 4, 5, 6], 'z': [10, 20, 30, 40, 50, 60]}, index=[1, 2, 3, 4, 6, 7])

In [4]: B = pd.DataFrame({'y': list('abcdef'), 'z': [10, 20, 40, 50, 60, 80]}, index=[1, 2, 4, 5, 6, 8])

In [5]: a = dd.repartition(A, [1, 4, 7])

In [6]: b = dd.repartition(B, [1, 2, 5, 8])

In [7]: from dask.dataframe.multi import join_indexed_dataframes, hash_join

In [8]: c = join_indexed_dataframes(a, b, 'left', lsuffix='l', rsuffix='r')

In [9]: d = hash_join(a, 'z', b, 'z')

In [12]: c.compute()
Out[12]: 
   x  zl    y  zr
1  1  10    a  10
2  2  20    b  20
3  3  30  NaN NaN
4  4  40    c  40
6  5  50    e  60
7  6  60  NaN NaN

In [13]: d.compute()
Out[13]: 
   x   z  y
0  6  60  e
0  4  40  c
1  1  10  a
0  5  50  d
1  2  20  b
```

### Indexed Join

![indexed-join](https://cloud.githubusercontent.com/assets/306380/8338923/ef04e972-1a68-11e5-9363-981f9d4d7aee.png)

### Hash Join

![hash-join](https://cloud.githubusercontent.com/assets/306380/8338921/ed569c92-1a68-11e5-8650-203665a8891d.png)

