### PR TITLE
Raise informative error on bad keyword arguments

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1108,7 +1108,7 @@ def normalize_chunks(chunks, shape=None):
     return tuple(map(tuple, chunks))
 
 
-def from_array(x, chunks, name=None, lock=False, **kwargs):
+def from_array(x, chunks, name=None, lock=False):
     """ Create dask array from something that looks like an array
 
     Input must have a ``.shape`` and support numpy-style slicing.
@@ -1238,7 +1238,10 @@ def atop(func, out_ind, *args, **kwargs):
         top - dict formulation of this function, contains most logic
     """
     out = kwargs.pop('name', None) or next(names)
-    dtype = kwargs.get('dtype', None)
+    dtype = kwargs.pop('dtype', None)
+    if kwargs:
+        raise TypeError("%s does not take the following keyword arguments %s" %
+            (func.__name__, str(sorted(kwargs.keys()))))
     arginds = list(partition(2, args)) # [x, ij, y, jk] -> [(x, ij), (y, jk)]
     numblocks = dict([(a.name, a.numblocks) for a, ind in arginds])
     argindsstr = list(concat([(a.name, ind) for a, ind in arginds]))

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1566,6 +1566,9 @@ def elemwise(op, *args, **kwargs):
     --------
     atop
     """
+    if not set(['name', 'dtype']).issuperset(kwargs):
+        raise TypeError("%s does not take the following keyword arguments %s" %
+            (op.__name__, str(sorted(set(kwargs) - set(['name', 'dtype'])))))
     name = kwargs.get('name') or next(names)
     out_ndim = max(len(arg.shape) if isinstance(arg, Array) else 0
                    for arg in args)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1123,3 +1123,12 @@ def test_chunks_is_immutable():
         assert False
     except TypeError as e:
         assert 'rechunk(2)' in str(e)
+
+
+def test_raise_on_bad_kwargs():
+    x = da.ones(5, chunks=3)
+    try:
+        da.minimum(x, out=None)
+    except TypeError as e:
+        assert 'minimum' in str(e)
+        assert 'out' in str(e)


### PR DESCRIPTION
Example
-------

```python
In [1]: import dask.array as da

In [2]: x = da.ones(6, chunks=3)

In [3]: da.minimum(x, out=None)
TypeError: minimum does not take the following keyword arguments ['out']
```

cc @JDWarner

Fixes #429