### PR TITLE
support nrows in read_csv

### DIFF
--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -471,3 +471,11 @@ def test_to_csv():
             result = pd.read_csv(fn, index_col=0)
 
             tm.assert_frame_equal(result, df)
+
+
+def test_read_csv_with_nrows():
+    with filetext(text) as fn:
+        f = read_csv(fn, nrows=3)
+        assert list(f.columns) == ['name', 'amount']
+        assert f.npartitions == 1
+        assert eq(read_csv(fn, nrows=3), pd.read_csv(fn, nrows=3))


### PR DESCRIPTION
This creates a dask DataFrame with a single partition with the
desired number of rows.

Some issues:

1.  This adds a significant amount of complexity
2.  This does not work with multiple csv files

cc @rea725