### PR TITLE
pytest.importorskip('partd') in dask.dataframe

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('partd')
+
 from operator import getitem
 
 import pandas as pd

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('partd')
+
 import gzip
 import pandas as pd
 import numpy as np

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('partd')
+
 import dask.dataframe as dd
 import pandas as pd
 from dask.dataframe.multi import (align_partitions, join_indexed_dataframes,

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip('partd')
+
 import dask.dataframe as dd
 import pandas.util.testing as tm
 import pandas as pd


### PR DESCRIPTION
Don't run dataframe tests that require partd if partd is not present.