### PR TITLE
Fixes to distributed test suite

### DIFF
--- a/dask/distributed/tests/test_client.py
+++ b/dask/distributed/tests/test_client.py
@@ -17,8 +17,8 @@ def inc(x):
 
 @contextmanager
 def scheduler_and_workers(n=2):
-    s = Scheduler()
-    workers = [Worker(s.address_to_workers) for i in range(n)]
+    s = Scheduler(hostname='127.0.0.1')
+    workers = [Worker(s.address_to_workers, hostname='127.0.0.1') for i in range(n)]
     while len(s.workers) < n:
         sleep(1e-6)
     try:

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -20,7 +20,7 @@ context = zmq.Context()
 
 @contextmanager
 def scheduler(kwargs={}):
-    s = Scheduler(**kwargs)
+    s = Scheduler(hostname='127.0.0.1', **kwargs)
     try:
         yield s
     finally:
@@ -30,7 +30,7 @@ def scheduler(kwargs={}):
 @contextmanager
 def scheduler_and_workers(n=2, scheduler_kwargs={}, worker_kwargs={}):
     with scheduler(scheduler_kwargs) as s:
-        workers = [Worker(s.address_to_workers, **worker_kwargs) for i in range(n)]
+        workers = [Worker(s.address_to_workers, hostname='127.0.0.1', nthreads=50, **worker_kwargs) for i in range(n)]
 
         # wait for workers to register
         while(len(s.workers) < n):

--- a/dask/distributed/tests/test_worker.py
+++ b/dask/distributed/tests/test_worker.py
@@ -23,11 +23,11 @@ def add(x, y):
 
 
 @contextmanager
-def worker(data=None, scheduler='tcp://localhost:5555'):
+def worker(data=None, scheduler='tcp://127.0.0.1:5555'):
     if data is None:
         data = dict()
 
-    a = Worker(scheduler, data)
+    a = Worker(scheduler, data, hostname='127.0.0.1', nthreads=50)
 
     try:
         yield a


### PR DESCRIPTION
- Specify hostname for all Schedulers/Workers
- Use fewer threads per worker

This now passes on my computer. I'm a little concerned about the threads bit, as it seems to indicate they might not be cleaning up properly, but reading through the code I can't see where we miss a thread.