### PR TITLE
Fix GH #472: Add fallback for apply, better class argspec detection

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1104,7 +1104,10 @@ def takes_multiple_arguments(func):
     False
     """
     try:
-        spec = inspect.getargspec(func)
+        if inspect.isclass(func):
+            spec = inspect.getargspec(func.__init__)
+        else:
+            spec = inspect.getargspec(func)
     except:
         return False
     if spec.varargs:

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -16,9 +16,9 @@ if PY3:
     unicode = str
     long = int
     def apply(func, args, kwargs=None):
-        if not isinstance(args, list) and kwargs is None:
+        if not isinstance(args, list) and not isinstance(args, tuple) and kwargs is None:
             return func(args)
-        elif not isinstance(args, list):
+        elif not isinstance(args, list) and not isinstance(args, tuple):
             return func(args, **kwargs)
         elif kwargs:
             return func(*args, **kwargs)

--- a/dask/compatibility.py
+++ b/dask/compatibility.py
@@ -16,7 +16,11 @@ if PY3:
     unicode = str
     long = int
     def apply(func, args, kwargs=None):
-        if kwargs:
+        if not isinstance(args, list) and kwargs is None:
+            return func(args)
+        elif not isinstance(args, list):
+            return func(args, **kwargs)
+        elif kwargs:
             return func(*args, **kwargs)
         else:
             return func(*args)


### PR DESCRIPTION
Fixes GH #472 (mostly).  Compatibility `apply` function now falls back to just calling the function on args if args is not an instance of `list`.  Also, `takes_multiple_arguments` now inspects the `__init__` method for classes, as it is different than inspecting the class itself for some classes.

This _does not_ solve the problem of inspecting classes that inherit from `object`, as even inspecting their `__init__` method doesn't yield the proper results.