### PR TITLE
Discussion: Add an imperative way of building dask graphs

### DIFF
--- a/dask/pipe.py
+++ b/dask/pipe.py
@@ -1,0 +1,64 @@
+"""
+Dynamically trace code decorated to build an execution graph.
+"""
+
+import uuid
+
+EXECUTION_GRAPH = {}
+
+class Variable(object):
+
+    def __init__(self):
+        self._uid = uuid.uuid4().hex
+
+    def __getitem__(self, *args):
+        # How does dask deal with multiple return arguments?
+        pass
+
+    def get():
+        # Here call the dask computation retrieval mechanism
+        pass
+
+
+def add_var(obj):
+    variable = Variable()
+    EXECUTION_GRAPH[variable._uid] = obj
+    return variable
+
+
+class do(object):
+    # Could also be called 'run'
+
+    def __init__(self, function):
+        self.function = function
+
+    def __call__(self, *args, **kwargs):
+        traceable_args = [arg if isinstance(arg, Variable)
+                          else add_var(arg)
+                          for arg in args]
+        traceable_args = tuple([arg._uid for arg in traceable_args])
+
+        # XXX: I don't know how dask deals so far with kwargs
+        #traceable_kwargs = dict((name,
+        #                          arg._uid if isinstance(arg, Variable)
+        #                          else arg)
+        #                        for name, arg in kwargs.items())
+        result = Variable()
+        EXECUTION_GRAPH[result._uid] = (self.function, ) + traceable_args
+
+        return result
+
+
+if __name__ == '__main__':
+    # Simple demo code, doing a bit of pseudo computation, and displaying
+    # the built execution graph
+    import numpy as np
+
+    x = do(np.add)(1, 2)
+    y = do(np.multiply)(x, 4)
+    z = do(np.sum)(x, y, do(np.power)(x, 4))
+
+    import pprint
+    pprint.pprint(EXECUTION_GRAPH)
+
+


### PR DESCRIPTION
After discussions with @mrocklin , here is a bunch of code to introduce a way of building execution graphs for dask with an imperative API in standard Python.

There are two important reasons to strive for write standard imperative Python. First, all the static analysis tools that are useful to guard oneself against typos would no longer be able to detect a spelling error in a variable name. Similarly, it breaks all the help that an IDE is giving to writing or refactory coding. The second thing about loosing imperative Python syntax, is that I loose all my standard ability to write flow control, and I need to learn new tricks. That's really a deal-breaker for anything non trivial.  

The code in this PR is just proof of principle. It can be vastly improved in many ways. It comes with an example at the end of the file which shows imperative code that builds a dask graph.

I will not have time to work on this to finish off. I am submitting this PR at the request of @mrocklin to generate discussion. I will most likely not have much time to commit on this discussion, other project really need my time.