### PR TITLE
API: qunatile compat with pandas

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -355,13 +355,20 @@ class Series(_Frame):
         return ("dd.Series<%s, divisions=%s>" %
                 (self._name, repr_long_list(self.divisions)))
 
-    def quantiles(self, q):
+    def quantile(self, q):
         """ Approximate quantiles of column
 
         q : list/array of floats
-            Iterable of numbers ranging from 0 to 100 for the desired quantiles
+            Iterable of numbers ranging from 0 to 1 for the desired quantiles
         """
-        return quantiles(self, q)
+        # pandas uses quantile in [0, 1]
+        # numpy / everyone else uses [0, 100]
+        return quantile(self, np.asarray(q) * 100)
+
+    def quantiles(self, *args, **kwargs):
+        raise NotImplementedError("This has moved to quantile to match the Pandas API\n"
+                                  "Also, quantiles will now be specified on the range "
+                                  "[0, 1], not [0, 100]")
 
     def __getitem__(self, key):
         name = 'getitem' + next(tokens)
@@ -1078,7 +1085,7 @@ def categorize(df, columns=None, **kwargs):
     return df.map_partitions(func, columns=df.columns)
 
 
-def quantiles(df, q, **kwargs):
+def quantile(df, q, **kwargs):
     """ Approximate quantiles of column
 
     Parameters

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -225,7 +225,7 @@ def categories_and_quantiles(fn, args, kwargs, index=None, categorize=None,
 
     import dask
     if index:
-        quantiles = d[index].quantiles(np.linspace(0, 100, nchunks + 1))
+        quantiles = d[index].quantile(np.linspace(0, 1, nchunks + 1))
         result = compute(quantiles, *categories)
         quantiles, categories = result[0].values, result[1:]
     else:

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -29,7 +29,7 @@ def set_index(df, index, npartitions=None, compute=True, **kwargs):
         index2 = index
 
     divisions = (index2
-                  .quantiles(np.linspace(0, 100, npartitions+1))
+                  .quantile(np.linspace(0, 1, npartitions+1))
                   .compute()).tolist()
     return set_partition(df, index, divisions, compute=compute, **kwargs)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -298,16 +298,18 @@ def test_len():
     assert len(d) == len(full)
 
 
-def test_quantiles():
-    result = d.b.quantiles([30, 70]).compute()
+def test_quantile():
+    result = d.b.quantile([.3, .7]).compute()
     assert len(result) == 2
     assert result[0] == 0
     assert 3 < result[1] < 7
 
 
-def test_empty_quantiles():
-    assert d.b.quantiles([]).compute().tolist() == []
+def test_empty_quantile():
+    assert d.b.quantile([]).compute().tolist() == []
 
+def test_quantiles_raises():
+    assert raises(NotImplementedError, lambda: d.b.quantiles([30]))
 
 def test_index():
     assert eq(d.index, full.index)


### PR DESCRIPTION
Closes https://github.com/ContinuumIO/dask/issues/469

pandas uses [0, 1] for quantile, and calls it quantile
instead of quantiles.

I did change the top-level function `quantiles` to `quantile` as well, just for consistency.