### PR TITLE
WIP: cluster resiliency, remove workers if they die

### DIFF
--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -1,19 +1,21 @@
 from __future__ import print_function
 
-import zmq
 import socket
-import dill
 import uuid
-from collections import defaultdict
 import itertools
-from multiprocessing.pool import ThreadPool
+import traceback
+import sys
 import random
+from collections import defaultdict
+from multiprocessing.pool import ThreadPool
 from datetime import datetime
 from threading import Thread, Lock
 from contextlib import contextmanager
 from time import sleep
-import traceback
-import sys
+
+import dill
+import zmq
+
 from ..compatibility import Queue, unicode, Empty
 try:
     import cPickle as pickle

--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -737,11 +737,10 @@ class Scheduler(object):
         """
         now = datetime.utcnow()
         remove = []
-        with self.lock:
-            for worker, data in self.workers.items():
-                if abs(data['last-seen'] - now).microseconds > (timeout * 1e6):
-                    remove.append(worker)
-            [self.workers.pop(r) for r in remove]
+        for worker, data in self.workers.items():
+            if abs(data['last-seen'] - now).microseconds > (timeout * 1e6):
+                remove.append(worker)
+        [self.workers.pop(r) for r in remove]
         return remove
 
     def prune_and_notify(self, timeout=20):

--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -11,6 +11,7 @@ import random
 from datetime import datetime
 from threading import Thread, Lock
 from contextlib import contextmanager
+from time import sleep
 import traceback
 import sys
 from ..compatibility import Queue, unicode, Empty
@@ -212,6 +213,7 @@ class Scheduler(object):
         """ Event loop: Monitor worker heartbeats """
         while self.status != 'closed':
             self.prune_and_notify(timeout=timeout)
+            sleep(timeout)
 
     def block(self):
         """ Block until listener threads close

--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -214,8 +214,8 @@ class Scheduler(object):
     def _monitor_workers(self, timeout=20):
         """ Event loop: Monitor worker heartbeats """
         while self.status != 'closed':
-            self.prune_and_notify(timeout=timeout)
             sleep(timeout)
+            self.prune_and_notify(timeout=timeout)
 
     def block(self):
         """ Block until listener threads close

--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -543,10 +543,9 @@ class Scheduler(object):
 
     def close_workers(self):
         header = {'function': 'close'}
-        with self.lock:
-            for w in self.workers:
-                self.send_to_worker(w, header, {})
-        self.workers.clear()
+        while self.workers != {}:
+            w, v = self.workers.popitem()
+            self.send_to_worker(w, header, {})
         self.send_to_workers_queue.join()
 
     def _close(self, header, payload):

--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -539,8 +539,9 @@ class Scheduler(object):
 
     def close_workers(self):
         header = {'function': 'close'}
-        for w in self.workers:
-            self.send_to_worker(w, header, {})
+        with self.lock:
+            for w in self.workers:
+                self.send_to_worker(w, header, {})
         self.workers.clear()
         self.send_to_workers_queue.join()
 

--- a/dask/distributed/tests/test_client.py
+++ b/dask/distributed/tests/test_client.py
@@ -19,6 +19,8 @@ def inc(x):
 def scheduler_and_workers(n=2):
     s = Scheduler()
     workers = [Worker(s.address_to_workers) for i in range(n)]
+    while len(s.workers) < n:
+        sleep(0.01)
     try:
         yield s, workers
     finally:

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -14,7 +14,6 @@ import dill
 
 from dask.distributed.scheduler import Scheduler
 from dask.distributed.worker import Worker
-from dask.compatibility import Queue
 
 context = zmq.Context()
 
@@ -290,35 +289,6 @@ def test_collect_retry():
         assert result.ready() == True
         assert 'x' in w1.data
         assert w1.data['x'] == 42
-
-
-def test_collect():
-    with scheduler_and_workers() as (s, (w1, w2)):
-        w1.data['x'] = 42
-        w2.collect({'x': [w1.address]})
-        assert w2.data['x'] == 42
-
-
-def test_worker_death():
-    with scheduler_and_workers() as (s, (w1, w2)):
-        # setup worker
-        qkey = 'queue_key'
-        dkey = 'data_key'
-        w1.queues[qkey] = Queue()
-        w1.queues_by_worker[w2.address] = {qkey: [dkey]}
-
-        # mock message
-        header = {}
-        payload = pickle.dumps({'removed': [w2.address]})
-
-        # worker death
-        w1.worker_death(header, payload)
-
-        # assertions
-        msg = w1.queues[qkey].get()
-        assert msg['got_key'] == False
-        assert msg['key'] == dkey
-        assert msg['worker'] == w2.address
 
 
 def test_monitor_workers():

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -247,7 +247,7 @@ def test_prune_workers():
 
         w2.close()
         sleep(0.2)
-        assert s.prune_workers(timeout=0.2) == w2.address
+        assert w2.address in s.prune_workers(timeout=0.2)
         assert w1.address in s.workers
         assert w2.address not in s.workers
 

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -266,7 +266,7 @@ def test_workers_reregister():
 
         while w1.address not in s.workers:
             sleep(1e-6)
-        assert w1.address in s.workers  # but now it's back
+        assert w1.address in s.workers  # but now its back
 
 
 def test_collect_retry():

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -235,21 +235,6 @@ def test_close_scheduler():
     assert s.context.closed
 
 
-def test_prune_workers():
-    """
-    We close a worker, then make sure prune workers notices this and removes
-    it from the scheduler. This is "correcting the schedulers' state".
-    """
-    with scheduler_and_workers(worker_kwargs={'heartbeat': 0.001}) as (s, (w1, w2)):
-
-        w2.close()
-        while w2.status != 'closed':
-            sleep(1e-6)
-        assert w2.address in s.prune_workers(timeout=0.01)
-        assert w1.address in s.workers
-        assert w2.address not in s.workers
-
-
 def test_prune_and_notify():
     with scheduler_and_workers(worker_kwargs={'heartbeat': 0.001}) as (s, (w1, w2)):
         # Oh no! A worker died!
@@ -281,7 +266,7 @@ def test_workers_reregister():
 
         while w1.address not in s.workers:
             sleep(1e-6)
-        assert w1.address in s.workers  # but now its back
+        assert w1.address in s.workers  # but now it's back
 
 
 def test_collect_retry():

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -78,9 +78,6 @@ def scheduler_and_workers(n=2, heartbeat=5):
         # wait for workers to register
         while(len(s.workers) < n):
             sleep(0.01)
-        # wait until scheduler sees all heartbeats
-        while not all('last-seen' in s.workers[workers[i].address] for i in range(n)):
-            sleep(0.01)
         try:
             yield s, workers
         finally:

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -269,7 +269,8 @@ def test_workers_reregister():
 
 
 def test_collect_retry():
-    with scheduler_and_workers(n=3, worker_kwargs={'heartbeat': 0.001}) as (s, (w1, w2, w3)):
+    with scheduler_and_workers(n=3, scheduler_kwargs={'worker_timeout': 0.05},
+                               worker_kwargs={'heartbeat': 0.001}) as (s, (w1, w2, w3)):
         w3.data['x'] = 42
         w2.close()
         while w2.status != 'closed':  # make sure closed
@@ -278,7 +279,7 @@ def test_collect_retry():
         result = w1.pool.apply_async(w1.collect,
                                      args=({'x': [w2.address, w3.address]},))
         while w2.address in s.workers:
-            s.prune_and_notify(timeout=0.05)
+            sleep(1e-6)
 
         # make sure prune_and_notify didn't remove these
         assert w1.address in s.workers

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -20,8 +20,8 @@ context = zmq.Context()
 
 
 @contextmanager
-def scheduler(scheduler_kwargs={}):
-    s = Scheduler(**scheduler_kwargs)
+def scheduler(kwargs={}):
+    s = Scheduler(**kwargs)
     try:
         yield s
     finally:

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -278,7 +278,7 @@ def test_collect_retry():
         result = w1.pool.apply_async(w1.collect,
                                      args=({'x': [w2.address, w3.address]},))
         while w2.address in s.workers:
-            s.prune_and_notify(timeout=0.01)
+            s.prune_and_notify(timeout=0.05)
 
         # make sure prune_and_notify didn't remove these
         assert w1.address in s.workers

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -332,3 +332,14 @@ def test_worker_death():
         assert msg['got_key'] == False
         assert msg['key'] == dkey
         assert msg['worker'] == w2.address
+
+
+def test_monitor_workers():
+    with scheduler_and_workers(scheduler_kwargs={'worker_timeout': 0.01},
+                               worker_kwargs={'heartbeat': 0.001}) as (s, (w1, w2)):
+        w2.close()
+        while w2.status != 'closed':  # wait to close
+            sleep(1e-3)
+        while w2.address in s.workers:  # wait to be removed
+            sleep(1e-3)
+        assert w2.address not in s.workers

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -71,7 +71,7 @@ def test_status_client():
 
 
 @contextmanager
-def scheduler_and_workers(n=2, heartbeat=None):
+def scheduler_and_workers(n=2, heartbeat=5):
     with scheduler() as s:
         workers = [Worker(s.address_to_workers, heartbeat=heartbeat) for i in range(n)]
 

--- a/dask/distributed/tests/test_worker.py
+++ b/dask/distributed/tests/test_worker.py
@@ -2,6 +2,7 @@ import pytest
 pytest.importorskip('zmq')
 pytest.importorskip('dill')
 
+from dask.utils import raises
 from dask.distributed.worker import Worker
 from contextlib import contextmanager
 import multiprocessing
@@ -138,6 +139,9 @@ def test_collect():
                            'y': [a.address]})
 
                 assert c.data == dict(a=1, c=5, x=10, y=20)
+
+                assert raises(ValueError,
+                              lambda: c.collect({'nope': [a.address]}))
 
 
 def test_compute():

--- a/dask/distributed/tests/test_worker.py
+++ b/dask/distributed/tests/test_worker.py
@@ -185,6 +185,6 @@ def test_worker_death():
 
             # assertions
             msg = w1.queues[qkey].get()
-            assert msg['got_key'] == False
+            assert msg['status'] == 'failed'
             assert msg['key'] == dkey
             assert msg['worker'] == w2.address

--- a/dask/distributed/tests/test_worker.py
+++ b/dask/distributed/tests/test_worker.py
@@ -24,7 +24,7 @@ def worker(data=None, scheduler='tcp://localhost:5555'):
     if data is None:
         data = dict()
 
-    a = Worker(scheduler, data, heartbeat=False)
+    a = Worker(scheduler, data)
 
     try:
         yield a

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -190,12 +190,17 @@ class Worker(object):
             loads = header.get('loads', pickle.loads)
             payload = loads(payload)
             log(self.address, 'Getitem ack', payload)
-            assert header['status'] == 'OK'
+            if header['status'] == 'Bad key':
+                msg = {'status': 'failed',
+                       'key': payload['key'],
+                       'worker': header['address']}
 
-            self.data[payload['key']] = payload['value']
-            msg = {'status': 'success',
-                   'key': payload['key'],
-                   'worker': self.address}
+            elif header['status'] == 'OK':
+                self.data[payload['key']] = payload['value']
+                msg = {'status': 'success',
+                       'key': payload['key'],
+                       'worker': header['address']}
+
             self.queues[payload['queue']].put(msg)
 
     def getitem_scheduler(self, header, payload):

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -432,16 +432,16 @@ class Worker(object):
         qkey = str(uuid.uuid1())
         queue = Queue()
         self.queues[qkey] = queue
-        locations_copy = locations.copy()  # don't mutate global locations
+        locations = locations.copy()  # don't mutate global locations
 
         # Send out requests for data
-        log(self.address, 'Collect data from peers', locations_copy)
+        log(self.address, 'Collect data from peers', locations)
         start = time()
         counter = 0
         with logerrors():
-            for key, locs in list(locations_copy.items()):
+            for key, locs in list(locations.items()):
                 if key in self.data:  # already have this locally
-                    locations_copy.pop(key)
+                    locations.pop(key)
                     continue
                 worker = random.choice(tuple(locs))  # randomly select one peer
 
@@ -464,17 +464,17 @@ class Worker(object):
             msgs = [queue.get() for i in range(counter)]
             for m in msgs:
                 if not m['got_key']:
-                    locations_copy[m['key']].remove(m['worker'])
+                    locations[m['key']].remove(m['worker'])
                     log(self.address, 'Failed to get key: ', m['key'],
                         ' from worker: ', m['worker'])
                 else:
-                    locations_copy.pop(m['key'])
+                    locations.pop(m['key'])
 
             del self.queues[qkey]
-            if locations_copy != {}:
+            if locations != {}:
                 log(self.address, 'Retrying collect with keys and locations',
-                    locations_copy)
-                self.collect(locations_copy)
+                    locations)
+                self.collect(locations)
             log(self.address, 'Collect finishes', time() - start, 'seconds')
 
     def compute(self, header, payload):

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -566,6 +566,8 @@ class Worker(object):
 
     def worker_death(self, header, payload):
         """
+        A worker died, check no queues are blocking waiting for data from the
+        worker.
         """
         with logerrors():
             loads = header.get('loads', pickle.loads)

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -439,7 +439,7 @@ class Worker(object):
         start = time()
         counter = 0
         with logerrors():
-            for key, locs in locations_copy.items():
+            for key, locs in list(locations_copy.items()):
                 if key in self.data:  # already have this locally
                     locations_copy.pop(key)
                     continue

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -10,7 +10,8 @@ from threading import Thread, Lock, Event
 from multiprocessing.pool import ThreadPool
 from contextlib import contextmanager
 from datetime import datetime
-from time import time, sleep
+from time import time
+from collections import defaultdict
 
 try:
     import cPickle as pickle
@@ -110,7 +111,7 @@ class Worker(object):
         self.lock = Lock()
 
         self.queues = dict()
-        self.queues_by_worker = dict()
+        self.queues_by_worker = defaultdict(lambda: defaultdict(set))
 
         self.pid = os.getpid()
 
@@ -447,12 +448,7 @@ class Worker(object):
                 worker = random.choice(tuple(locs))  # randomly select one peer
 
                 # track keys and where they are comming from
-                if worker not in self.queues_by_worker:
-                    self.queues_by_worker.update({worker: {qkey: [key]}})
-                elif qkey not in self.queues_by_worker[worker]:
-                    self.queues_by_worker[worker].update({qkey: [key]})
-                elif key not in self.queues_by_worker[worker][qkey]:
-                    self.queues_by_worker[worker][qkey].append(key)
+                self.queues_by_worker[worker][qkey].add(key)
 
                 header = {'jobid': key,
                           'function': 'getitem'}

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -112,11 +112,12 @@ class Worker(object):
         self.queues = dict()
         self.queues_by_worker = dict()
 
+        self.pid = os.getpid()
+
         self.to_scheduler = self.context.socket(zmq.DEALER)
 
         self.to_scheduler.setsockopt(zmq.IDENTITY, self.address)
         self.to_scheduler.connect(scheduler)
-        self.send_to_scheduler({'function': 'register'}, {'pid': os.getpid()})
 
         self.scheduler_functions = {'status': self.status_to_scheduler,
                                     'compute': self.compute,
@@ -545,7 +546,7 @@ class Worker(object):
         """Send a message to scheduler at a given interval"""
         while self.status != 'closed':
             header = {'function': 'heartbeat'}
-            payload = {}
+            payload = {'pid': self.pid}
             self.send_to_scheduler(header, payload)
             self._heartbeat_thread.event.wait(pulse)
 

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -192,7 +192,8 @@ class Worker(object):
             assert header['status'] == 'OK'
 
             self.data[payload['key']] = payload['value']
-            msg = {'got_key': True, 'key': payload['key'],
+            msg = {'status': 'success',
+                   'key': payload['key'],
                    'worker': self.address}
             self.queues[payload['queue']].put(msg)
 
@@ -463,7 +464,7 @@ class Worker(object):
 
             msgs = [queue.get() for i in range(counter)]
             for m in msgs:
-                if not m['got_key']:
+                if m['status'] == 'failed':
                     locations[m['key']].remove(m['worker'])
                     log(self.address, 'Failed to get key: ', m['key'],
                         ' from worker: ', m['worker'])
@@ -576,7 +577,7 @@ class Worker(object):
             for w in removed_workers:
                 for queue, keys in self.queues_by_worker[w].items():
                     for k in keys:
-                        msg = {'got_key': False,
+                        msg = {'status': 'failed',
                                'key': k,
                                'worker': w}
                         self.queues[queue].put(msg)

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -450,7 +450,11 @@ class Worker(object):
                 if key in self.data:  # already have this locally
                     locations.pop(key)
                     continue
-                worker = random.choice(tuple(locs))  # randomly select one peer
+                try:
+                    worker = random.choice(tuple(locs))  # randomly select one peer
+                except IndexError:
+                    raise ValueError("%s could not be collected from any "
+                                     "locations." % (key))
 
                 # track keys and where they are comming from
                 self.queues_by_worker[worker][qkey].add(key)


### PR DESCRIPTION
Currently this adds a function to the scheduler that checks if workers have not sent a heartbeat within some timeout period. If this is the case the worker is removed from `Scheduler.workers`.

I want to be able to interrupt the workers if this happens, however I am still thinking of a proper way to do this. Suggestions?

Then once the workers are interrupted restart the job.