### PR TITLE
WIP: dask.array.store_context

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -619,6 +619,22 @@ def test_store():
     assert raises(ValueError, lambda: store([at, bt], [at, bt]))
 
 
+def test_store_context():
+    d = da.ones((4, 4), chunks=(2, 2))
+    a, b = d + 1, d + 2
+
+    at = np.empty(shape=(4, 4))
+    bt = np.empty(shape=(4, 4))
+
+    @contextlib.contextmanager
+    def gen_array(arr):
+        yield arr
+
+    store_context([a, b], [gen_array(at), gen_array(bt)])
+    assert (at == 2).all()
+    assert (bt == 3).all()
+
+
 def test_to_hdf5():
     try:
         import h5py


### PR DESCRIPTION
Posting this for feedback -- I know it needs a bit more polish.

This function stores dask arrays in array-like objects created and
cleaned up by context-managers.

This is useful, for example, if you would like to store arrays in a very
larger number of files, such that creating each of the files in which to
store these arrays ahead of time would exhaust your file pointers.

Example usage:

    >>> import h5py
    >>> @contextlib.contextmanager
    ... def out(n, shape, dtype):
    ...     with h5py.File('%s.hdf5' % n) as f:
    ...         yield f.create_dataset('data', shape=shape, dtype=dtype)

    >>> target_contexts = [out(n, a.shape, a.dtype) for n, a in enumerate(arrays)]
    >>> store_context(arrays, target_contexts)