### PR TITLE
[WIP] Reuse Distributed State

### DIFF
--- a/dask/async.py
+++ b/dask/async.py
@@ -170,13 +170,16 @@ def start_state_from_dask(dsk, cache=None, sortkey=None):
             cache[k] = v
             data_keys.add(k)
 
-    dependencies = dict((k, get_dependencies(dsk, k)) for k in dsk)
+    dsk2 = dsk.copy()
+    dsk2.update(cache)
+
+    dependencies = dict((k, get_dependencies(dsk2, k)) for k in dsk)
     waiting = dict((k, v.copy()) for k, v in dependencies.items()
                                  if k not in data_keys)
 
     dependents = reverse_dict(dependencies)
-    for a in data_keys:
-        for b in dependents[a]:
+    for a in cache:
+        for b in dependents.get(a, ()):
             waiting[b].remove(a)
     waiting_data = dict((k, v.copy()) for k, v in dependents.items() if v)
 

--- a/dask/distributed/client.py
+++ b/dask/distributed/client.py
@@ -37,10 +37,10 @@ class Client(object):
         self.socket.connect(self.address_to_scheduler)
         self.register_client()
 
-    def get(self, dsk, keys):
+    def get(self, dsk, keys, keep_results=False):
         header = {'function': 'schedule',
                   'jobid': next(jobids)}
-        payload = {'dask': dsk, 'keys': keys}
+        payload = {'dask': dsk, 'keys': keys, 'keep_results': keep_results}
 
         self.send_to_scheduler(header, payload)
         header2, payload2 = self.recv_from_scheduler()

--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -668,6 +668,9 @@ class Scheduler(object):
                 for key in flatten(result):
                     if key not in preexisting_data:
                         self.release_key(key)
+
+            self.cull_redundant_data(3)
+
         return result2
 
     def _schedule_from_client(self, header, payload):

--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -683,11 +683,12 @@ class Scheduler(object):
             address = header['address']
             dsk = payload['dask']
             keys = payload['keys']
+            keep_results = payload.get('keep_results', False)
 
             header2 = {'jobid': header.get('jobid'),
                        'function': 'schedule-ack'}
             try:
-                result = self.schedule(dsk, keys)
+                result = self.schedule(dsk, keys, keep_results)
                 header2['status'] = 'OK'
             except Exception as e:
                 result = e

--- a/dask/distributed/scheduler.py
+++ b/dask/distributed/scheduler.py
@@ -571,7 +571,7 @@ class Scheduler(object):
         self.block()
         self.context.destroy(linger=3)
 
-    def schedule(self, dsk, result, **kwargs):
+    def schedule(self, dsk, result, keep_results=False, **kwargs):
         """ Execute dask graph against workers
 
         Parameters
@@ -664,9 +664,10 @@ class Scheduler(object):
                     fire_task()
 
             result2 = self.gather(result)
-            for key in flatten(result):  # release result data from workers
-                if key not in preexisting_data:
-                    self.release_key(key)
+            if not keep_results:  # release result data from workers
+                for key in flatten(result):
+                    if key not in preexisting_data:
+                        self.release_key(key)
         return result2
 
     def _schedule_from_client(self, header, payload):

--- a/dask/distributed/tests/test_client.py
+++ b/dask/distributed/tests/test_client.py
@@ -138,3 +138,12 @@ def test_get_workers():
 
         s.close_workers()
         assert c.get_registered_workers() == {}
+
+
+def test_keep_results():
+    with scheduler_and_workers() as (s, (a, b)):
+        c = Client(s.address_to_clients)
+
+        assert c.get({'x': (inc, 1)}, 'x', keep_results=True) == 2
+
+        assert 'x' in a.data or 'x' in b.data

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -337,3 +337,6 @@ def test_cull_redundant_data():
 
         while 'x' in a.data and 'x' in b.data:
             sleep(0.01)
+
+        assert ('x' in a.data and 'x' not in b.data or
+                'x' in b.data and 'x' not in a.data)

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -310,9 +310,6 @@ def test_monitor_workers():
 
 
 def test_scheduler_reuses_worker_state():
-    def inc(x):
-        return x + 1
-
     with scheduler_and_workers() as (s, (a, b)):
         assert s.schedule({'x': (inc, 1)}, 'x') == 2
 
@@ -322,3 +319,10 @@ def test_scheduler_reuses_worker_state():
         sleep(0.1)
         assert a.data['x'] == 10
         assert s.schedule({'x': (inc, 1), 'y': (lambda x: x, 'x')}, 'y') == 10
+
+
+def test_keep_results():
+    with scheduler_and_workers() as (s, (a, b)):
+        assert s.schedule({'x': (inc, 1)}, 'x', keep_results=True) == 2
+        sleep(0.1)
+        assert a.data.get('x') == 2 or b.data.get('x') == 2

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -319,7 +319,6 @@ def test_scheduler_reuses_worker_state():
         s.send_data('x', 10, address=a.address)  # send x to a worker
         assert a.data['x'] == 10
         assert s.schedule({'x': (inc, 1)}, 'x') == 10  # recall, don't compute
-
-        s.send_data('x', 10, address=a.address)  # send x to a worker
+        sleep(0.1)
         assert a.data['x'] == 10
         assert s.schedule({'x': (inc, 1), 'y': (lambda x: x, 'x')}, 'y') == 10

--- a/dask/distributed/tests/test_scheduler.py
+++ b/dask/distributed/tests/test_scheduler.py
@@ -326,3 +326,14 @@ def test_keep_results():
         assert s.schedule({'x': (inc, 1)}, 'x', keep_results=True) == 2
         sleep(0.1)
         assert a.data.get('x') == 2 or b.data.get('x') == 2
+
+
+def test_cull_redundant_data():
+    with scheduler_and_workers() as (s, (a, b)):
+        s.send_data('x', 10, address=a.address)  # send x to a worker
+        s.send_data('x', 10, address=b.address)  # send x to a worker
+
+        s.cull_redundant_data(1)
+
+        while 'x' in a.data and 'x' in b.data:
+            sleep(0.01)

--- a/dask/tests/test_async.py
+++ b/dask/tests/test_async.py
@@ -33,6 +33,13 @@ def test_start_state():
                                 'y': set(['w']),
                                 'z': set(['w'])}}
 
+def test_start_state_looks_at_cache():
+    dsk = {'b': (inc, 'a')}
+    cache = {'a': 1}
+    result = start_state_from_dask(dsk, cache)
+    assert result['dependencies']['b'] == set(['a'])
+    assert result['ready'] == ['b']
+
 
 def test_start_state_with_redirects():
     dsk = {'x': 1, 'y': 'x', 'z': (inc, 'y')}


### PR DESCRIPTION
This is a WIP PR to establish and reuse state in the distributed scheduler. 

When computing on the distributed scheduler you can provide a keyword argument to keep the results in memory on the workers.  When future computations occur they reuse this state.

- [x] Execution state checks provided cache
- [x] `distributed.Scheduler.schedule` culls unnecessary parts of the graph after looking at data in current memory
- [x] Provide user hook to ask for the result to stay in memory rather than be cleared out.

Fixes #488 cc @dataisle