### PR TITLE
Better repr for distributed workers.

### DIFF
--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -530,6 +530,11 @@ class Worker(object):
     def __del__(self):
         self.close()
 
+    def __repr__(self):
+        s = '<dask.distributed.Worker at %s address=%s, scheduler=%s>'
+        return s % (hex(id(self)), self.address.decode('utf-8')[6:],
+                    self.scheduler.decode('utf-8')[6:])
+
     def heart(self, pulse=5):
         """Send a message to scheduler at a given interval"""
         while self.status != 'closed':

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -531,8 +531,8 @@ class Worker(object):
         self.close()
 
     def __repr__(self):
-        s = '<dask.distributed.Worker at %s address=%s, scheduler=%s>'
-        return s % (hex(id(self)), self.address.decode('utf-8')[6:],
+        s = '<dask.distributed.Worker address=%s, scheduler=%s>'
+        return s % (self.address.decode('utf-8')[6:],
                     self.scheduler.decode('utf-8')[6:])
 
     def heart(self, pulse=5):


### PR DESCRIPTION
```python
In [1]: from dask.distributed import Scheduler, Worker; s = Scheduler(); w = Worker(s.address_to_workers); w
Out[1]: <dask.distributed.Worker at 0x7fdd4c7c26a0 address=camargo:59318, scheduler=camargo:42964>
```