### PR TITLE
DOC: Readme badges (use SVGs)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -223,7 +223,7 @@ includes the following projects:
 .. _Swiftlang: http://swift-lang.org/main/
 .. _PaRSEC: http://icl.eecs.utk.edu/parsec/index.html
 .. _blogposts: http://matthewrocklin.com/blog/tags.html#dask-ref
-.. |Build Status| image:: https://travis-ci.org/ContinuumIO/dask.png
+.. |Build Status| image:: https://travis-ci.org/ContinuumIO/dask.svg
    :target: https://travis-ci.org/ContinuumIO/dask
 .. |Version Status| image:: https://pypip.in/v/dask.png
    :target: https://pypi.python.org/pypi/dask/

--- a/README.rst
+++ b/README.rst
@@ -225,7 +225,7 @@ includes the following projects:
 .. _blogposts: http://matthewrocklin.com/blog/tags.html#dask-ref
 .. |Build Status| image:: https://travis-ci.org/ContinuumIO/dask.svg
    :target: https://travis-ci.org/ContinuumIO/dask
-.. |Version Status| image:: https://pypip.in/v/dask.png
+.. |Version Status| image:: https://img.shields.io/pypi/v/dask.svg
    :target: https://pypi.python.org/pypi/dask/
 .. |Doc Status| image:: https://readthedocs.org/projects/dask/badge/?version=latest
    :target: https://readthedocs.org/projects/dask/?badge=latest


### PR DESCRIPTION
Makes the badges look a little nicer. Also, it appears that pypip.in is down; so, switched to shields.io. ( https://github.com/badges/pypipins/issues/37 )