### PR TITLE
Break apart large files in dask.bag.from_filenames

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -804,6 +804,11 @@ def from_filenames(filenames, chunkbytes=None):
 
     >>> b = from_filenames('myfiles.*.txt')  # doctest: +SKIP
 
+    Parallelize a large files by providing the number of uncompressed bytes to
+    load into each partition.
+
+    >>> b = from_filenames('largefile.txt', chunkbytes=1e7)  # 10 MB chunks
+
     See also:
         from_sequence: A more generic bag creation function
     """
@@ -818,6 +823,7 @@ def from_filenames(filenames, chunkbytes=None):
     name = 'from-filename' + next(tokens)
 
     if chunkbytes:
+        chunkbytes = int(chunkbytes)
         taskss = [_chunk_read_file(fn, chunkbytes) for fn in full_filenames]
         d = dict(((name, i), task)
                  for i, task in enumerate(toolz.concat(taskss)))

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -807,7 +807,7 @@ def from_filenames(filenames, chunkbytes=None):
     Parallelize a large files by providing the number of uncompressed bytes to
     load into each partition.
 
-    >>> b = from_filenames('largefile.txt', chunkbytes=1e7)  # 10 MB chunks
+    >>> b = from_filenames('largefile.txt', chunkbytes=1e7)  # doctest: +SKIP
 
     See also:
         from_sequence: A more generic bag creation function
@@ -841,8 +841,8 @@ def _chunk_read_file(filename, chunkbytes):
     extension = os.path.splitext(filename)[1].strip('.')
     compression = {'gz': 'gzip', 'bz2': 'bz2'}.get(extension, None)
 
-    return [(list, (StringIO,
-                    (textblock, filename, i, i + chunkbytes, compression)))
+    return [(list, (StringIO, (bytes.decode,
+                    (textblock, filename, i, i + chunkbytes, compression))))
              for i in range(0, file_size(filename, compression), chunkbytes)]
 
 

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -835,7 +835,8 @@ def _chunk_read_file(filename, chunkbytes):
     extension = os.path.splitext(filename)[1].strip('.')
     compression = {'gz': 'gzip', 'bz2': 'bz2'}.get(extension, None)
 
-    return [(list, (StringIO, (textblock, filename, i, i + chunkbytes)))
+    return [(list, (StringIO,
+                    (textblock, filename, i, i + chunkbytes, compression)))
              for i in range(0, file_size(filename, compression), chunkbytes)]
 
 

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -19,7 +19,7 @@ from toolz import (merge, frequencies, merge_with, take, reduce,
                    join, reduceby, valmap, count, map, partition_all, filter,
                    remove, pluck, groupby, topk)
 import toolz
-from ..utils import tmpfile, ignoring
+from ..utils import tmpfile, ignoring, file_size, textblock
 with ignoring(ImportError):
     from cytoolz import (frequencies, merge_with, join, reduceby,
                          count, pluck, groupby, topk)
@@ -28,7 +28,7 @@ from ..multiprocessing import get as mpget
 from ..core import istask, get_dependencies, reverse_dict
 from ..optimize import fuse, cull, inline
 from ..compatibility import (apply, BytesIO, unicode, urlopen, urlparse, quote,
-        unquote)
+        unquote, StringIO)
 from ..context import _globals
 
 names = ('bag-%d' % i for i in itertools.count(1))
@@ -793,7 +793,7 @@ def collect(grouper, group, p, barrier_token):
 opens = {'gz': gzip.open, 'bz2': bz2.BZ2File}
 
 
-def from_filenames(filenames):
+def from_filenames(filenames, chunkbytes=None):
     """ Create dask by loading in lines from many files
 
     Provide list of filenames
@@ -815,12 +815,28 @@ def from_filenames(filenames):
 
     full_filenames = [os.path.abspath(f) for f in filenames]
 
-    extension = os.path.splitext(filenames[0])[1].strip('.')
-    myopen = opens.get(extension, open)
+    name = 'from-filename' + next(tokens)
 
-    d = dict((('load', i), (list, (myopen, fn)))
-             for i, fn in enumerate(full_filenames))
-    return Bag(d, 'load', len(d))
+    if chunkbytes:
+        taskss = [_chunk_read_file(fn, chunkbytes) for fn in full_filenames]
+        d = dict(((name, i), task)
+                 for i, task in enumerate(toolz.concat(taskss)))
+    else:
+        extension = os.path.splitext(filenames[0])[1].strip('.')
+        myopen = opens.get(extension, open)
+
+        d = dict(((name, i), (list, (myopen, fn)))
+                 for i, fn in enumerate(full_filenames))
+
+    return Bag(d, name, len(d))
+
+
+def _chunk_read_file(filename, chunkbytes):
+    extension = os.path.splitext(filename)[1].strip('.')
+    compression = {'gz': 'gzip', 'bz2': 'bz2'}.get(extension, None)
+
+    return [(list, (StringIO, (textblock, filename, i, i + chunkbytes)))
+             for i in range(0, file_size(filename, compression), chunkbytes)]
 
 
 def write(data, filename):

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -262,6 +262,16 @@ def test_from_filenames_bz2():
                  (list, (bz2.BZ2File, os.path.abspath('bar.json.bz2')))]))
 
 
+def test_from_filenames_large():
+    with tmpfile() as fn:
+        with open(fn, 'w') as f:
+            f.write('Hello, world!\n' * 100)
+        b = db.from_filenames(fn, chunkbytes=100)
+        c = db.from_filenames(fn)
+        assert len(b.dask) > 5
+        assert list(b) == list(c)
+
+
 @pytest.mark.slow
 def test_from_s3():
     # note we don't test connection modes with aws_access_key and

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -278,8 +278,10 @@ def test_from_filenames_large():
 
 def test_from_filenames_large_gzip():
     with tmpfile('gz') as fn:
-        with gzip.open(fn, 'wb') as f:
-            f.write(b'Hello, world!\n' * 100)
+        f = gzip.open(fn, 'wb')
+        f.write(b'Hello, world!\n' * 100)
+        f.close()
+
         b = db.from_filenames(fn, chunkbytes=100)
         c = db.from_filenames(fn)
         assert len(b.dask) > 5

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -271,6 +271,9 @@ def test_from_filenames_large():
         assert len(b.dask) > 5
         assert list(b) == list(c)
 
+        d = db.from_filenames([fn], chunkbytes=100)
+        assert list(b) == list(d)
+
 
 def test_from_filenames_large_gzip():
     with tmpfile('gz') as fn:

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -272,6 +272,16 @@ def test_from_filenames_large():
         assert list(b) == list(c)
 
 
+def test_from_filenames_large_gzip():
+    with tmpfile('gz') as fn:
+        with gzip.open(fn, 'wb') as f:
+            f.write('Hello, world!\n' * 100)
+        b = db.from_filenames(fn, chunkbytes=100)
+        c = db.from_filenames(fn)
+        assert len(b.dask) > 5
+        assert list(b) == list(c)
+
+
 @pytest.mark.slow
 def test_from_s3():
     # note we don't test connection modes with aws_access_key and

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -10,6 +10,7 @@ from dask.bag.core import (Bag, lazify, lazify_task, fuse, map, collect,
         reduceby, bz2_stream, stream_decompress, reify, partition,
         _parse_s3_URI, inline_singleton_lists, optimize)
 from dask.utils import filetexts, tmpfile, raises
+from dask.async import get_sync
 import dask
 import dask.bag as db
 import shutil
@@ -278,11 +279,11 @@ def test_from_filenames_large():
 def test_from_filenames_large_gzip():
     with tmpfile('gz') as fn:
         with gzip.open(fn, 'wb') as f:
-            f.write('Hello, world!\n' * 100)
+            f.write(b'Hello, world!\n' * 100)
         b = db.from_filenames(fn, chunkbytes=100)
         c = db.from_filenames(fn)
         assert len(b.dask) > 5
-        assert list(b) == list(c)
+        assert list(b) == [s.decode() for s in c]
 
 
 @pytest.mark.slow

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -4,7 +4,6 @@ import pandas as pd
 import numpy as np
 from functools import wraps, partial
 import re
-import struct
 import os
 from glob import glob
 from math import ceil
@@ -13,26 +12,12 @@ from itertools import count
 from operator import getitem
 
 from ..compatibility import BytesIO, unicode, range
-from ..utils import textblock
+from ..utils import textblock, file_size
 from .. import array as da
 
 from . import core
 from .core import DataFrame, Series, compute, concat, categorize_block, tokens
 from .shuffle import set_partition
-
-
-def file_size(fn, compression=None):
-    """ Size of a file on disk
-
-    If compressed then return the uncompressed file size
-    """
-    if compression == 'gzip':
-        with open(fn, 'rb') as f:
-            f.seek(-4, 2)
-            result = struct.unpack('I', f.read(4))[0]
-    else:
-        result = os.stat(fn).st_size
-    return result
 
 
 csv_defaults = {'compression': None}

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from functools import partial
 import os
 import shutil
+import struct
 import gzip
 import tempfile
 import inspect
@@ -246,3 +247,17 @@ def is_integer(i):
         return i
     else:
         return False
+
+
+def file_size(fn, compression=None):
+    """ Size of a file on disk
+
+    If compressed then return the uncompressed file size
+    """
+    if compression == 'gzip':
+        with open(fn, 'rb') as f:
+            f.seek(-4, 2)
+            result = struct.unpack('I', f.read(4))[0]
+    else:
+        result = os.stat(fn).st_size
+    return result


### PR DESCRIPTION
This allows users to break apart single large text files in dask.bag.  It reuses the `textblock` functionality that we've been using in `dask.dataframe.io.read_csv`

```python
In [1]: import dask.bag as db

In [2]: b = db.from_filenames('iris.json', chunkbytes=5000)  # 5kB chunks

In [3]: b.dask
Out[3]: 
{('from-filename-1', 0): (list,
  (<class StringIO.StringIO at 0x7fdf2828f940>,
   (<function dask.utils.textblock>,
    '/home/mrocklin/data/iris.json',
    0,
    5000,
    None))),
 ('from-filename-1', 1): (list,
  (<class StringIO.StringIO at 0x7fdf2828f940>,
   (<function dask.utils.textblock>,
    '/home/mrocklin/data/iris.json',
    5000,
    10000,
    None))),
 ('from-filename-1', 2): (list,
  (<class StringIO.StringIO at 0x7fdf2828f940>,
   (<function dask.utils.textblock>,
    '/home/mrocklin/data/iris.json',
    10000,
    15000,
    None))),
 ('from-filename-1', 3): (list,
  (<class StringIO.StringIO at 0x7fdf2828f940>,
   (<function dask.utils.textblock>,
    '/home/mrocklin/data/iris.json',
    15000,
    20000,
    None)))}

In [5]: b.count().compute()
Out[5]: 150
```

cc @danielfrg