### PR TITLE
small edits to distributed

### DIFF
--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -726,11 +726,12 @@ class Scheduler(object):
 
     def _heartbeat(self, header, payload):
         with logerrors():
-            log(self.address_to_clients, "Heartbeat", header)
+            # log(self.address_to_workers, "Heartbeat", header)
             payload = pickle.loads(payload)
             address = header['address']
 
             if address not in self.workers:
+                log(self.address_to_workers, "New Worker", header)
                 self.available_workers.put(address)
 
             self.workers[address] = payload
@@ -746,7 +747,8 @@ class Scheduler(object):
         for worker, data in self.workers.items():
             if abs(data['last-seen'] - now).microseconds > (timeout * 1e6):
                 remove.append(worker)
-        [self.workers.pop(r) for r in remove]
+        for r in remove:
+            self.workers.pop(r)
         return remove
 
     def prune_and_notify(self, timeout=20):

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -248,7 +248,7 @@ def test_prune_and_notify():
 
         # The scheduler notices, and corrects it state.
         while w2.address in s.workers:
-            s.prune_and_notify(timeout=0.01)
+            s.prune_and_notify(timeout=0.1)
 
         # But the sheduler notified the workers about the death
         while not result.ready():

--- a/dask/distributed/worker.py
+++ b/dask/distributed/worker.py
@@ -394,7 +394,7 @@ class Worker(object):
         self._listen_scheduler_thread.join()
         if self.heartbeat:
             self._heartbeat_thread.join()
-        log('Unblocked')
+        log(self.address, 'Unblocked')
 
     def collect(self, locations):
         """ Collect data from peers


### PR DESCRIPTION
1.  Avoid large numbers of heartbeat log messages (I'm not sure if this is wise or not)
2.  Change prune test so that the scheduler checks at an interval much longer than the heartbeats themselves
3.  Slight style changes.