### PR TITLE
Don't test conda.recipe/run_test.py with py.test

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,3 +8,8 @@ def pytest_addoption(parser):
 def pytest_runtest_setup(item):
     if 'slow' in item.keywords and not item.config.getoption("--runslow"):
         pytest.skip("need --runslow option to run")
+
+
+def pytest_ignore_collect(path, config):
+    if 'run_test.py' in str(path):
+        return True


### PR DESCRIPTION
Before, when running py.test from the dask root directory, py.test would
try to "test" the conda.recipe/run_test.py file, and fail, since it is
not for unit-tests.