### PR TITLE
Cachey

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then conda install bokeh; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then conda install unittest2; fi
   - pip install git+https://github.com/mrocklin/partd --upgrade
+  - pip install git+https://github.com/mrocklin/cachey --upgrade
   - pip install blosc --upgrade
   - pip install graphviz
   - if [[ $TRAVIS_PYTHON_VERSION < '3' ]]; then pip install git+https://github.com/Blosc/castra; fi

--- a/dask/async.py
+++ b/dask/async.py
@@ -123,6 +123,7 @@ from .core import istask, flatten, reverse_dict, get_dependencies, ishashable
 from .context import _globals
 from .order import order
 from .callbacks import unpack_callbacks
+from .optimize import cull
 
 def inc(x):
     return x + 1
@@ -436,6 +437,8 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
 
     for f in start_cbs:
         f(dsk)
+
+    dsk = cull(dsk, list(results))
 
     keyorder = order(dsk)
 

--- a/dask/async.py
+++ b/dask/async.py
@@ -434,11 +434,12 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
         result_flat = set([result])
     results = set(result_flat)
 
+    for f in start_cbs:
+        f(dsk)
+
     keyorder = order(dsk)
 
     state = start_state_from_dask(dsk, cache=cache, sortkey=keyorder.get)
-    for f in start_cbs:
-        f(dsk, state)
 
     if rerun_exceptions_locally is None:
         rerun_exceptions_locally = _globals.get('rerun_exceptions_locally', False)

--- a/dask/async.py
+++ b/dask/async.py
@@ -435,6 +435,7 @@ def get_async(apply_async, num_workers, dsk, result, cache=None,
         result_flat = set([result])
     results = set(result_flat)
 
+    dsk = dsk.copy()
     for f in start_cbs:
         f(dsk)
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -30,6 +30,9 @@ from ..base import Base, compute
 no_default = '__no_default__'
 
 
+pd.computation.expressions.set_use_numexpr(False)
+
+
 def tokenize(obj):
     """ Deterministic token
 

--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -3,7 +3,7 @@
 a, b, c, d, e = '~a', '~b', '~c', '~d', '~e'
 from ..rewrite import RuleSet, RewriteRule
 from .io import dataframe_from_ctable
-from ..optimize import cull, fuse, inline_functions, fuse_getitem
+from ..optimize import cull, inline_functions, fuse_getitem
 from ..core import istask
 from ..utils import ignoring
 from .. import core
@@ -12,22 +12,16 @@ from operator import getitem
 import operator
 
 
-fast_functions = [getattr(operator, attr) for attr in dir(operator)
-                                          if not attr.startswith('_')]
-
-
 def optimize(dsk, keys, **kwargs):
     if isinstance(keys, list):
         dsk2 = cull(dsk, list(core.flatten(keys)))
     else:
         dsk2 = cull(dsk, [keys])
-    dsk3 = inline_functions(dsk2, fast_functions)
     try:
         from castra import Castra
-        dsk4 = fuse_getitem(dsk3, Castra.load_partition, 3)
+        dsk3 = fuse_getitem(dsk2, Castra.load_partition, 3)
     except ImportError:
-        dsk4 = dsk3
-    dsk5 = fuse_getitem(dsk4, dataframe_from_ctable, 3)
-    dsk6 = fuse(dsk5)
-    dsk7 = cull(dsk6, keys)
-    return dsk7
+        dsk3 = dsk2
+    dsk4 = fuse_getitem(dsk3, dataframe_from_ctable, 3)
+    dsk5 = cull(dsk4, keys)
+    return dsk5

--- a/dask/dataframe/tests/test_optimize_dataframe.py
+++ b/dask/dataframe/tests/test_optimize_dataframe.py
@@ -27,24 +27,14 @@ def test_column_optimizations_with_bcolz_and_rewrite():
                           for i in [1, 2, 3]),
                      dict((('y', i),
                           (getitem, ('x', i), (list, ['a', 'b'])))
-                          for i in [1, 2, 3]),
-                     dict((('z', i), (func, ('y', i)))
                           for i in [1, 2, 3]))
 
-        expected = dict((('z', i), (func, (dataframe_from_ctable,
-                                     bc, slice(0, 2), (list, ['a', 'b']), {})))
+        expected = dict((('y', i), (dataframe_from_ctable,
+                                     bc, slice(0, 2), (list, ['a', 'b']), {}))
                           for i in [1, 2, 3])
 
-        result = dd.optimize(dsk2, [('z', i) for i in [1, 2, 3]])
+        result = dd.optimize(dsk2, [('y', i) for i in [1, 2, 3]])
         assert result == expected
-
-
-def test_fast_functions():
-    df = dd.DataFrame(dsk, 'x', ['a', 'b'], [None, None, None, None])
-    e = df.a + df.b
-    assert len(e.dask) > 6
-
-    assert len(dd.optimize(e.dask, e._keys())) == 6
 
 
 def test_castra_column_store():

--- a/dask/diagnostics/__init__.py
+++ b/dask/diagnostics/__init__.py
@@ -1,2 +1,3 @@
 from .profile import Profiler
 from .progress import ProgressBar
+from .cache import Cache

--- a/dask/diagnostics/cache.py
+++ b/dask/diagnostics/cache.py
@@ -13,7 +13,7 @@ class Cache(Diagnostic):
     >>> cache = Cache(1e9)  # available bytes
 
     >>> with cache:         # use as a context manager around get/compute calls
-    ...     result = x.compute()
+    ...     result = x.compute()  # doctest: +SKIP
 
     >>> cache.register()    # or use globally
     """

--- a/dask/diagnostics/cache.py
+++ b/dask/diagnostics/cache.py
@@ -53,4 +53,5 @@ class Cache(Callback):
         self.cache.put(key, value, cost=duration / nb / 1e9, nbytes=nb)
 
     def _finish(self, dsk, state, errored):
-        pass
+        self.starttimes.clear()
+        self.durations.clear()

--- a/dask/diagnostics/cache.py
+++ b/dask/diagnostics/cache.py
@@ -1,11 +1,15 @@
 from ..callbacks import Callback
 from timeit import default_timer
 from numbers import Number
+import sys
 
 try:
     import cachey
 except ImportError:
     pass
+
+overhead = sys.getsizeof(1.23) * 4 + sys.getsizeof(()) * 4
+
 
 class Cache(Callback):
     """ Use cache for computation
@@ -45,7 +49,7 @@ class Cache(Callback):
         if deps:
             duration += max(self.durations.get(k, 0) for k in deps)
         self.durations[key] = duration
-        nb = cachey.nbytes(value)
+        nb = cachey.nbytes(value) + overhead + sys.getsizeof(key) * 4
         self.cache.put(key, value, cost=duration / nb / 1e9, nbytes=nb)
 
     def _finish(self, dsk, state, errored):

--- a/dask/diagnostics/cache.py
+++ b/dask/diagnostics/cache.py
@@ -1,0 +1,29 @@
+from .core import Diagnostic
+from timeit import default_timer
+from cachey import Cache, nbytes
+
+
+class cache(Diagnostic):
+    """ Use cache for computation
+
+    """
+
+    def __init__(self, cache):
+        self.cache = cache
+        self.starttimes = dict()
+
+    def _start(self, dsk):
+        overlap = set(dsk) & set(self.cache.data)
+        for key in overlap:
+            dsk[key] = self.cache.data[key]
+
+    def _pretask(self, key, dsk, state):
+        self.starttimes[key] = default_timer()
+
+    def _posttask(self, key, value, dsk, state, id):
+        duration = default_timer() - self.starttimes[key]
+        nb = nbytes(value)
+        self.cache.put(key, value, cost=duration / nb / 1e9, nbytes=nb)
+
+    def _finish(self, dsk, state, errored):
+        pass

--- a/dask/diagnostics/cache.py
+++ b/dask/diagnostics/cache.py
@@ -16,6 +16,7 @@ class Cache(Diagnostic):
     ...     result = x.compute()  # doctest: +SKIP
 
     >>> cache.register()    # or use globally
+    >>> cache.unregister()
     """
 
     def __init__(self, cache, *args, **kwargs):

--- a/dask/diagnostics/cache.py
+++ b/dask/diagnostics/cache.py
@@ -1,4 +1,4 @@
-from .core import Diagnostic
+from ..callbacks import Callback
 from timeit import default_timer
 from numbers import Number
 
@@ -7,7 +7,7 @@ try:
 except ImportError:
     pass
 
-class Cache(Diagnostic):
+class Cache(Callback):
     """ Use cache for computation
 
     Example

--- a/dask/diagnostics/cache.py
+++ b/dask/diagnostics/cache.py
@@ -1,8 +1,11 @@
 from .core import Diagnostic
 from timeit import default_timer
-import cachey
 from numbers import Number
 
+try:
+    import cachey
+except ImportError:
+    pass
 
 class Cache(Diagnostic):
     """ Use cache for computation

--- a/dask/diagnostics/profile.py
+++ b/dask/diagnostics/profile.py
@@ -45,7 +45,7 @@ class Profiler(Callback):
         self._results = {}
         self._dsk = {}
 
-    def _start(self, dsk, state):
+    def _start(self, dsk):
         self.clear()
         self._dsk = dsk.copy()
 

--- a/dask/diagnostics/progress.py
+++ b/dask/diagnostics/progress.py
@@ -43,7 +43,7 @@ class ProgressBar(Callback):
         self._width = width
         self._dt = dt
 
-    def _start(self, dsk, state):
+    def _start(self, dsk):
         self._ntasks = len([k for (k, v) in dsk.items() if istask(v)])
         self._ndone = 0
         self._update_rate = max(1, self._ntasks // self._width)

--- a/dask/diagnostics/tests/test_cache.py
+++ b/dask/diagnostics/tests/test_cache.py
@@ -2,6 +2,7 @@ from dask.diagnostics.cache import Cache
 import cachey
 from dask.threaded import get
 from operator import add
+from dask.context import _globals
 
 
 flag = []
@@ -27,6 +28,8 @@ def test_cache():
         assert get(dsk, 'z') == 5
 
     assert flag == [2]  # no x present
+
+    assert not _globals['callbacks']
 
 
 def test_cache_with_number():

--- a/dask/diagnostics/tests/test_cache.py
+++ b/dask/diagnostics/tests/test_cache.py
@@ -1,5 +1,5 @@
-from dask.diagnostics.cache import cache
-from cachey import Cache
+from dask.diagnostics.cache import Cache
+import cachey
 from dask.threaded import get
 from operator import add
 
@@ -12,9 +12,9 @@ def inc(x):
 
 
 def test_cache():
-    c = Cache(10000)
+    c = cachey.Cache(10000)
 
-    with cache(c):
+    with Cache(c):
         assert get({'x': (inc, 1)}, 'x') == 2
 
     assert flag == [1]
@@ -23,7 +23,14 @@ def test_cache():
     while flag:
         flag.pop()
     dsk = {'x': (inc, 1), 'y': (inc, 2), 'z': (add, 'x', 'y')}
-    with cache(c):
+    with Cache(c):
         assert get(dsk, 'z') == 5
 
     assert flag == [2]  # no x present
+
+
+def test_cache_with_number():
+    c = Cache(10000, limit=1)
+    assert isinstance(c.cache, cachey.Cache)
+    assert c.cache.available_bytes == 10000
+    assert c.cache.limit == 1

--- a/dask/diagnostics/tests/test_cache.py
+++ b/dask/diagnostics/tests/test_cache.py
@@ -1,0 +1,29 @@
+from dask.diagnostics.cache import cache
+from cachey import Cache
+from dask.threaded import get
+from operator import add
+
+
+flag = []
+
+def inc(x):
+    flag.append(x)
+    return x + 1
+
+
+def test_cache():
+    c = Cache(10000)
+
+    with cache(c):
+        assert get({'x': (inc, 1)}, 'x') == 2
+
+    assert flag == [1]
+    assert c.data['x'] == 2
+
+    while flag:
+        flag.pop()
+    dsk = {'x': (inc, 1), 'y': (inc, 2), 'z': (add, 'x', 'y')}
+    with cache(c):
+        assert get(dsk, 'z') == 5
+
+    assert flag == [2]  # no x present

--- a/dask/diagnostics/tests/test_cache.py
+++ b/dask/diagnostics/tests/test_cache.py
@@ -1,8 +1,10 @@
 from dask.diagnostics.cache import Cache
-import cachey
 from dask.threaded import get
 from operator import add
 from dask.context import _globals
+import pytest
+
+cachey = pytest.importorskip('cachey')
 
 
 flag = []

--- a/dask/diagnostics/tests/test_cache.py
+++ b/dask/diagnostics/tests/test_cache.py
@@ -18,17 +18,21 @@ def inc(x):
 
 def test_cache():
     c = cachey.Cache(10000)
+    cc = Cache(c)
 
-    with Cache(c):
+    with cc:
         assert get({'x': (inc, 1)}, 'x') == 2
 
     assert flag == [1]
     assert c.data['x'] == 2
 
+    assert not cc.starttimes
+    assert not cc.durations
+
     while flag:
         flag.pop()
     dsk = {'x': (inc, 1), 'y': (inc, 2), 'z': (add, 'x', 'y')}
-    with Cache(c):
+    with cc:
         assert get(dsk, 'z') == 5
 
     assert flag == [2]  # no x present


### PR DESCRIPTION
Adds opportunistic caching via callbacks and [cachey](https://github.com/mrocklin/cachey)

Example
-------

```python
In [1]: import dask.dataframe as dd

In [2]: from cachey import Cache

In [3]: from dask.diagnostics.cache import cache

In [4]: df = dd.read_csv('data/accounts.*.csv')

In [5]: c = Cache(1000000000)

In [6]: result = df.amount.sum()

In [7]: with cache(c):
    print result.compute()
   ...:     
3575826832

In [8]: with cache(c):
    print result.compute()
   ...:     
3575826832

In [9]: c.data
Out[9]: 
{('reduction-aggregation-6', 0): 3575826832,
 ('reduction-chunk-5', 0): 1187712489,
 ('reduction-chunk-5', 1): 1192801040,
 ('reduction-chunk-5', 2): 1195313303}
```

Some problems
1.  badly named keys like `('x', 1000)` stop this from being as effective as it might be
2.  `fuse` operations stop us from seeing some of the useful intermediate computations we could cache
3.  I had to add `cull` into the async scheduler and depend on an impure start callback
4.  Cachey is still quite immature