### PR TITLE
WIP - Dataframe docs

### DIFF
--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -17,7 +17,7 @@ from ..compatibility import StringIO, unicode, range
 from ..utils import textblock
 
 from . import core
-from .core import names, DataFrame, compute, concat, categorize_block, tokens
+from .core import DataFrame, compute, concat, categorize_block, tokens
 from .shuffle import set_partition
 
 
@@ -130,7 +130,7 @@ def read_csv(fn, *args, **kwargs):
                           **dissoc(kwargs, 'compression'))
 
     # Create dask graph
-    name = next(names)
+    name = 'read-csv' + next(tokens)
     dsk = dict(((name, i), (rest_read_csv, (_StringIO,
                                (textblock, fn,
                                    i*chunkbytes, (i+1) * chunkbytes,
@@ -432,7 +432,7 @@ def dataframe_from_ctable(x, slc, columns=None, categories=None):
             columns = list(columns)
         x = x[columns]
 
-    name = next(names)
+    name = 'from-bcolz' + next(tokens)
 
     if isinstance(x, bcolz.ctable):
         chunks = [x[name][slc] for name in x.names]

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -8,7 +8,7 @@ import pandas as pd
 import numpy as np
 
 from .. import threaded
-from .core import DataFrame, Series, get, names, _Frame, tokens
+from .core import DataFrame, Series, get, _Frame, tokens
 from ..compatibility import unicode
 from ..utils import ignoring
 from .utils import (strip_categories, unique, shard_df_on_index, _categorize,
@@ -62,13 +62,13 @@ def set_partition(df, index, divisions):
     p = ('zpartd' + next(tokens),)
 
     # Get Categories
-    catname = next(names)
+    catname = 'set-partition--get-categories' + next(tokens)
 
     dsk1 = {catname: (get_categories, df._keys()[0]),
             p: (partd.PandasBlocks, (partd.Buffer, (partd.Dict,), (partd.File,)))}
 
     # Partition data on disk
-    name = next(names)
+    name = 'set-partition--partition' + next(tokens)
     if isinstance(index, _Frame):
         dsk2 = dict(((name, i),
                      (_set_partition, part, ind, divisions, p))
@@ -85,7 +85,7 @@ def set_partition(df, index, divisions):
     dsk3 = {barrier_token: (barrier, list(dsk2))}
 
     # Collect groups
-    name = next(names)
+    name = 'set-partition--collet' + next(tokens)
     dsk4 = dict(((name, i),
                  (_categorize, catname, (_set_collect, i, p, barrier_token)))
                 for i in range(len(divisions) - 1))
@@ -145,7 +145,7 @@ def shuffle(df, index, npartitions=None):
                                                    (partd.File,)))}
 
     # Partition data on disk
-    name = next(names)
+    name = 'shuffle-partition' + next(tokens)
     if isinstance(index, _Frame):
         dsk2 = dict(((name, i),
                      (partition, part, ind, npartitions, p))
@@ -162,7 +162,7 @@ def shuffle(df, index, npartitions=None):
     dsk3 = {barrier_token: (barrier, list(dsk2))}
 
     # Collect groups
-    name = next(names)
+    name = 'shuffle-collect' + next(tokens)
     dsk4 = dict(((name, i),
                  (collect, i, p, barrier_token))
                 for i in range(npartitions))

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -85,7 +85,7 @@ def set_partition(df, index, divisions):
     dsk3 = {barrier_token: (barrier, list(dsk2))}
 
     # Collect groups
-    name = 'set-partition--collet' + next(tokens)
+    name = 'set-partition--collect' + next(tokens)
     dsk4 = dict(((name, i),
                  (_categorize, catname, (_set_collect, i, p, barrier_token)))
                 for i in range(len(divisions) - 1))

--- a/docs/source/dataframe-details.rst
+++ b/docs/source/dataframe-details.rst
@@ -1,0 +1,242 @@
+DataFrame
+=========
+
+Dask.dataframe is not ready for public use.  This document targets developers,
+not users.
+
+.. image:: images/frame.png
+   :width: 50%
+   :align: right
+   :alt: A dask dataframe
+
+Dask dataframe implements a blocked DataFrame as a sequence of in-memory Pandas
+DataFrames, partitioned along the index.
+
+Partitioning along the index is good because it tells us which blocks hold
+which data.  This makes efficient implementations of complex operations like
+join and arbitrary groupby possible in a blocked setting as long as we
+join/group along the index.
+
+Partitioning along the index is also hard because, when we re-index, we need to
+shuffle all of our data between blocks.  This is tricky to code up and
+expensive to compute.
+
+
+Relevant Metadata
+-----------------
+
+Dask ``DataFrame`` objects contain the following data:
+
+*  ``dask`` - The task dependency graph necessary to compute the dataframe
+*  ``_name`` - String like ``'f'`` that is the prefix to all keys to define this dataframe
+   like ``('f', 0)``
+*  ``columns`` - list of column names to improve usability and error checking
+
+    or
+
+    ``name`` - a single name used in a Series
+
+*  ``divisions`` - tuple of index values on which we partition our blocks
+
+The ``divisions`` attribute, analogous to ``chunks`` in ``dask.array`` is
+particularly important.  The values in divisions determine a partitioning of
+left-inclusive / right-exclusive ranges on the index::
+
+    divisions -- (0, 10, 20, 40, 50)
+    ranges    -- [0, 10), [10, 20), [20, 40), [40, 50]
+
+Alternatively if our data is not partitioned (as is unfortunately often the
+case) then divisions will contain many instances of ``None``::
+
+    divisions -- (None, None, None, None, None)
+
+This is common if, for example, we read data from CSV files which don't have an
+obvious ordering.
+
+
+Example Partitioning
+--------------------
+
+Consider the following dataset of twelve entries in an account book separated
+into three dataframes of size four.  We would like to organize them into
+partitions arranged by name::
+
+        name, balance                       name, balance
+        Alice, 100                          Alice, 100
+        Bob, 200                            Alice, 300
+        Alice, 300                          Alice, 600
+        Frank, 400                          Alice, 700
+                                            Alice, 900
+        name, balance
+        Dan, 500                            name, balance
+        Alice, 600       -> Shuffle ->      Bob, 200
+        Alice, 700                          Dan, 500
+        Charlie, 800                        Bob, 1200
+                                            Charlie, 800
+        name, balance
+        Alice, 900                          name, balance
+        Edith, 1000                         Frank, 400
+        Frank, 1100                         Edith, 1000
+        Bob, 1200                           Frank, 1100
+
+Notice a few things
+
+1.  On the right records are now organized by name; given any name (e.g. Bob)
+    it is obvious to which block it belongs (the second).
+2.  Blocks are roughly the same size (though not exactly).  We prefer evenly
+    sized blocks over predictable partition values, (e.g. A, B, C).  Because
+    this dataset has many Alices we have a block just for her.
+3.  The blocks don't need to be sorted internally
+
+Our divisions in this case are ``['Alice', 'Bob', 'Edith', 'Frank']``
+
+
+Quantiles and Shuffle
+---------------------
+
+Many of the complex bits of ``dask.dataframe`` are about shuffling records to
+obtain this nice arrangement of records along an index.  We do this in two
+stages
+
+1.  Find good values on which to partition our data
+    (e.g. find, ``['Bob', 'Edith']``)
+2.  Shuffle records from old blocks to new blocks
+
+
+Find partition values by approximate quantiles
+----------------------------------------------
+
+The problem of finding approximate values that regularly divide our data is
+exactly the problem of approximate quantiles.  This problem is somewhat
+difficult due to the blocked nature of our storage, but has decent solutions.
+
+Currently we compute percentiles/quantiles on the new index of each block and
+then merge these together intelligently.
+
+
+Shuffle without Partitioning
+----------------------------
+
+For large datasets one should endeavor to store data in a partitioned way.
+Often this isn't possible and we need a sane fallback.
+
+We can shuffle data into separate groups without the approximate quantile step
+if we group by a decent hash function.  We can trust that idiosyncrasies in the
+distribution of our data (e.g. far more Alices than Bobs) will be somewhat
+smoothed over by the hash function.  This is a typical solution in many
+databases.
+
+
+Supported API
+-------------
+
+Dask dataframe supports the following API from Pandas
+
+* Trivially parallelizable (fast):
+    *  Elementwise operations:  ``df.x + df.y``
+    *  Row-wise selections:  ``df[df.x > 0]``
+    *  Loc:  ``df.loc[4.0:10.5]``
+    *  Common aggregations:  ``df.x.max()``
+    *  Is in:  ``df[df.x.isin([1, 2, 3])]``
+* Cleverly parallelizable (also fast):
+    *  groupby-aggregate (with common aggregations): ``df.groupby(df.x).y.max()``
+    *  value_counts:  ``df.x.value_counts``
+    *  Drop duplicates:  ``df.x.drop_duplicates()``
+* Requires shuffle (slow-ish, unless on index)
+    *  Set index:  ``df.set_index(df.x)``
+    *  groupby-apply (with anything):  ``df.groupby(df.x).apply(myfunc)``
+* Ingest
+    *  ``pd.read_csv``  (in all its glory)
+
+Dask dataframe also introduces some new API
+
+* Requires full dataset read, but otherwise fast
+    *  Approximate quantiles:  ``df.x.quantiles([25, 50, 75])``
+    *  Convert object dtypes to categoricals:  ``df.categorize()``
+* Ingest
+    *  Read from bcolz (efficient on-disk column-store):
+      ``from_bcolz(x, index='mycol', categorize=True)``
+
+
+Create Dask DataFrames
+----------------------
+
+From CSV files
+~~~~~~~~~~~~~~
+
+``dask.dataframe.read_csv`` uses ``pandas.read_csv`` and so inherits all of
+that functions options.  Additionally it gains two new functionalities
+
+1.  You can provide a globstring
+
+.. code-block:: python
+
+   >>> df = dd.read_csv('data.*.csv.gz', compression='gzip')
+
+2.  You can specify the size of each block of data in bytes of uncompressed
+    data.  Note that, especially for text data the size on disk may be much
+    less than the number of bytes in memory.
+
+.. code-block:: python
+
+   >>> df = dd.read_csv('data.csv', chunkbytes=10000000)  # 1MB chunks
+
+3.  You can ask to categorize your result.  This is slightly faster at read_csv
+    time because we can selectively read the object dtype columns first.  This
+    requires a full read of the dataset and may take some time
+
+.. code-block:: python
+
+   >>> df = dd.read_csv('data.csv', categorize=True)
+
+
+so needs a docstring. Maybe we should have ``iris.csv`` somewhere in
+the project.
+
+From an Array
+~~~~~~~~~~~~~
+
+You can create a DataFrame from any sliceable array like object including both
+NumPy arrays and HDF5 datasets.
+
+.. code-block:: Python
+
+   >>> dd.from_array(x, chunksize=1000000)
+
+From BColz
+~~~~~~~~~~
+
+BColz_ is an on-disk, chunked, compressed, column-store.  These attributes make
+it very attractive for dask.dataframe which can operate particularly well on
+it.  There is a special ``from_bcolz`` function.
+
+.. code-block:: Python
+
+   >>> df = dd.from_bcolz('myfile.bcolz', chunksize=1000000)
+
+In particular column access on a dask.dataframe backed by a ``bcolz.ctable``
+will only read the necessary columns from disk.  This can provide dramatic
+performance improvements.
+
+
+Known Limitations
+-----------------
+
+Dask.dataframe is experimental and not to be used by the general public.
+Additionally it has the following constraints
+
+1.  Is uses the multiprocessing scheduler and so inherits those limitations
+    (see shared_)
+2.  The Pandas API is large and dask.dataframe does not attempt to fill it.
+    Many holes exist
+3.  Operations like groupby and join may take some time, as they are much more
+    challenging to do in parallel
+4.  Some operations like ``iloc`` cease to make sense
+
+Generally speakings users familiar with the mature and excellent functionality
+of Pandas should expect disappointment if they do not deeply understand the
+current design and limitations of dask.dataframe.
+
+
+.. _Chest: http://github.com/ContinuumIO/chest
+.. _shared: shared.html

--- a/docs/source/dataframe.rst
+++ b/docs/source/dataframe.rst
@@ -1,17 +1,19 @@
 DataFrame
 =========
 
-The ``dask.dataframe`` modules implements a blocked parallel clone of a subset
-of the Pandas DataFrame.  One dask DataFrame is comprised of several in-memory
-pandas DataFrames.  An operation on a dask DataFrame triggers possibly very
-many operations on the constituent pandas DataFrames in a way that is mindful
-of potential parallelism and memory constraints.
+The ``dask.dataframe`` module implements a blocked parallel DataFrame that
+mimics a subset of the Pandas DataFrame.  One dask DataFrame is comprised of
+several in-memory pandas DataFrames separated along the index.  An operation on
+one dask DataFrame triggers many operations on the constituent pandas
+DataFrames in a way that is mindful of potential parallelism and memory
+constraints.
 
 Dask.dataframe copies the Pandas API
 ------------------------------------
 
-Dask.dataframe exactly copies the Pandas API so operations should be familiar.
-There are some slight alterations due to the parallel nature of dask.
+Dask.dataframe copies a subset of the Pandas API so operations should be
+familiar to Pandas users.  There are however some alterations due to the
+parallel nature of dask.
 
 .. code-block:: python
 
@@ -28,8 +30,8 @@ There are some slight alterations due to the parallel nature of dask.
 
    >>> df2 = df[df.y == 'a'].x + 1
 
-As with all dask collections (e.g. Array, Bag) one triggers computation by
-calling the ``.compute()`` method.
+As with all dask collections (e.g. Array, Bag, DataFrame) one triggers
+computation by calling the ``.compute()`` method.
 
 .. code-block:: python
 
@@ -39,49 +41,95 @@ calling the ``.compute()`` method.
    Name: x, dtype: int64
 
 
-Threading
----------
+Threaded Scheduling
+-------------------
 
-By default ``dask.dataframe`` uses the multi-threaded scheduler by default.
+By default ``dask.dataframe`` uses the multi-threaded scheduler.
 This exposes some parallelism when pandas or the underlying numpy operations
-release the GIL but generally Pandas is more GIL bound than NumPy, so
-multi-core speedups are not as pronounced.
+release the GIL.  Generally Pandas is more GIL bound than NumPy, so multi-core
+speedups are not as pronounced for ``dask.dataframe`` as they are for
+``dask.array``.  This is changing and the Pandas development team is actively
+working on releasing the GIL.
 
 
 What doesn't work?
 ------------------
 
-Dask.dataframe only covers a small well-used portion of the Pandas API.  This
-is for two reasons
+Dask.dataframe covers a small but well-used portion of the Pandas API.  This is
+for two reasons:
 
 1.  The Pandas API is *huge*
 2.  Some operations are genuinely hard to do in parallel
 
-Additionally, some important operations like ``set_index`` work, but are now
-much slower than in Pandas because they occassionally write out to disk.
+Additionally, some important operations like ``set_index`` work, but are slower
+than in Pandas because they may write out to disk.
 
 
 What definitely works?
 ----------------------
 
-* Trivially parallelizable
+* Trivially parallelizable operations (fast):
     *  Elementwise operations:  ``df.x + df.y``
     *  Row-wise selections:  ``df[df.x > 0]``
     *  Loc:  ``df.loc[4.0:10.5]``
     *  Common aggregations:  ``df.x.max()``
     *  Is in:  ``df[df.x.isin([1, 2, 3])]``
     *  Datetime/string accessors:  ``df.timestamp.month``
-* Cleverly parallelizable (also fast):
+* Cleverly parallelizable operations (also fast):
     *  groupby-aggregate (with common aggregations): ``df.groupby(df.x).y.max()``
     *  value_counts:  ``df.x.value_counts``
     *  Drop duplicates:  ``df.x.drop_duplicates()``
     *  Join on index:  ``dd.merge(df1, df2, left_index=True, right_index=True)``
-* Requires shuffle (slow-ish, unless on index)
+* Operations requiring a shuffle (slow-ish, unless on index)
     *  Set index:  ``df.set_index(df.x)``
     *  groupby-apply (with anything):  ``df.groupby(df.x).apply(myfunc)``
     *  Join not on the index:  ``pd.merge(df1, df2, on='name')``
-* Ingest
+* Ingest operations
     *  CSVs: ``pd.read_csv``
     *  Pandas: ``pd.from_pandas``
     *  Anything supporting numpy slicing: ``pd.from_array``
     *  Dask.bag: ``b.to_dataframe(columns=[...])``
+
+
+Partitions
+----------
+
+Internally a dask dataframe is split into many partitions, each partition is
+one pandas dataframe.  These dataframes are split vertically along the index.
+When our index is sorted and we know the values of the divisions of our
+partitions then we can be clever and efficient.
+
+For example, if we have a time-series index then our partitoins might be divided by
+month.  All of January will live in one partition while all of February will
+live in the next.  In these cases operations like ``loc``, ``groupby``, and
+``join/merge`` along the index can be *much* more efficient than would otherwise be possible.  You can view the number of partitions and divisions of your dataframe with the following fields
+
+.. code-block:: python
+
+   >>> df.npartitions
+   4
+   >>> df.divisions
+   ['2015-01-01', '2015-02-01', '2015-03-01', '2015-04-01', '2015-04-31']
+
+Divisions includes the minimum value of every partition's index and the maximum
+value of the last partition's index.  In the example above if the user searches
+for a specific datetime range then we know which partitions we need to inspect
+and which we can drop.
+
+.. code-block:: python
+
+   >>> df.loc['2015-01-20': '2015-02-10']
+
+Often we do not have such information about our partitions.  When reading CSV
+files for example we do not know, without extra user input, how the data is
+divided.  In this case ``.divisions`` will be all ``None``.
+
+.. code-block:: python
+
+   >>> df.divisions
+   [None, None, None, None, None]
+
+
+See also the API_
+
+.. _API: dataframe-api.html

--- a/docs/source/dataframe.rst
+++ b/docs/source/dataframe.rst
@@ -1,242 +1,87 @@
 DataFrame
 =========
 
-Dask.dataframe is not ready for public use.  This document targets developers,
-not users.
+The ``dask.dataframe`` modules implements a blocked parallel clone of a subset
+of the Pandas DataFrame.  One dask DataFrame is comprised of several in-memory
+pandas DataFrames.  An operation on a dask DataFrame triggers possibly very
+many operations on the constituent pandas DataFrames in a way that is mindful
+of potential parallelism and memory constraints.
 
-.. image:: images/frame.png
-   :width: 50%
-   :align: right
-   :alt: A dask dataframe
+Dask.dataframe copies the Pandas API
+------------------------------------
 
-Dask dataframe implements a blocked DataFrame as a sequence of in-memory Pandas
-DataFrames, partitioned along the index.
+Dask.dataframe exactly copies the Pandas API so operations should be familiar.
+There are some slight alterations due to the parallel nature of dask.
 
-Partitioning along the index is good because it tells us which blocks hold
-which data.  This makes efficient implementations of complex operations like
-join and arbitrary groupby possible in a blocked setting as long as we
-join/group along the index.
+.. code-block:: python
 
-Partitioning along the index is also hard because, when we re-index, we need to
-shuffle all of our data between blocks.  This is tricky to code up and
-expensive to compute.
+   >>> import dask.dataframe as dd
+   >>> df = dd.read_csv('2014-*.csv.gz', compression='gzip')
+   >>> df.head()
+      x  y
+   0  1  a
+   1  2  b
+   2  3  c
+   3  4  a
+   4  5  b
+   5  6  c
 
+   >>> df2 = df[df.y == 'a'].x + 1
 
-Relevant Metadata
------------------
+As with all dask collections (e.g. Array, Bag) one triggers computation by
+calling the ``.compute()`` method.
 
-Dask ``DataFrame`` objects contain the following data:
+.. code-block:: python
 
-*  ``dask`` - The task dependency graph necessary to compute the dataframe
-*  ``_name`` - String like ``'f'`` that is the prefix to all keys to define this dataframe
-   like ``('f', 0)``
-*  ``columns`` - list of column names to improve usability and error checking
-
-    or
-
-    ``name`` - a single name used in a Series
-
-*  ``divisions`` - tuple of index values on which we partition our blocks
-
-The ``divisions`` attribute, analogous to ``chunks`` in ``dask.array`` is
-particularly important.  The values in divisions determine a partitioning of
-left-inclusive / right-exclusive ranges on the index::
-
-    divisions -- (0, 10, 20, 40, 50)
-    ranges    -- [0, 10), [10, 20), [20, 40), [40, 50]
-
-Alternatively if our data is not partitioned (as is unfortunately often the
-case) then divisions will contain many instances of ``None``::
-
-    divisions -- (None, None, None, None, None)
-
-This is common if, for example, we read data from CSV files which don't have an
-obvious ordering.
+   >>> df2.compute()
+   0    2
+   3    5
+   Name: x, dtype: int64
 
 
-Example Partitioning
---------------------
+Threading
+---------
 
-Consider the following dataset of twelve entries in an account book separated
-into three dataframes of size four.  We would like to organize them into
-partitions arranged by name::
-
-        name, balance                       name, balance
-        Alice, 100                          Alice, 100
-        Bob, 200                            Alice, 300
-        Alice, 300                          Alice, 600
-        Frank, 400                          Alice, 700
-                                            Alice, 900
-        name, balance
-        Dan, 500                            name, balance
-        Alice, 600       -> Shuffle ->      Bob, 200
-        Alice, 700                          Dan, 500
-        Charlie, 800                        Bob, 1200
-                                            Charlie, 800
-        name, balance
-        Alice, 900                          name, balance
-        Edith, 1000                         Frank, 400
-        Frank, 1100                         Edith, 1000
-        Bob, 1200                           Frank, 1100
-
-Notice a few things
-
-1.  On the right records are now organized by name; given any name (e.g. Bob)
-    it is obvious to which block it belongs (the second).
-2.  Blocks are roughly the same size (though not exactly).  We prefer evenly
-    sized blocks over predictable partition values, (e.g. A, B, C).  Because
-    this dataset has many Alices we have a block just for her.
-3.  The blocks don't need to be sorted internally
-
-Our divisions in this case are ``['Alice', 'Bob', 'Edith', 'Frank']``
+By default ``dask.dataframe`` uses the multi-threaded scheduler by default.
+This exposes some parallelism when pandas or the underlying numpy operations
+release the GIL but generally Pandas is more GIL bound than NumPy, so
+multi-core speedups are not as pronounced.
 
 
-Quantiles and Shuffle
----------------------
+What doesn't work?
+------------------
 
-Many of the complex bits of ``dask.dataframe`` are about shuffling records to
-obtain this nice arrangement of records along an index.  We do this in two
-stages
+Dask.dataframe only covers a small well-used portion of the Pandas API.  This
+is for two reasons
 
-1.  Find good values on which to partition our data
-    (e.g. find, ``['Bob', 'Edith']``)
-2.  Shuffle records from old blocks to new blocks
+1.  The Pandas API is *huge*
+2.  Some operations are genuinely hard to do in parallel
 
-
-Find partition values by approximate quantiles
-----------------------------------------------
-
-The problem of finding approximate values that regularly divide our data is
-exactly the problem of approximate quantiles.  This problem is somewhat
-difficult due to the blocked nature of our storage, but has decent solutions.
-
-Currently we compute percentiles/quantiles on the new index of each block and
-then merge these together intelligently.
+Additionally, some important operations like ``set_index`` work, but are now
+much slower than in Pandas because they occassionally write out to disk.
 
 
-Shuffle without Partitioning
-----------------------------
+What definitely works?
+----------------------
 
-For large datasets one should endeavor to store data in a partitioned way.
-Often this isn't possible and we need a sane fallback.
-
-We can shuffle data into separate groups without the approximate quantile step
-if we group by a decent hash function.  We can trust that idiosyncrasies in the
-distribution of our data (e.g. far more Alices than Bobs) will be somewhat
-smoothed over by the hash function.  This is a typical solution in many
-databases.
-
-
-Supported API
--------------
-
-Dask dataframe supports the following API from Pandas
-
-* Trivially parallelizable (fast):
+* Trivially parallelizable
     *  Elementwise operations:  ``df.x + df.y``
     *  Row-wise selections:  ``df[df.x > 0]``
     *  Loc:  ``df.loc[4.0:10.5]``
     *  Common aggregations:  ``df.x.max()``
     *  Is in:  ``df[df.x.isin([1, 2, 3])]``
+    *  Datetime/string accessors:  ``df.timestamp.month``
 * Cleverly parallelizable (also fast):
     *  groupby-aggregate (with common aggregations): ``df.groupby(df.x).y.max()``
     *  value_counts:  ``df.x.value_counts``
     *  Drop duplicates:  ``df.x.drop_duplicates()``
+    *  Join on index:  ``dd.merge(df1, df2, left_index=True, right_index=True)``
 * Requires shuffle (slow-ish, unless on index)
     *  Set index:  ``df.set_index(df.x)``
     *  groupby-apply (with anything):  ``df.groupby(df.x).apply(myfunc)``
+    *  Join not on the index:  ``pd.merge(df1, df2, on='name')``
 * Ingest
-    *  ``pd.read_csv``  (in all its glory)
-
-Dask dataframe also introduces some new API
-
-* Requires full dataset read, but otherwise fast
-    *  Approximate quantiles:  ``df.x.quantiles([25, 50, 75])``
-    *  Convert object dtypes to categoricals:  ``df.categorize()``
-* Ingest
-    *  Read from bcolz (efficient on-disk column-store):
-      ``from_bcolz(x, index='mycol', categorize=True)``
-
-
-Create Dask DataFrames
-----------------------
-
-From CSV files
-~~~~~~~~~~~~~~
-
-``dask.dataframe.read_csv`` uses ``pandas.read_csv`` and so inherits all of
-that functions options.  Additionally it gains two new functionalities
-
-1.  You can provide a globstring
-
-.. code-block:: python
-
-   >>> df = dd.read_csv('data.*.csv.gz', compression='gzip')
-
-2.  You can specify the size of each block of data in bytes of uncompressed
-    data.  Note that, especially for text data the size on disk may be much
-    less than the number of bytes in memory.
-
-.. code-block:: python
-
-   >>> df = dd.read_csv('data.csv', chunkbytes=10000000)  # 1MB chunks
-
-3.  You can ask to categorize your result.  This is slightly faster at read_csv
-    time because we can selectively read the object dtype columns first.  This
-    requires a full read of the dataset and may take some time
-
-.. code-block:: python
-
-   >>> df = dd.read_csv('data.csv', categorize=True)
-
-
-so needs a docstring. Maybe we should have ``iris.csv`` somewhere in
-the project.
-
-From an Array
-~~~~~~~~~~~~~
-
-You can create a DataFrame from any sliceable array like object including both
-NumPy arrays and HDF5 datasets.
-
-.. code-block:: Python
-
-   >>> dd.from_array(x, chunksize=1000000)
-
-From BColz
-~~~~~~~~~~
-
-BColz_ is an on-disk, chunked, compressed, column-store.  These attributes make
-it very attractive for dask.dataframe which can operate particularly well on
-it.  There is a special ``from_bcolz`` function.
-
-.. code-block:: Python
-
-   >>> df = dd.from_bcolz('myfile.bcolz', chunksize=1000000)
-
-In particular column access on a dask.dataframe backed by a ``bcolz.ctable``
-will only read the necessary columns from disk.  This can provide dramatic
-performance improvements.
-
-
-Known Limitations
------------------
-
-Dask.dataframe is experimental and not to be used by the general public.
-Additionally it has the following constraints
-
-1.  Is uses the multiprocessing scheduler and so inherits those limitations
-    (see shared_)
-2.  The Pandas API is large and dask.dataframe does not attempt to fill it.
-    Many holes exist
-3.  Operations like groupby and join may take some time, as they are much more
-    challenging to do in parallel
-4.  Some operations like ``iloc`` cease to make sense
-
-Generally speakings users familiar with the mature and excellent functionality
-of Pandas should expect disappointment if they do not deeply understand the
-current design and limitations of dask.dataframe.
-
-
-.. _Chest: http://github.com/ContinuumIO/chest
-.. _shared: shared.html
+    *  CSVs: ``pd.read_csv``
+    *  Pandas: ``pd.from_pandas``
+    *  Anything supporting numpy slicing: ``pd.from_array``
+    *  Dask.bag: ``b.to_dataframe(columns=[...])``

--- a/docs/source/dataframe.rst
+++ b/docs/source/dataframe.rst
@@ -99,10 +99,12 @@ one pandas dataframe.  These dataframes are split vertically along the index.
 When our index is sorted and we know the values of the divisions of our
 partitions then we can be clever and efficient.
 
-For example, if we have a time-series index then our partitoins might be divided by
-month.  All of January will live in one partition while all of February will
-live in the next.  In these cases operations like ``loc``, ``groupby``, and
-``join/merge`` along the index can be *much* more efficient than would otherwise be possible.  You can view the number of partitions and divisions of your dataframe with the following fields
+For example, if we have a time-series index then our partitions might be
+divided by month.  All of January will live in one partition while all of
+February will live in the next.  In these cases operations like ``loc``,
+``groupby``, and ``join/merge`` along the index can be *much* more efficient
+than would otherwise be possible.  You can view the number of partitions and
+divisions of your dataframe with the following fields
 
 .. code-block:: python
 


### PR DESCRIPTION
This resets the dataframe docs to be more user focused

This also does various style cleaning

- normalize old pronouns `f` or `frame` to `df`
- Remove `names` in place of explicit names and `tokens`.  E.g. don't have names like `df-1` but rather descriptive names like `read-csv-1`