### PR TITLE
Various dataframe changes

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -690,8 +690,10 @@ def _coerce_loc_index(divisions, o):
 
     This is particularly valuable to use with pandas datetimes
     """
-    if divisions and isinstance(divisions[0], (np.datetime64, datetime)):
+    if divisions and isinstance(divisions[0], datetime):
         return pd.Timestamp(o)
+    if divisions and isinstance(divisions[0], np.datetime64):
+        return np.datetime64(o)
     return o
 
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -29,6 +29,7 @@ from .. import threaded
 from ..compatibility import unicode, apply
 from ..utils import repr_long_list, IndexCallable, pseudorandom
 from .utils import shard_df_on_index
+from ..context import _globals
 
 
 def _concat(args):
@@ -1074,10 +1075,11 @@ def quantiles(df, q, **kwargs):
     return da.Array(dsk, name3, chunks=((len(q),),))
 
 
-def get(dsk, keys, get=threaded.get, **kwargs):
+def get(dsk, keys, get=None, **kwargs):
     """ Get function with optimizations specialized to dask.Dataframe """
     from .optimize import optimize
     dsk2 = optimize(dsk, keys, **kwargs)
+    get = get or _globals['get'] or threaded.get
     return get(dsk2, keys, **kwargs)  # use synchronous scheduler for now
 
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -16,7 +16,7 @@ from .utils import (strip_categories, unique, shard_df_on_index, _categorize,
         get_categories)
 
 
-def set_index(df, index, npartitions=None, **kwargs):
+def set_index(df, index, npartitions=None, compute=True, **kwargs):
     """ Set DataFrame index to new column
 
     Sorts index and realigns Dataframe to new sorted order.  This shuffles and
@@ -31,10 +31,10 @@ def set_index(df, index, npartitions=None, **kwargs):
     divisions = (index2
                   .quantiles(np.linspace(0, 100, npartitions+1))
                   .compute())
-    return df.set_partition(index, divisions, **kwargs)
+    return df.set_partition(index, divisions, compute=compute, **kwargs)
 
 
-def set_partition(df, index, divisions, compute=False):
+def set_partition(df, index, divisions, compute=False, **kwargs):
     """ Group DataFrame by index
 
     Sets a new index and partitions data along that index according to
@@ -86,8 +86,8 @@ def set_partition(df, index, divisions, compute=False):
     dsk3 = {barrier_token: (barrier, list(dsk2))}
 
     if compute:
-        import pdb; pdb.set_trace()
-        p, barrier_token = get(merge(df.dask, dsk1, dsk2, dsk3), [p, barrier_token])
+        p, barrier_token = get(merge(df.dask, dsk1, dsk2, dsk3),
+                               [p, barrier_token], **kwargs)
 
     # Collect groups
     name = 'set-partition--collect' + next(tokens)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -102,7 +102,7 @@ def set_partition(df, index, divisions, compute=False, **kwargs):
         dsk.update(index.dask)
 
     if compute:
-        dsk = cull(dsk, dsk4.keys())
+        dsk = cull(dsk, list(dsk4.keys()))
 
     return DataFrame(dsk, name, df.columns, divisions)
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -86,8 +86,10 @@ def set_partition(df, index, divisions, compute=False, **kwargs):
     dsk3 = {barrier_token: (barrier, list(dsk2))}
 
     if compute:
-        p, barrier_token = get(merge(df.dask, dsk1, dsk2, dsk3),
-                               [p, barrier_token], **kwargs)
+        dsk = merge(df.dask, dsk1, dsk2, dsk3)
+        if isinstance(index, _Frame):
+            dsk.update(index.dask)
+        p, barrier_token = get(dsk, [p, barrier_token], **kwargs)
 
     # Collect groups
     name = 'set-partition--collect' + next(tokens)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -241,6 +241,14 @@ def test_set_partition():
     assert eq(d2.compute().sort(ascending=True), expected)
 
 
+def test_set_partition_compute():
+    d2 = d.set_partition('b', [0, 2, 9])
+    d3 = d.set_partition('b', [0, 2, 9], compute=True)
+
+    assert eq(d2, d3)
+    assert len(d2.dask) > len(d3.dask)
+
+
 def test_categorize():
     dsk = {('x', 0): pd.DataFrame({'a': ['Alice', 'Bob', 'Alice'],
                                    'b': ['C', 'D', 'E']},
@@ -538,3 +546,26 @@ def test_empty_max():
                       ('x', 1): pd.DataFrame({'x': []})}, 'x',
                       ['x'], [None, None, None])
     assert a.x.max().compute() == 1
+
+
+def test_loc_on_numpy_datetimes():
+    df = pd.DataFrame({'x': [1, 2, 3]},
+                      index=list(map(np.datetime64, ['2014', '2015', '2016'])))
+    a = dd.from_pandas(df, 2)
+    a.divisions = list(map(np.datetime64, a.divisions))
+
+    assert eq(a.loc['2014': '2015'], a.loc['2014': '2015'])
+
+
+def test_loc_on_pandas_datetimes():
+    df = pd.DataFrame({'x': [1, 2, 3]},
+                      index=list(map(pd.Timestamp, ['2014', '2015', '2016'])))
+    a = dd.from_pandas(df, 2)
+    a.divisions = list(map(pd.Timestamp, a.divisions))
+
+    assert eq(a.loc['2014': '2015'], a.loc['2014': '2015'])
+
+
+def test_coerce_loc_index():
+    for t in [pd.Timestamp, np.datetime64]:
+        assert isinstance(_coerce_loc_index([t('2014')], '2014'), t)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -8,7 +8,8 @@ import dask
 from dask.async import get_sync
 from dask.utils import raises
 import dask.dataframe as dd
-from dask.dataframe.core import get, concat, repartition_divisions, _loc
+from dask.dataframe.core import (get, concat, repartition_divisions, _loc,
+        _coerce_loc_index)
 
 
 def eq(a, b):

--- a/dask/distributed/tests/test_client.py
+++ b/dask/distributed/tests/test_client.py
@@ -119,14 +119,21 @@ def test_register_with_scheduler():
         c = Client(s.address_to_clients)
         pid = os.getpid()
         assert s.clients[c.address]['pid'] == os.getpid()
+
+        assert set(c.registered_workers) == set([a.address, b.address])
         assert c.registered_workers[a.address]['pid'] == pid
+        assert c.registered_workers[b.address]['pid'] == pid
 
 
 def test_get_workers():
     with scheduler_and_workers() as (s, (a, b)):
         c = Client(s.address_to_clients)
         pid = os.getpid()
-        assert c.get_registered_workers()[a.address]['pid'] == pid
+
+        workers = c.get_registered_workers()
+        assert set(workers) == set([a.address, b.address])
+        assert workers[a.address]['pid'] == pid
+        assert workers[b.address]['pid'] == pid
 
         s.close_workers()
         assert c.get_registered_workers() == {}


### PR DESCRIPTION
1.  Help with coercion of datetimes
2.  Set_index evaluates more greedily.  This feels nicer in common workflows.
3.  dask.dataframe.core.get respects globals