### PR TITLE
Add `compute` method for dask.imperative

### DIFF
--- a/dask/imperative.py
+++ b/dask/imperative.py
@@ -194,12 +194,9 @@ def compute(*args, **kwargs):
     >>> compute(b, c)  # Compute both simultaneously
     (3, 4)
     """
-    if len(args) == 1:
-        return args[0].compute(**kwargs)
-    else:
-        dsk = merge(*[arg.dask for arg in args])
-        keys = [arg.key for arg in args]
-        return tuple(get(dsk, keys, **kwargs))
+    dsk = merge(*[arg.dask for arg in args])
+    keys = [arg.key for arg in args]
+    return tuple(get(dsk, keys, **kwargs))
 
 
 def right(method):

--- a/dask/tests/test_imperative.py
+++ b/dask/tests/test_imperative.py
@@ -86,7 +86,7 @@ def test_compute():
     b = a + 1
     c = a + 2
     assert compute(b, c) == (7, 8)
-    assert compute(b) == 7
+    assert compute(b) == (7,)
 
 
 def test_named_value():

--- a/dask/tests/test_imperative.py
+++ b/dask/tests/test_imperative.py
@@ -2,7 +2,7 @@ from operator import add
 from collections import Iterator
 from random import random
 
-from dask.imperative import value, do, to_task_dasks
+from dask.imperative import value, do, to_task_dasks, compute
 from dask.utils import raises
 
 
@@ -79,6 +79,14 @@ def test_do():
     a = value(1)
     b = add2(add2(a, 2), 3)
     assert a.key in b.dask
+
+
+def test_compute():
+    a = value(1) + 5
+    b = a + 1
+    c = a + 2
+    assert compute(b, c) == (7, 8)
+    assert compute(b) == 7
 
 
 def test_named_value():

--- a/docs/source/imperative.rst
+++ b/docs/source/imperative.rst
@@ -141,5 +141,6 @@ Definitions
 
 .. autofunction:: value
 .. autofunction:: do
+.. autofunction:: compute
 
 .. _`custom graphs`: custom-graphs.html#Example


### PR DESCRIPTION
Can now compute multiple values at once in a clean manner.

```
>>> from dask.imperative import value, compute
>>> a = value(1)
>>> b = a + 1
>>> c = a + 2
>>> compute(b, c)
(2, 3)
```

cc @cpcloud