### PR TITLE
Add rerun_on_exception kwarg to async scheduler

### DIFF
--- a/dask/async.py
+++ b/dask/async.py
@@ -409,6 +409,9 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
     get_id : callable, optional
         Function to return the worker id, takes no arguments. Examples are
         `threading.current_thread` and `multiprocessing.current_process`.
+    rerun_on_exception : bool, optional
+        Whether to rerun failing tasks in local process to enable debugging
+        (False by default)
     start_callback : function, optional
         Callback run every time a new task is started. Receives the key of the
         task to be run, the dask, and the scheduler state. At the end of

--- a/dask/async.py
+++ b/dask/async.py
@@ -480,7 +480,9 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
                 "Something you've asked dask to compute raised an exception.\n"
                 "That exception and the traceback are copied below.\n"
                 "To use pdb, rerun the computation with the keyword argument\n"
-                "    rerun_exceptions_locally=True\n\n"
+                "    dask.set_options(rerun_exceptions_locally=True)\n"
+                "    or\n"
+                "    dataset.compute(rerun_exceptions_locally=True)\n\n"
                 "The original exception and traceback follow below:\n\n"
                     + str(res) + "\n\nTraceback:\n" + tb)
         state['cache'][key] = res

--- a/dask/async.py
+++ b/dask/async.py
@@ -474,7 +474,13 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
                 task = dsk[key]
                 _execute_task(task, data)  # Re-execute locally
             else:
-                raise type(res)(" Exception in remote process\n\n"
+                raise type(res)(
+                "Exception occurred in remote worker.\n\n"
+                "Something you've asked dask to compute raised an exception.\n"
+                "That exception and the traceback are copied below.\n"
+                "To use pdb, rerun the computation with the keyword argument\n"
+                "    rerun_on_exception=True\n\n"
+                "The original exception and traceback follow below:\n\n"
                     + str(res) + "\n\nTraceback:\n" + tb)
         state['cache'][key] = res
         finish_task(dsk, key, state, results, keyorder.get)

--- a/dask/async.py
+++ b/dask/async.py
@@ -380,7 +380,8 @@ The main function of the scheduler.  Get is the main entry point.
 
 def get_async(apply_async, num_workers, dsk, result, cache=None,
               queue=None, get_id=default_get_id, raise_on_exception=False,
-              start_callback=None, end_callback=None, rerun_on_exception=False,
+              start_callback=None, end_callback=None,
+              rerun_exceptions_locally=False,
               **kwargs):
     """ Asynchronous get function
 
@@ -409,7 +410,7 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
     get_id : callable, optional
         Function to return the worker id, takes no arguments. Examples are
         `threading.current_thread` and `multiprocessing.current_process`.
-    rerun_on_exception : bool, optional
+    rerun_exceptions_locally : bool, optional
         Whether to rerun failing tasks in local process to enable debugging
         (False by default)
     start_callback : function, optional
@@ -468,7 +469,7 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
     while state['waiting'] or state['ready'] or state['running']:
         key, res, tb, worker_id = queue.get()
         if isinstance(res, Exception):
-            if rerun_on_exception:
+            if rerun_exceptions_locally:
                 data = dict((dep, state['cache'][dep])
                             for dep in get_dependencies(dsk, key))
                 task = dsk[key]
@@ -479,7 +480,7 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
                 "Something you've asked dask to compute raised an exception.\n"
                 "That exception and the traceback are copied below.\n"
                 "To use pdb, rerun the computation with the keyword argument\n"
-                "    rerun_on_exception=True\n\n"
+                "    rerun_exceptions_locally=True\n\n"
                 "The original exception and traceback follow below:\n\n"
                     + str(res) + "\n\nTraceback:\n" + tb)
         state['cache'][key] = res

--- a/dask/async.py
+++ b/dask/async.py
@@ -381,7 +381,7 @@ The main function of the scheduler.  Get is the main entry point.
 def get_async(apply_async, num_workers, dsk, result, cache=None,
               queue=None, get_id=default_get_id, raise_on_exception=False,
               start_callback=None, end_callback=None,
-              rerun_exceptions_locally=False,
+              rerun_exceptions_locally=None,
               **kwargs):
     """ Asynchronous get function
 
@@ -441,6 +441,9 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
     keyorder = order(dsk)
 
     state = start_state_from_dask(dsk, cache=cache, sortkey=keyorder.get)
+
+    if rerun_exceptions_locally is None:
+        rerun_exceptions_locally = _globals.get('rerun_exceptions_locally', False)
 
     if state['waiting'] and not state['ready']:
         raise ValueError("Found no accessible jobs in dask")

--- a/dask/context.py
+++ b/dask/context.py
@@ -21,6 +21,7 @@ class set_options(object):
         cache - Cache to use for intermediate results
         func_loads/func_dumps - loads/dumps functions for serialization of data
             likely to contain functions.  Defaults to dill.loads/dill.dumps
+        rerun_exceptions_locally - rerun failed tasks in master process
 
     Example
     -------

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -165,3 +165,9 @@ def test_rerun_exceptions_locally():
         get({'x': (f,)}, 'x', rerun_exceptions_locally=True)
     except Exception as e:
         assert 'remote' not in str(e).lower()
+
+    try:
+        with dask.set_options(rerun_exceptions_locally=True):
+            get({'x': (f,)}, 'x')
+    except Exception as e:
+        assert 'remote' not in str(e).lower()

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -149,7 +149,7 @@ def test_order_of_startstate():
     assert result['ready'] == ['b', 'y']
 
 
-def test_rerun_on_exception():
+def test_rerun_exceptions_locally():
     counter = [0]
     def f():
         counter[0] += 1
@@ -162,6 +162,6 @@ def test_rerun_on_exception():
         assert 'remote' in str(e).lower()
 
     try:
-        get({'x': (f,)}, 'x', rerun_on_exception)
+        get({'x': (f,)}, 'x', rerun_exceptions_locally=True)
     except Exception as e:
         assert 'remote' not in str(e).lower()

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -147,3 +147,21 @@ def test_order_of_startstate():
     result = start_state_from_dask(dsk)
 
     assert result['ready'] == ['b', 'y']
+
+
+def test_rerun_on_exception():
+    counter = [0]
+    def f():
+        counter[0] += 1
+        raise Exception('TOKEN')
+
+    from dask.threaded import get
+    try:
+        get({'x': (f,)}, 'x')
+    except Exception as e:
+        assert 'remote' in str(e).lower()
+
+    try:
+        get({'x': (f,)}, 'x', rerun_on_exception)
+    except Exception as e:
+        assert 'remote' not in str(e).lower()


### PR DESCRIPTION
This reruns the failing task in the main process when an exception
occurs.  This enables the use of tools like ``pdb`` on parallel code
with errors.

Example
-------

```python
In [1]: from dask.threaded import get

In [2]: def div(x):
    return x / 0
   ...: 

In [3]: get({'x': (div, 1)}, 'x')
ZeroDivisionError: Exception occurred in remote worker.

Something you've asked dask to compute raised an exception.
That exception and the traceback are copied below.
To use pdb, rerun the computation with the keyword argument
    rerun_on_exception=True

The original exception and traceback follow below:

integer division or modulo by zero

Traceback:
  File "dask/async.py", line 260, in execute_task
    result = _execute_task(task, data)
  File "dask/async.py", line 243, in _execute_task
    return func(*args2)
  File "<ipython-input-2-fb7f8b9553bd>", line 2, in div
    return x / 0

In [4]: pdb
Automatic pdb calling has been turned ON

In [5]: get({'x': (div, 1)}, 'x', rerun_on_exception=True)
ZeroDivisionError: integer division or modulo by zero
> <ipython-input-2-fb7f8b9553bd>(2)div()
      1 def div(x):
----> 2     return x / 0
      3 

ipdb> print x
1
```

I'm not sure if we want this on by default or not.  

Argument for: It's almost always really helpful and sort of hard to explain to people well
Argument against: In the event of side effects this is potentially surprising and harmful because the function gets run twice.

I've also significantly expanded the "Exception in remote worker" error message.  I'm not yet super happy with it.  Recommendations on how to concisely convey the situation and steps out of it are welcome.

@quasiben - This could use your feedback on how to improve the user experience

Fixes #386 