### PR TITLE
Add DataFrame arithmetics

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -307,6 +307,74 @@ class _Frame(object):
         return to_hdf(self, path_or_buf, key, mode, append, complevel, complib,
                 fletcher32, **kwargs)
 
+    @property
+    def _elemwise_cols(self):
+        """passed to elemwise ops, None for Series, columns for DataFrame"""
+        return None
+
+    def __abs__(self):
+        return elemwise(operator.abs, self, columns=self._elemwise_cols)
+    def __add__(self, other):
+        return elemwise(operator.add, self, other, columns=self._elemwise_cols)
+    def __radd__(self, other):
+        return elemwise(operator.add, other, self, columns=self._elemwise_cols)
+    def __and__(self, other):
+        return elemwise(operator.and_, self, other, columns=self._elemwise_cols)
+    def __rand__(self, other):
+        return elemwise(operator.and_, other, self, columns=self._elemwise_cols)
+    def __div__(self, other):
+        return elemwise(operator.div, self, other, columns=self._elemwise_cols)
+    def __rdiv__(self, other):
+        return elemwise(operator.div, other, self, columns=self._elemwise_cols)
+    def __eq__(self, other):
+        return elemwise(operator.eq, self, other, columns=self._elemwise_cols)
+    def __gt__(self, other):
+        return elemwise(operator.gt, self, other, columns=self._elemwise_cols)
+    def __ge__(self, other):
+        return elemwise(operator.ge, self, other, columns=self._elemwise_cols)
+    def __invert__(self):
+        return elemwise(operator.inv, self, columns=self._elemwise_cols)
+    def __lt__(self, other):
+        return elemwise(operator.lt, self, other, columns=self._elemwise_cols)
+    def __le__(self, other):
+        return elemwise(operator.le, self, other, columns=self._elemwise_cols)
+    def __mod__(self, other):
+        return elemwise(operator.mod, self, other, columns=self._elemwise_cols)
+    def __rmod__(self, other):
+        return elemwise(operator.mod, other, self, columns=self._elemwise_cols)
+    def __mul__(self, other):
+        return elemwise(operator.mul, self, other, columns=self._elemwise_cols)
+    def __rmul__(self, other):
+        return elemwise(operator.mul, other, self, columns=self._elemwise_cols)
+    def __ne__(self, other):
+        return elemwise(operator.ne, self, other, columns=self._elemwise_cols)
+    def __neg__(self):
+        return elemwise(operator.neg, self, columns=self._elemwise_cols)
+    def __or__(self, other):
+        return elemwise(operator.or_, self, other, columns=self._elemwise_cols)
+    def __ror__(self, other):
+        return elemwise(operator.or_, other, self, columns=self._elemwise_cols)
+    def __pow__(self, other):
+        return elemwise(operator.pow, self, other, columns=self._elemwise_cols)
+    def __rpow__(self, other):
+        return elemwise(operator.pow, other, self, columns=self._elemwise_cols)
+    def __sub__(self, other):
+        return elemwise(operator.sub, self, other, columns=self._elemwise_cols)
+    def __rsub__(self, other):
+        return elemwise(operator.sub, other, self, columns=self._elemwise_cols)
+    def __truediv__(self, other):
+        return elemwise(operator.truediv, self, other, columns=self._elemwise_cols)
+    def __rtruediv__(self, other):
+        return elemwise(operator.truediv, other, self, columns=self._elemwise_cols)
+    def __floordiv__(self, other):
+        return elemwise(operator.floordiv, self, other, columns=self._elemwise_cols)
+    def __rfloordiv__(self, other):
+        return elemwise(operator.floordiv, other, self, columns=self._elemwise_cols)
+    def __xor__(self, other):
+        return elemwise(operator.xor, self, other, columns=self._elemwise_cols)
+    def __rxor__(self, other):
+        return elemwise(operator.xor, other, self, columns=self._elemwise_cols)
+
 
 class Series(_Frame):
     """ Out-of-core Series object
@@ -372,69 +440,6 @@ class Series(_Frame):
             return Series(merge(self.dask, key.dask, dsk), name,
                           self.name, self.divisions)
         raise NotImplementedError()
-
-    def __abs__(self):
-        return elemwise(operator.abs, self)
-    def __add__(self, other):
-        return elemwise(operator.add, self, other)
-    def __radd__(self, other):
-        return elemwise(operator.add, other, self)
-    def __and__(self, other):
-        return elemwise(operator.and_, self, other)
-    def __rand__(self, other):
-        return elemwise(operator.and_, other, self)
-    def __div__(self, other):
-        return elemwise(operator.div, self, other)
-    def __rdiv__(self, other):
-        return elemwise(operator.div, other, self)
-    def __eq__(self, other):
-        return elemwise(operator.eq, self, other)
-    def __gt__(self, other):
-        return elemwise(operator.gt, self, other)
-    def __ge__(self, other):
-        return elemwise(operator.ge, self, other)
-    def __invert__(self):
-        return elemwise(operator.inv, self)
-    def __lt__(self, other):
-        return elemwise(operator.lt, self, other)
-    def __le__(self, other):
-        return elemwise(operator.le, self, other)
-    def __mod__(self, other):
-        return elemwise(operator.mod, self, other)
-    def __rmod__(self, other):
-        return elemwise(operator.mod, other, self)
-    def __mul__(self, other):
-        return elemwise(operator.mul, self, other)
-    def __rmul__(self, other):
-        return elemwise(operator.mul, other, self)
-    def __ne__(self, other):
-        return elemwise(operator.ne, self, other)
-    def __neg__(self):
-        return elemwise(operator.neg, self)
-    def __or__(self, other):
-        return elemwise(operator.or_, self, other)
-    def __ror__(self, other):
-        return elemwise(operator.or_, other, self)
-    def __pow__(self, other):
-        return elemwise(operator.pow, self, other)
-    def __rpow__(self, other):
-        return elemwise(operator.pow, other, self)
-    def __sub__(self, other):
-        return elemwise(operator.sub, self, other)
-    def __rsub__(self, other):
-        return elemwise(operator.sub, other, self)
-    def __truediv__(self, other):
-        return elemwise(operator.truediv, self, other)
-    def __rtruediv__(self, other):
-        return elemwise(operator.truediv, other, self)
-    def __floordiv__(self, other):
-        return elemwise(operator.floordiv, self, other)
-    def __rfloordiv__(self, other):
-        return elemwise(operator.floordiv, other, self)
-    def __xor__(self, other):
-        return elemwise(operator.xor, self, other)
-    def __rxor__(self, other):
-        return elemwise(operator.xor, other, self)
 
     @wraps(pd.Series.sum)
     def sum(self):
@@ -685,6 +690,10 @@ class DataFrame(_Frame):
         from .io import to_csv
         return to_csv(self, filename, **kwargs)
 
+    @property
+    def _elemwise_cols(self):
+        return self.columns
+
 
 def _assign(df, *pairs):
     kwargs = dict(partition(2, pairs))
@@ -794,18 +803,21 @@ def elemwise(op, *args, **kwargs):
     else:
         op2 = op
 
-    assert all(df.divisions == dfs[0].divisions for df in dfs)
-    assert all(df.npartitions == dfs[0].npartitions for df in dfs)
+    if not all(df.divisions == dfs[0].divisions for df in dfs):
+        msg = 'All dask.Dataframe and dask.Series must have same divisions'
+        raise ValueError(msg)
+    if not all(df.npartitions == dfs[0].npartitions for df in dfs):
+        msg = 'All dask.Dataframe and dask.Series must have same npartitions'
+        raise ValueError(msg)
 
     dsk = dict(((_name, i), (op2,) + frs)
                 for i, frs in enumerate(zip(*[df._keys() for df in dfs])))
-
     if columns is not None:
         return DataFrame(merge(dsk, *[df.dask for df in dfs]),
                          _name, columns, dfs[0].divisions)
     else:
         column_name = name or consistent_name(n for df in dfs
-                                                 for n in df.columns)
+                                              for n in df.columns)
         return Series(merge(dsk, *[df.dask for df in dfs]),
                       _name, column_name, dfs[0].divisions)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -68,7 +68,8 @@ def test_Dataframe():
 def test_Series():
     assert isinstance(d.a, dd.Series)
     assert isinstance(d.a + 1, dd.Series)
-    assert raises(Exception, lambda: d + 1)
+
+    tm.assert_frame_equal((d + 1).compute(), full + 1)
 
 
 def test_attributes():
@@ -185,6 +186,120 @@ def test_arithmetic():
     assert eq(abs(d.a), abs(full.a))
     assert eq(~(d.a == d.b), ~(full.a == full.b))
     assert eq(~(d.a == d.b), ~(full.a == full.b))
+
+
+def test_arithmetic_frame():
+    tm.assert_frame_equal((d + d).compute(), full + full)
+    tm.assert_frame_equal((d * d).compute(), full * full)
+    tm.assert_frame_equal((d - d).compute(), full - full)
+    tm.assert_frame_equal((d / d).compute(), full / full)
+    tm.assert_frame_equal((d & d).compute(), full & full)
+    tm.assert_frame_equal((d | d).compute(), full | full)
+    tm.assert_frame_equal((d ^ d).compute(), full ^ full)
+    tm.assert_frame_equal((d // d).compute(), full // full)
+    tm.assert_frame_equal((d ** d).compute(), full ** full)
+    tm.assert_frame_equal((d % d).compute(), full % full)
+    tm.assert_frame_equal((d > d).compute(), full > full)
+    tm.assert_frame_equal((d < d).compute(), full < full)
+    tm.assert_frame_equal((d >= d).compute(), full >= full)
+    tm.assert_frame_equal((d <= d).compute(), full <= full)
+    tm.assert_frame_equal((d == d).compute(), full == full)
+    tm.assert_frame_equal((d != d).compute(), full != full)
+
+    tm.assert_frame_equal((d + 2).compute(), full + 2)
+    tm.assert_frame_equal((d * 2).compute(), full * 2)
+    tm.assert_frame_equal((d - 2).compute(), full - 2)
+    tm.assert_frame_equal((d / 2).compute(), full / 2)
+    tm.assert_frame_equal((d & True).compute(), full & True)
+    tm.assert_frame_equal((d | True).compute(), full | True)
+    tm.assert_frame_equal((d ^ True).compute(), full ^ True)
+    tm.assert_frame_equal((d // 2).compute(), full // 2)
+    tm.assert_frame_equal((d ** 2).compute(), full ** 2)
+    tm.assert_frame_equal((d % 2).compute(), full % 2)
+    tm.assert_frame_equal((d > 2).compute(), full > 2)
+    tm.assert_frame_equal((d < 2).compute(), full < 2)
+    tm.assert_frame_equal((d >= 2).compute(), full >= 2)
+    tm.assert_frame_equal((d <= 2).compute(), full <= 2)
+    tm.assert_frame_equal((d == 2).compute(), full == 2)
+    tm.assert_frame_equal((d != 2).compute(), full != 2)
+
+    tm.assert_frame_equal((2 + d).compute(), 2 + full)
+    tm.assert_frame_equal((2 * d).compute(), 2 * full)
+    tm.assert_frame_equal((2 - d).compute(), 2 - full)
+    tm.assert_frame_equal((2 / d).compute(), 2 / full)
+    tm.assert_frame_equal((True & d).compute(), True & full)
+    tm.assert_frame_equal((True | d).compute(), True | full)
+    tm.assert_frame_equal((True ^ d).compute(), True ^ full)
+    tm.assert_frame_equal((2 // d).compute(), 2 // full)
+    tm.assert_frame_equal((2 ** d).compute(), 2 ** full)
+    tm.assert_frame_equal((2 % d).compute(), 2 % full)
+    tm.assert_frame_equal((2 > d).compute(), 2 > full)
+    tm.assert_frame_equal((2 < d).compute(), 2 < full)
+    tm.assert_frame_equal((2 >= d).compute(), 2 >= full)
+    tm.assert_frame_equal((2 <= d).compute(), 2 <= full)
+    tm.assert_frame_equal((2 == d).compute(), 2 == full)
+    tm.assert_frame_equal((2 != d).compute(), 2 != full)
+
+    tm.assert_frame_equal((-d).compute(), -full)
+    tm.assert_frame_equal((abs(d)).compute(), abs(full))
+    tm.assert_frame_equal((~(d == d)).compute(), ~(full == full))
+
+    d2 = dd.from_pandas(pd.DataFrame({'x': [1, 2, 3, 4], 'y': [5, 6, 7, 8]}), 3)
+    d3 = dd.from_pandas(pd.DataFrame({'x': [5, 6, 7, 8], 'y': [2, 4, 5, 3]}), 2)
+    full2 = d2.compute()
+    full3 = d3.compute()
+
+    tm.assert_frame_equal((d2 + d3).compute(), full2 + full3)
+    tm.assert_frame_equal((d2 * d3).compute(), full2 * full3)
+    tm.assert_frame_equal((d2 - d3).compute(), full2 - full3)
+    tm.assert_frame_equal((d2 / d3).compute(), full2 / full3)
+    tm.assert_frame_equal((d2 & d3).compute(), full2 & full3)
+    tm.assert_frame_equal((d2 | d3).compute(), full2 | full3)
+    tm.assert_frame_equal((d2 ^ d3).compute(), full2 ^ full3)
+    tm.assert_frame_equal((d2 // d3).compute(), full2 // full3)
+    tm.assert_frame_equal((d2 ** d3).compute(), full2 ** full3)
+    tm.assert_frame_equal((d2 % d3).compute(), full2 % full3)
+    tm.assert_frame_equal((d2 > d3).compute(), full2 > full3)
+    tm.assert_frame_equal((d2 < d3).compute(), full2 < full3)
+    tm.assert_frame_equal((d2 >= d3).compute(), full2 >= full3)
+    tm.assert_frame_equal((d2 <= d3).compute(), full2 <= full3)
+    tm.assert_frame_equal((d2 == d3).compute(), full2 == full3)
+    tm.assert_frame_equal((d2 != d3).compute(), full2 != full3)
+
+    dsk4 = {('y', 0): pd.DataFrame({'a': [3, 2, 1], 'b': [7, 8, 9]},
+                                   index=[0, 1, 3]),
+            ('y', 1): pd.DataFrame({'a': [5, 2, 8], 'b': [4, 2, 3]},
+                                   index=[5, 6, 8]),
+            ('y', 2): pd.DataFrame({'a': [1, 4, 10], 'b': [1, 0, 5]},
+                                   index=[9, 9, 9])}
+
+    d4 = dd.DataFrame(dsk4, 'y', ['a', 'b'], [0, 4, 9, 9])
+    full4 = d4.compute()
+    tm.assert_frame_equal((d + d4).compute(), full + full4)
+    tm.assert_frame_equal((d * d4).compute(), full * full4)
+    tm.assert_frame_equal((d - d4).compute(), full - full4)
+    tm.assert_frame_equal((d / d4).compute(), full / full4)
+    tm.assert_frame_equal((d & d4).compute(), full & full4)
+    tm.assert_frame_equal((d | d4).compute(), full | full4)
+    tm.assert_frame_equal((d ^ d4).compute(), full ^ full4)
+    tm.assert_frame_equal((d // d4).compute(), full // full4)
+    tm.assert_frame_equal((d ** d4).compute(), full ** full4)
+    tm.assert_frame_equal((d % d4).compute(), full % full4)
+    tm.assert_frame_equal((d > d4).compute(), full > full4)
+    tm.assert_frame_equal((d < d4).compute(), full < full4)
+    tm.assert_frame_equal((d >= d4).compute(), full >= full4)
+    tm.assert_frame_equal((d <= d4).compute(), full <= full4)
+    tm.assert_frame_equal((d == d4).compute(), full == full4)
+    tm.assert_frame_equal((d != d4).compute(), full != full4)
+
+    dsk5 = {('z', 0): pd.DataFrame({'a': [3, 2, 1], 'b': [7, 8, 9]},
+                                   index=[0, 1, 3]),
+            ('z', 1): pd.DataFrame({'a': [5, 2, 8], 'b': [4, 2, 3]},
+                                   index=[5, 6, 8]),
+            ('z', 2): pd.DataFrame({'a': [1, 4, 10], 'b': [1, 0, 5]},
+                                   index=[9, 9, 9])}
+    d5 = dd.DataFrame(dsk4, 'z', ['a', 'b'], [0, 3, 6, 9])
+    assert raises(ValueError, lambda: (d + d5).compute())
 
 
 def test_reductions():


### PR DESCRIPTION
This PR allows elementwise ops for ``DataFrame``.

```
import pandas as pd
import dask.dataframe as dd
df = dd.from_pandas(pd.DataFrame({'x': [1, 2, 3, 4], 'y': [5, 6, 7, 8]}), 2)
df.compute()
#    x  y
# 0  1  5
# 1  2  6
# 2  3  7
# 3  4  8

(df + 1).compute()
#    x  y
# 0  2  6
# 1  3  7
# 2  4  8
# 3  5  9

(df + df).compute()
#    x   y
# 0  2  10
# 1  4  12
# 2  6  14
# 3  8  16
```