### PR TITLE
Rename map_blocks to map_partitions

### DIFF
--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -1,4 +1,4 @@
-from .core import (DataFrame, Series, Index, _Frame, concat, map_blocks,
+from .core import (DataFrame, Series, Index, _Frame, concat, map_partitions,
         repartition)
 from .io import (read_csv, from_array, from_bcolz, from_array,
                  from_bcolz, from_pandas)

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -148,7 +148,7 @@ def read_csv(fn, *args, **kwargs):
 
     if categorize:
         func = partial(categorize_block, categories=categories)
-        result = result.map_blocks(func, columns=columns)
+        result = result.map_partitions(func, columns=columns)
 
     if index:
         result = set_partition(result, index, quantiles)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -196,15 +196,15 @@ def test_reductions():
     assert eq(d.b.mean(), full.b.mean())
 
 
-def test_map_blocks_multi_argument():
-    assert eq(dd.map_blocks(lambda a, b: a + b, 'c', d.a, d.b),
+def test_map_partitions_multi_argument():
+    assert eq(dd.map_partitions(lambda a, b: a + b, 'c', d.a, d.b),
               full.a + full.b)
-    assert eq(dd.map_blocks(lambda a, b, c: a + b + c, 'c', d.a, d.b, 1),
+    assert eq(dd.map_partitions(lambda a, b, c: a + b + c, 'c', d.a, d.b, 1),
               full.a + full.b + 1)
 
 
-def test_map_blocks():
-    assert eq(d.map_blocks(lambda df: df, 'a'), full)
+def test_map_partitions():
+    assert eq(d.map_partitions(lambda df: df, 'a'), full)
 
 
 def test_drop_duplicates():


### PR DESCRIPTION
This breaks tradition with dask.array but is consistent with dask.bag
and spark