### PR TITLE
Raise informative error on chunks=None

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -633,7 +633,7 @@ class Array(object):
         return self._chunks
 
     def _set_chunks(self, chunks):
-        raise ValueError("Can not set chunks directly\n\n"
+        raise TypeError("Can not set chunks directly\n\n"
             "Please use the rechunk method instead:\n"
             "  x.rechunk(%s)" % str(chunks))
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1078,15 +1078,14 @@ def normalize_chunks(chunks, shape=None):
     >>> normalize_chunks((), shape=(0, 0))  #  respects null dimensions
     ((), ())
     """
+    if chunks is None:
+        raise ValueError(chunks_none_error_message)
     if isinstance(chunks, list):
         chunks = tuple(chunks)
     if isinstance(chunks, Number):
         chunks = (chunks,) * len(shape)
-    if not chunks:
-        if not shape:
-            chunks = ()
-        else:
-            raise ValueError(chunks_none_error_message)
+    if not chunks and shape and all(s == 0 for s in shape):
+        chunks = ((),) * len(shape)
 
     if shape is not None:
         chunks = tuple(c if c is not None else s for c, s in zip(chunks, shape))

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -611,6 +611,8 @@ class Array(object):
         self.dask = dask
         self.name = name
         self.chunks = normalize_chunks(chunks, shape)
+        if self.chunks is None:
+            raise ValueError(chunks_none_error_message)
         if dtype is not None:
             dtype = np.dtype(dtype)
         self._dtype = dtype
@@ -1081,10 +1083,10 @@ def normalize_chunks(chunks, shape=None):
     if isinstance(chunks, Number):
         chunks = (chunks,) * len(shape)
     if not chunks:
-        if shape is None:
+        if not shape:
             chunks = ()
         else:
-            chunks = ((),) * len(shape)
+            raise ValueError(chunks_none_error_message)
 
     if shape is not None:
         chunks = tuple(c if c is not None else s for c, s in zip(chunks, shape))
@@ -1752,6 +1754,13 @@ for a more thorough explanation:
 """.strip()
 
 
+chunks_none_error_message = """
+You must specify a chunks= keyword argument.
+This specifies the chunksize of your array blocks.
+
+See the following documentation page for details:
+  http://dask.pydata.org/en/latest/array-creation.html#chunks
+""".strip()
 
 @wraps(np.where)
 def where(condition, x=None, y=None):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -442,7 +442,7 @@ def map_blocks(func, *arrs, **kwargs):
         chunks = tuple([nb * (bs,)
                         for nb, bs in zip(result.numblocks, chunks)])
     if chunks is not None:
-        result.chunks = chunks
+        result._chunks = chunks
 
     return result
 
@@ -605,13 +605,13 @@ class Array(object):
         block sizes along each dimension
     """
 
-    __slots__ = 'dask', 'name', 'chunks', '_dtype'
+    __slots__ = 'dask', 'name', '_chunks', '_dtype'
 
     def __init__(self, dask, name, chunks, dtype=None, shape=None):
         self.dask = dask
         self.name = name
-        self.chunks = normalize_chunks(chunks, shape)
-        if self.chunks is None:
+        self._chunks = normalize_chunks(chunks, shape)
+        if self._chunks is None:
             raise ValueError(chunks_none_error_message)
         if dtype is not None:
             dtype = np.dtype(dtype)
@@ -628,6 +628,16 @@ class Array(object):
     @property
     def shape(self):
         return tuple(map(sum, self.chunks))
+
+    def _get_chunks(self):
+        return self._chunks
+
+    def _set_chunks(self, chunks):
+        raise ValueError("Can not set chunks directly\n\n"
+            "Please use the rechunk method instead:\n"
+            "  x.rechunk(%s)" % str(chunks))
+
+    chunks = property(_get_chunks, _set_chunks, "chunks property")
 
     def __len__(self):
         return sum(self.chunks[0])

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1082,3 +1082,13 @@ def test_take_dask_from_numpy():
 
 def test_normalize_chunks():
     assert normalize_chunks(3, (4, 6)) == ((3, 1), (3, 3))
+
+
+def test_raise_on_no_chunks():
+    x = da.ones(6, chunks=3)
+    try:
+        Array(x.dask, x.name, chunks=None, dtype=x.dtype)
+    except ValueError as e:
+        assert "dask.pydata.org" in str(e)
+
+    assert raises(ValueError, lambda: da.ones(6))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1093,3 +1093,12 @@ def test_raise_on_no_chunks():
         assert "dask.pydata.org" in str(e)
 
     assert raises(ValueError, lambda: da.ones(6))
+
+
+def test_chunks_is_immutable():
+    x = da.ones(6, chunks=3)
+    try:
+        x.chunks = 2
+        assert False
+    except ValueError as e:
+        assert 'rechunk(2)' in str(e)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1100,5 +1100,5 @@ def test_chunks_is_immutable():
     try:
         x.chunks = 2
         assert False
-    except ValueError as e:
+    except TypeError as e:
         assert 'rechunk(2)' in str(e)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1087,7 +1087,8 @@ def test_normalize_chunks():
 def test_raise_on_no_chunks():
     x = da.ones(6, chunks=3)
     try:
-        Array(x.dask, x.name, chunks=None, dtype=x.dtype)
+        Array(x.dask, x.name, chunks=None, dtype=x.dtype, shape=None)
+        assert False
     except ValueError as e:
         assert "dask.pydata.org" in str(e)
 


### PR DESCRIPTION
Fixes #415

Example
-------

```python
In [1]: import dask.array as da

In [2]: da.random.random(size=(100, 100))
ValueError: You must specify a chunks= keyword argument.
This specifies the chunksize of your array blocks.

See the following documentation page for details:
  http://dask.pydata.org/en/latest/array-creation.html#chunks
```
cc @jdwarner