### PR TITLE
Add DataFrame.query

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -644,8 +644,19 @@ class DataFrame(_Frame):
 
         return elemwise(_assign, self, *pairs, columns=list(df2.columns))
 
-    @wraps(pd.DataFrame.query)
     def query(self, expr, **kwargs):
+        """ Blocked version of pd.DataFrame.query
+
+        This is like the sequential version except that this will also happen
+        in many threads.  This may conflict with ``numexpr`` which will use
+        multiple threads itself.  We recommend that you set numexpr to use a
+        single thread
+
+            import numexpr
+            numexpr.set_nthreads(1)
+
+        The original docstring follows below:\n
+        """ + pd.DataFrame.query.__doc__
         name = 'query' + next(tokens)
         if kwargs:
             dsk = dict(((name, i), (apply, pd.DataFrame.query,

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -600,3 +600,9 @@ def test_categorical_set_index():
         b = a.set_index(a.y)
         df2 = df.set_index(df.y)
         assert list(b.index.compute()), list(df2.index)
+
+
+def test_query():
+    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [5, 6, 7, 8]})
+    a = dd.from_pandas(df, npartitions=2)
+    assert eq(a.query('x**2 > y'), df.query('x**2 > y'))


### PR DESCRIPTION
Fixes #474

Example
-------

```python
In [1]: import dask.dataframe as dd

In [2]: import pandas as pd

In [3]: df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [5, 6, 7, 8]})

In [4]: a = dd.from_pandas(df, npartitions=2)

In [5]: a.compute()
Out[5]:
   x  y
0  1  5
1  2  6
2  3  7
3  4  8

In [6]: a.query('x**2 > y').compute()
   x  y
2  3  7
3  4  8
```