### PR TITLE
numpy_compat.divide uses np.divide

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1969,11 +1969,21 @@ def chunks_from_arrays(arrays):
     >>> x = np.array([[1, 2]])
     >>> chunks_from_arrays([[x, x]])
     ((1,), (2, 2))
+
+    >>> chunks_from_arrays([1, 1])
+    ((1, 1),)
     """
     result = []
     dim = 0
+
+    def shape(x):
+        try:
+            return x.shape
+        except AttributeError:
+            return (1,)
+
     while isinstance(arrays, (list, tuple)):
-        result.append(tuple(deepfirst(a).shape[dim] for a in arrays))
+        result.append(tuple(shape(deepfirst(a))[dim] for a in arrays))
         arrays = arrays[0]
         dim += 1
     return tuple(result)
@@ -2021,11 +2031,19 @@ def concatenate3(arrays):
         return arrays
     chunks = chunks_from_arrays(arrays)
     shape = tuple(map(sum, chunks))
-    result = np.empty(shape=shape, dtype=deepfirst(arrays).dtype)
+
+    def dtype(x):
+        try:
+            return x.dtype
+        except AttributeError:
+            return type(x)
+
+    result = np.empty(shape=shape, dtype=dtype(deepfirst(arrays)))
 
     for (idx, arr) in zip(slices_from_chunks(chunks), core.flatten(arrays)):
-        while arr.ndim < ndim:
-            arr = arr[None, ...]
+        if hasattr(arr, 'ndim'):
+            while arr.ndim < ndim:
+                arr = arr[None, ...]
         result[idx] = arr
 
     return result

--- a/dask/array/numpy_compat.py
+++ b/dask/array/numpy_compat.py
@@ -36,18 +36,7 @@ except TypeError:
 
         Temporary compatibility fix for a bug in numpy's version. See
         https://github.com/numpy/numpy/issues/3484 for the relevant issue."""
-
-        out_orig = out
-        if out is None:
-            out = np.asarray(x1, dtype=dtype)
-            if out is x1:
-                out = x1.copy()
-        else:
-            if out is not x1:
-                out[:] = x1
-        if dtype is not None and out.dtype != dtype:
-            out = out.astype(dtype)
-        out /= x2
-        if out_orig is None and np.isscalar(x1):
-            out = np.asscalar(out)
-        return out
+        x = np.divide(x1, x2, out)
+        if dtype is not None:
+            x = x.astype(dtype)
+        return x

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -74,6 +74,10 @@ def test_concatenate3():
                             [x, x, x]]).shape == (2, 6)
 
 
+def test_concatenate3_on_scalars():
+    assert eq(concatenate3([1, 2]), np.array([1, 2]))
+
+
 def eq(a, b):
     if isinstance(a, Array):
         adt = a._dtype

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -254,6 +254,14 @@ def test_short_stack():
     assert get(s.dask, s._keys())[0][0].shape == (1, 1)
 
 
+def test_stack_scalars():
+    d = da.arange(4, chunks=2)
+
+    s = da.stack([d.mean(), d.sum()])
+
+    assert s.compute().tolist() == [np.arange(4).mean(), np.arange(4).sum()]
+
+
 def test_concatenate():
     a, b, c = [Array(getem(name, chunks=(2, 3), shape=(4, 6)),
                      name, shape=(4, 6), chunks=(2, 3))

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -217,3 +217,9 @@ def test_nan():
     assert eq(np.nanargmax(x, axis=0), da.nanargmax(d, axis=0))
     with ignoring(AttributeError):
         assert eq(np.nanprod(x), da.nanprod(d))
+
+
+def test_0d_array():
+    x = da.mean(da.ones(4, chunks=4), axis=0).compute()
+    y = np.mean(np.ones(4))
+    assert type(x) == type(y)

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -223,3 +223,7 @@ def test_0d_array():
     x = da.mean(da.ones(4, chunks=4), axis=0).compute()
     y = np.mean(np.ones(4))
     assert type(x) == type(y)
+
+    x = da.sum(da.zeros(4, chunks=1)).compute()
+    y = np.sum(np.zeros(4))
+    assert type(x) == type(y)


### PR DESCRIPTION
Fixes #391

cc @jcrist does this miss something with np.divide?

cc @shoyer this seems to handle the mean type issue