### PR TITLE
add point slicing to dask.array.core

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -837,10 +837,13 @@ class Array(object):
         return Array(merge(self.dask, dsk), out, chunks, dtype=self._dtype)
 
     def _vindex(self, key):
-        if not len([k for k in key if isinstance(k, list)]) >= 2:
-            raise IndexError("vindex must receive at least two lists")
-        if not all(isinstance(k, list) or k == slice(None, None) for k in key):
-            raise IndexError("vindex must receive only lists and full slices")
+        if (not isinstance(key, tuple) or
+           not len([k for k in key if isinstance(k, list)]) >= 2 or
+           not all(isinstance(k, list) or k == slice(None, None) for k in key)):
+            raise IndexError("vindex expects only lists and full slices\n"
+            "At least two entries must be a list\n"
+            "For other combinations try doing normal slicing first, followed\n"
+            "by vindex slicing")
         key = [i if isinstance(i, list) else None for i in key]
         return _vindex(self, *key)
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -850,6 +850,9 @@ class Array(object):
                for k in key):
             raise IndexError("vindex does not support multi-dimensional keys\n"
                     "Got: %s" % str(key))
+        if len(set(len(k) for k in key if isinstance(k, (list, np.ndarray)))) != 1:
+            raise IndexError("All indexers must have the same length, got\n"
+                    "\t%s" % str(key))
         key = key + (slice(None, None),) * (self.ndim - len(key))
         key = [i if isinstance(i, list) else
                i.tolist() if isinstance(i, np.ndarray) else

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2254,20 +2254,6 @@ def to_hdf5(filename, *args, **kwargs):
         store(list(data.values()), dsets)
 
 
-'''
-def rekey(key, where_none, other):
-    """
-
-    >>> rekey(('x', 1), [0], [5])
-    ('x', 5, 1)
-    >>> rekey(('x', 1), [0, 2], [5, 3])
-    ('x', 5, 1, 3)
-    """
-    result = [key[0]]
-    for i in range(1, len(key) + len(other)):
-
-'''
-
 def interleave_none(a, b):
     """
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2377,6 +2377,7 @@ def _vindex_slice(block, points):
     return block[tuple(points)]
 
 def _vindex_transpose(block, axis):
+    """ Rotate block so that points are on the first dimension """
     axes = [axis] + list(range(axis)) + list(range(axis + 1, block.ndim))
     return block.transpose(axes)
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2283,10 +2283,10 @@ def interleave_none(a, b):
 def keyname(name, i, okey, axis):
     """
 
-    >>> keyname('x', 3, [0, None, 2])
+    >>> keyname('x', 3, [0, None, 2], 1)
     ('x', 0, 3, 2)
 
-    >>> keyname('x', 3, [None, None, 0, 2])
+    >>> keyname('x', 3, [None, None, 0, 2], 0)
     ('x', 3, 0, 2)
     """
     okey = [k for k in okey if k is not None]
@@ -2369,9 +2369,9 @@ def _get_axis(indexes):
 
     >>> _get_axis([[1, 2], None, [1, 2], None])
     0
-    >>> _get_axis([None, [1, 2] [1, 2], None])
+    >>> _get_axis([None, [1, 2], [1, 2], None])
     1
-    >>> _get_axis([None, None, [1, 2] [1, 2]])
+    >>> _get_axis([None, None, [1, 2], [1, 2]])
     2
     """
     ndim = len(indexes)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -838,13 +838,16 @@ class Array(object):
 
     def _vindex(self, key):
         if (not isinstance(key, tuple) or
-           not len([k for k in key if isinstance(k, list)]) >= 2 or
-           not all(isinstance(k, list) or k == slice(None, None) for k in key)):
+           not len([k for k in key if isinstance(k, (np.ndarray, list))]) >= 2 or
+           not all(isinstance(k, (np.ndarray, list)) or k == slice(None, None)
+                   for k in key)):
             raise IndexError("vindex expects only lists and full slices\n"
             "At least two entries must be a list\n"
             "For other combinations try doing normal slicing first, followed\n"
-            "by vindex slicing")
-        key = [i if isinstance(i, list) else None for i in key]
+            "by vindex slicing.  Got: \n\t%s" % str(key))
+        key = [i if isinstance(i, list) else
+               i.tolist() if isinstance(i, np.ndarray) else
+               None for i in key]
         return _vindex(self, *key)
 
     @property

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2105,6 +2105,8 @@ def chunks_from_arrays(arrays):
     >>> chunks_from_arrays([1, 1])
     ((1, 1),)
     """
+    if not arrays:
+        return ()
     result = []
     dim = 0
 
@@ -2136,6 +2138,8 @@ def deepfirst(seq):
 def ndimlist(seq):
     if not isinstance(seq, (list, tuple)):
         return 0
+    elif not seq:
+        return 1
     else:
         return 1 + ndimlist(seq[0])
 
@@ -2161,6 +2165,8 @@ def concatenate3(arrays):
     ndim = ndimlist(arrays)
     if not ndim:
         return arrays
+    if not arrays:
+        return np.empty(())
     chunks = chunks_from_arrays(arrays)
     shape = tuple(map(sum, chunks))
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -850,6 +850,7 @@ class Array(object):
                for k in key):
             raise IndexError("vindex does not support multi-dimensional keys\n"
                     "Got: %s" % str(key))
+        key = key + (slice(None, None),) * (self.ndim - len(key))
         key = [i if isinstance(i, list) else
                i.tolist() if isinstance(i, np.ndarray) else
                None for i in key]

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -845,6 +845,11 @@ class Array(object):
             "At least two entries must be a list\n"
             "For other combinations try doing normal slicing first, followed\n"
             "by vindex slicing.  Got: \n\t%s" % str(key))
+        if any((isinstance(k, np.ndarray) and k.ndim != 1) or
+               (isinstance(k, list) and k and isinstance(k[0], list))
+               for k in key):
+            raise IndexError("vindex does not support multi-dimensional keys\n"
+                    "Got: %s" % str(key))
         key = [i if isinstance(i, list) else
                i.tolist() if isinstance(i, np.ndarray) else
                None for i in key]

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -1,5 +1,5 @@
 from itertools import count, product
-from toolz import merge, first, accumulate
+from toolz import merge, first, accumulate, groupby, pluck
 from operator import getitem, add
 from math import ceil
 from ..compatibility import long

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1237,12 +1237,14 @@ def test_point_slicing_with_full_slice():
     x = np.arange(4*5*6*7).reshape((4, 5, 6, 7))
     d = da.from_array(x, chunks=(2, 3, 3, 4))
 
-    inds = [[[1, 2, 3], None, [4, 3, 2], None],
-            [None, None, [1, 2, 3], [4, 3, 2]],
+    inds = [
+            [None, [0, 2, 3], None, [0, 3, 2]],
+            [[1, 2, 3], None, [3, 2, 1], [5, 3, 4]],
+            [[1, 2, 3], None, [4, 3, 2], None],
             [[1, 2, 3], [3, 2, 1], [3, 2, 1], [5, 3, 4]],
             [[], [], [], None],
-            [[1, 2, 3], None, [3, 2, 1], [5, 3, 4]]]
-
+            [None, None, [1, 2, 3], [4, 3, 2]],
+            ]
 
     for ind in inds:
         slc = [i if isinstance(i, list) else slice(None, None) for i in ind]
@@ -1253,12 +1255,12 @@ def test_point_slicing_with_full_slice():
 
 def test_isel_merge():
     from dask.array.core import _isel_merge
-    locations = [0], [2, 1]
+    locations = [1], [0, 2]
     values = [np.array([[1, 2, 3]]),
               np.array([[10, 20, 30], [40, 50, 60]])]
 
-    assert (_isel_merge(locations, values, 0) == np.array([[1, 2, 3],
-                                                           [40, 50, 60],
+    assert (_isel_merge(locations, values, 0) == np.array([[40, 50, 60],
+                                                           [1, 2, 3],
                                                            [10, 20, 30]])).all()
 
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1226,10 +1226,10 @@ def test_point_slicing():
     x = np.arange(56).reshape((7, 8))
     d = da.from_array(x, chunks=(3, 4))
 
-    result = isel(d, [1, 2, 5, 5], [3, 1, 6, 1])
+    result = d.vindex[[1, 2, 5, 5], [3, 1, 6, 1]]
     assert eq(result, x[[1, 2, 5, 5], [3, 1, 6, 1]])
 
-    result = isel(d, [0, 1, 6, 0], [0, 1, 0, 7])
+    result = d.vindex[[0, 1, 6, 0], [0, 1, 0, 7]]
     assert eq(result, x[[0, 1, 6, 0], [0, 1, 0, 7]])
 
 
@@ -1248,18 +1248,18 @@ def test_point_slicing_with_full_slice():
 
     for ind in inds:
         slc = [i if isinstance(i, list) else slice(None, None) for i in ind]
-        result = isel(d, *ind)
+        result = d.vindex[tuple(slc)]
         expected = x[tuple(slc)]
         assert eq(result, expected)
 
 
-def test_isel_merge():
-    from dask.array.core import _isel_merge
-    locations = [1], [0, 2]
+def test_vindex_merge():
+    from dask.array.core import _vindex_merge
+    locations = [1], [2, 0]
     values = [np.array([[1, 2, 3]]),
               np.array([[10, 20, 30], [40, 50, 60]])]
 
-    assert (_isel_merge(locations, values, 0) == np.array([[40, 50, 60],
+    assert (_vindex_merge(locations, values, 0) == np.array([[40, 50, 60],
                                                            [1, 2, 3],
                                                            [10, 20, 30]])).all()
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1220,3 +1220,14 @@ def test_h5py_newaxis():
 
 def test_ellipsis_slicing():
     assert eq(da.ones(4, chunks=2)[...], np.ones(4))
+
+
+def test_point_slicing():
+    x = np.arange(56).reshape((7, 8))
+    d = da.from_array(x, chunks=(3, 4))
+
+    result = isel(d, [1, 2, 5, 5], [3, 1, 6, 1])
+    assert eq(result, x[[1, 2, 5, 5], [3, 1, 6, 1]])
+
+    result = isel(d, [0, 1, 6, 0], [0, 1, 0, 7])
+    assert eq(result, x[[0, 1, 6, 0], [0, 1, 0, 7]])

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1253,6 +1253,13 @@ def test_point_slicing_with_full_slice():
         assert eq(result, expected)
 
 
+def test_vindex_errors():
+    d = da.ones((5, 5, 5), chunks=(3, 3, 3))
+    assert raises(IndexError, lambda: d.vindex[0])
+    assert raises(IndexError, lambda: d.vindex[[1, 2, 3]])
+    assert raises(IndexError, lambda: d.vindex[[1, 2, 3], [1, 2, 3], 0])
+
+
 def test_vindex_merge():
     from dask.array.core import _vindex_merge
     locations = [1], [2, 0]

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1244,10 +1244,12 @@ def test_point_slicing_with_full_slice():
             [[1, 2, 3], [3, 2, 1], [3, 2, 1], [5, 3, 4]],
             [[], [], [], None],
             [None, None, [1, 2, 3], [4, 3, 2]],
+            [np.array([1, 2, 3]), None, np.array([4, 3, 2]), None],
             ]
 
     for ind in inds:
-        slc = [i if isinstance(i, list) else slice(None, None) for i in ind]
+        slc = [i if isinstance(i, (np.ndarray, list)) else slice(None, None)
+                for i in ind]
         result = d.vindex[tuple(slc)]
         expected = x[tuple(slc)]
         assert eq(result, expected)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1260,7 +1260,7 @@ def test_vindex_errors():
     assert raises(IndexError, lambda: d.vindex[0])
     assert raises(IndexError, lambda: d.vindex[[1, 2, 3]])
     assert raises(IndexError, lambda: d.vindex[[1, 2, 3], [1, 2, 3], 0])
-
+    assert raises(IndexError, lambda: d.vindex[[1, 2, 3], [[1], [2], [3]]])
 
 def test_vindex_merge():
     from dask.array.core import _vindex_merge

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1241,6 +1241,7 @@ def test_point_slicing_with_full_slice():
     inds = [
             [[1, 2, 3], None, [3, 2, 1], [5, 3, 4]],
             [[1, 2, 3], None, [4, 3, 2], None],
+            [[1, 2, 3], [3, 2, 1]],
             [[1, 2, 3], [3, 2, 1], [3, 2, 1], [5, 3, 4]],
             [[], [], [], None],
             [np.array([1, 2, 3]), None, np.array([4, 3, 2]), None],

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1260,3 +1260,7 @@ def test_isel_merge():
     assert (_isel_merge(locations, values, 0) == np.array([[1, 2, 3],
                                                            [40, 50, 60],
                                                            [10, 20, 30]])).all()
+
+
+def test_empty_array():
+    assert eq(np.arange(0), da.arange(0, chunks=5))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1270,6 +1270,7 @@ def test_vindex_errors():
     assert raises(IndexError, lambda: d.vindex[0])
     assert raises(IndexError, lambda: d.vindex[[1, 2, 3]])
     assert raises(IndexError, lambda: d.vindex[[1, 2, 3], [1, 2, 3], 0])
+    assert raises(IndexError, lambda: d.vindex[[1], [1, 2, 3]])
     assert raises(IndexError, lambda: d.vindex[[1, 2, 3], [[1], [2], [3]]])
 
 def test_vindex_merge():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1231,3 +1231,32 @@ def test_point_slicing():
 
     result = isel(d, [0, 1, 6, 0], [0, 1, 0, 7])
     assert eq(result, x[[0, 1, 6, 0], [0, 1, 0, 7]])
+
+
+def test_point_slicing_with_full_slice():
+    x = np.arange(4*5*6*7).reshape((4, 5, 6, 7))
+    d = da.from_array(x, chunks=(2, 3, 3, 4))
+
+    inds = [[[1, 2, 3], None, [4, 3, 2], None],
+            [None, None, [1, 2, 3], [4, 3, 2]],
+            [[1, 2, 3], [3, 2, 1], [3, 2, 1], [5, 3, 4]],
+            [[], [], [], None],
+            [[1, 2, 3], None, [3, 2, 1], [5, 3, 4]]]
+
+
+    for ind in inds:
+        slc = [i if isinstance(i, list) else slice(None, None) for i in ind]
+        result = isel(d, *ind)
+        expected = x[tuple(slc)]
+        assert eq(result, expected)
+
+
+def test_isel_merge():
+    from dask.array.core import _isel_merge
+    locations = [0], [2, 1]
+    values = [np.array([[1, 2, 3]]),
+              np.array([[10, 20, 30], [40, 50, 60]])]
+
+    assert (_isel_merge(locations, values, 0) == np.array([[1, 2, 3],
+                                                           [40, 50, 60],
+                                                           [10, 20, 30]])).all()


### PR DESCRIPTION
This is equivalent to numpy slicing with multiple input lists.

We could use a better name.  cc @shoyer @jhamman

Example
-------

```python
>>> x = np.arange(56).reshape((7, 8))
>>> x
array([[ 0,  1,  2,  3,  4,  5,  6,  7],
       [ 8,  9, 10, 11, 12, 13, 14, 15],
       [16, 17, 18, 19, 20, 21, 22, 23],
       [24, 25, 26, 27, 28, 29, 30, 31],
       [32, 33, 34, 35, 36, 37, 38, 39],
       [40, 41, 42, 43, 44, 45, 46, 47],
       [48, 49, 50, 51, 52, 53, 54, 55]])

>>> d = from_array(x, chunks=(3, 4))
>>> result = isel(d, [0, 1, 6, 0], [0, 1, 0, 7])
>>> result.compute()
array([ 0,  9, 48,  7])
```

Fixes #433