### PR TITLE
Add appveyor support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Dask
 ====
 
-|Build Status| |Coverage| |Doc Status| |Gitter| |Downloads|
+|Build Status| |Windows Status| |Coverage| |Doc Status| |Gitter| |Downloads|
 
 Dask provides multi-core execution on larger-than-memory datasets using blocked
 algorithms and task scheduling.  It maps high-level NumPy, Pandas, and list
@@ -225,6 +225,8 @@ includes the following projects:
 .. _blogposts: http://matthewrocklin.com/blog/tags.html#dask-ref
 .. |Build Status| image:: https://travis-ci.org/ContinuumIO/dask.png
    :target: https://travis-ci.org/ContinuumIO/dask
+.. |Windows Status| image:: https://ci.appveyor.com/api/projects/status/7qh6jn1bn6rmyld8/branch/master?svg=true
+   :target: https://ci.appveyor.com/project/jcrist/dask-u9ok5
 .. |Version Status| image:: https://pypip.in/v/dask.png
    :target: https://pypi.python.org/pypi/dask/
 .. |Doc Status| image:: https://readthedocs.org/projects/dask/badge/?version=latest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+# CI on Windows via appveyor
+# This file was based on Olivier Grisel's python-appveyor-demo
+
+environment:
+
+  matrix:
+    - PYTHON: "C:\\Python27-conda32"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python34-conda64"
+      PYTHON_VERSION: "3.4"
+      PYTHON_ARCH: "64"
+
+install:
+  # Install miniconda Python
+  - "powershell ./install_python.ps1"
+
+  # Prepend newly installed Python to the PATH of this build (this cannot be
+  # done from inside the powershell script as it would require to restart
+  # the parent CMD process).
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+  # Check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  # install dask and depenencies
+  - "conda config --set always_yes yes --set changeps1 no"
+  - "conda update conda"
+  - "conda create -n test-environment python=%PYTHON_VERSION%"
+  - "activate test-environment"
+  - "conda install --quiet pytest numpy pip coverage toolz pandas scikit-learn cytoolz dill networkx pyzmq psutil ipython bcolz chest cython bokeh"
+  - "pip install git+https://github.com/mrocklin/partd --upgrade"
+
+  # Install dask
+  - "python setup.py install"
+
+build: false
+
+test_script:
+  - "py.test dask --verbose"

--- a/install_python.ps1
+++ b/install_python.ps1
@@ -1,0 +1,93 @@
+# Sample script to install Python and pip under Windows
+# Authors: Olivier Grisel, Jonathan Helmus and Kyle Kastner
+# License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+
+$MINICONDA_URL = "http://repo.continuum.io/miniconda/"
+$BASE_URL = "https://www.python.org/ftp/python/"
+
+
+function DownloadMiniconda ($python_version, $platform_suffix) {
+    $webclient = New-Object System.Net.WebClient
+    if ($python_version -eq "3.4") {
+        $filename = "Miniconda3-3.7.3-Windows-" + $platform_suffix + ".exe"
+    } else {
+        $filename = "Miniconda-3.7.3-Windows-" + $platform_suffix + ".exe"
+    }
+    $url = $MINICONDA_URL + $filename
+
+    $basedir = $pwd.Path + "\"
+    $filepath = $basedir + $filename
+    if (Test-Path $filename) {
+        Write-Host "Reusing" $filepath
+        return $filepath
+    }
+
+    # Download and retry up to 3 times in case of network transient errors.
+    Write-Host "Downloading" $filename "from" $url
+    $retry_attempts = 2
+    for($i=0; $i -lt $retry_attempts; $i++){
+        try {
+            $webclient.DownloadFile($url, $filepath)
+            break
+        }
+        Catch [Exception]{
+            Start-Sleep 1
+        }
+   }
+   if (Test-Path $filepath) {
+       Write-Host "File saved at" $filepath
+   } else {
+       # Retry once to get the error message if any at the last try
+       $webclient.DownloadFile($url, $filepath)
+   }
+   return $filepath
+}
+
+
+function InstallMiniconda ($python_version, $architecture, $python_home) {
+    Write-Host "Installing Python" $python_version "for" $architecture "bit architecture to" $python_home
+    if (Test-Path $python_home) {
+        Write-Host $python_home "already exists, skipping."
+        return $false
+    }
+    if ($architecture -eq "32") {
+        $platform_suffix = "x86"
+    } else {
+        $platform_suffix = "x86_64"
+    }
+    $filepath = DownloadMiniconda $python_version $platform_suffix
+    Write-Host "Installing" $filepath "to" $python_home
+    $install_log = $python_home + ".log"
+    $args = "/S /D=$python_home"
+    Write-Host $filepath $args
+    Start-Process -FilePath $filepath -ArgumentList $args -Wait -Passthru
+    if (Test-Path $python_home) {
+        Write-Host "Python $python_version ($architecture) installation complete"
+    } else {
+        Write-Host "Failed to install Python in $python_home"
+        Get-Content -Path $install_log
+        Exit 1
+    }
+}
+
+
+function InstallMinicondaPip ($python_home) {
+    $pip_path = $python_home + "\Scripts\pip.exe"
+    $conda_path = $python_home + "\Scripts\conda.exe"
+    if (-not(Test-Path $pip_path)) {
+        Write-Host "Installing pip..."
+        $args = "install --yes pip"
+        Write-Host $conda_path $args
+        Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
+    } else {
+        Write-Host "pip already installed."
+    }
+}
+
+
+function main () {
+    InstallMiniconda $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON
+    InstallMinicondaPip $env:PYTHON
+}
+
+main


### PR DESCRIPTION
Build script works fine, everything gets setup and run properly. Just need to turn on appveyor for master.
Currently only testing on Python 2.7 + Win32 and Python 3.4 + Win64.

Right now I'm seeing an error on Python 2.7 + Win32 in a dask.distributed test ([test log](https://ci.appveyor.com/project/jcrist/dask/build/1.0.4/job/urb0le3a4x96pful)). Not sure if it's periodic, a python 2.7 + windows bug, or a python + Win32 bug. Would be easier to figure out if I had access to a windows machine.

Fixes #371.