### PR TITLE
Add support for lists of Values in compute

### DIFF
--- a/dask/imperative.py
+++ b/dask/imperative.py
@@ -193,7 +193,10 @@ def compute(*args, **kwargs):
     >>> c = a + 3
     >>> compute(b, c)  # Compute both simultaneously
     (3, 4)
+    >>> compute(a, [b, c])
+    (1, [3, 4])
     """
+    args = [value(a) for a in args]
     dsk = merge(*[arg.dask for arg in args])
     keys = [arg.key for arg in args]
     return tuple(get(dsk, keys, **kwargs))
@@ -345,6 +348,8 @@ def value(val, name=None):
     AttributeError("'list' object has no attribute 'not_a_real_method'")
     """
 
+    if isinstance(val, Value):
+        return val
     name = name or tokenize(val, True)
     task, dasks = to_task_dasks(val)
     dasks.append({name: task})

--- a/dask/tests/test_imperative.py
+++ b/dask/tests/test_imperative.py
@@ -87,6 +87,7 @@ def test_compute():
     c = a + 2
     assert compute(b, c) == (7, 8)
     assert compute(b) == (7,)
+    assert compute([a, b], c) == ([6, 7], 8)
 
 
 def test_named_value():


### PR DESCRIPTION
```python
>>> a = value(1)
>>> b = a + 1
>>> c = a + 2
>>> compute(a, [b, c])
(1, [2, 3])
```