### PR TITLE
Use deterministic names for dataframe 

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -127,7 +127,7 @@ class _Frame(Base):
             cache = cache()
 
         # Evaluate and store in cache
-        name = 'cache' + uuid.uuid1().get_hex()
+        name = 'cache' + uuid.uuid1().hex
         dsk = dict(((name, i), (setitem, cache, (tuple, list(key)), key))
                     for i, key in enumerate(self._keys()))
         self._get(merge(dsk, self.dask), list(dsk.keys()))

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4,6 +4,7 @@ from itertools import count
 from math import sqrt
 from functools import wraps
 import bisect
+from md5 import md5
 from toolz import merge, partial, first, partition
 from operator import getitem, setitem
 from datetime import datetime
@@ -874,7 +875,7 @@ def concat(dfs):
         # For this to work we need to add a final division for "maximum element"
         raise NotImplementedError("Concat can't currently handle dataframes"
                 " with known divisions")
-    name = 'concat' + next(tokens)
+    name = 'concat-' + md5('--'.join(df._name for df in dfs)).hexdigest()
     dsk = dict()
     i = 0
     for df in dfs:

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -783,7 +783,11 @@ def elemwise(op, *args, **kwargs):
     columns = kwargs.get('columns', None)
     name = kwargs.get('name', None)
 
-    _name = 'elemwise' + next(tokens)
+    token = (op,
+             [arg._name if isinstance(arg, _Frame) else arg for arg in args],
+             sorted(kwargs.items(), key=lambda kv: str(kv[0])))
+
+    _name = 'elemwise-' + md5(str(token)).hexdigest()
 
     dfs = [arg for arg in args if isinstance(arg, _Frame)]
     other = [(i, arg) for i, arg in enumerate(args)

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -53,7 +53,10 @@ def fill_kwargs(fn, args, kwargs):
 
     # Let pandas infer on the first 100 rows
     if '*' in fn:
-        fn = sorted(glob(fn))[0]
+        filenames = sorted(glob(fn))
+        if not filenames:
+            raise ValueError("No files found matching name %s" % fn)
+        fn = filenames[0]
 
     if 'names' not in kwargs:
         kwargs['names'] = csv_names(fn, **kwargs)

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -8,6 +8,7 @@ from glob import glob
 from math import ceil
 from toolz import merge, dissoc, assoc
 from operator import getitem
+from md5 import md5
 
 from ..compatibility import BytesIO, unicode, range, apply
 from ..utils import textblock, file_size
@@ -96,7 +97,8 @@ def read_csv(fn, *args, **kwargs):
     if '*' in fn:
         return concat([read_csv(f, *args, **kwargs) for f in sorted(glob(fn))])
 
-    name = 'read-csv' + next(tokens)
+    arg_token = (args, sorted(kwargs.items(), key=lambda kv: kv[0]))
+    name = 'read-csv-%s-%s' % (fn, md5(str(arg_token)).hexdigest())
 
     columns = kwargs.pop('columns')
     header = kwargs.pop('header')

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -14,6 +14,7 @@ from hashlib import md5
 from ..compatibility import BytesIO, unicode, range, apply
 from ..utils import textblock, file_size
 from ..base import compute
+from .utils import tokenize_dataframe
 from .. import array as da
 
 from . import core
@@ -341,7 +342,7 @@ def from_pandas(data, npartitions):
                       for i in range(0, nrows, chunksize))
     divisions = divisions + (data.index[-1],)
 
-    token = (id(data), nrows, columns, chunksize) # this could be improved
+    token = (tokenize_dataframe(data), chunksize) # this could be improved
     name = 'from_pandas-' + tokenize(token)
     dsk = dict(((name, i), data.iloc[i * chunksize:(i + 1) * chunksize])
                for i in range(npartitions - 1))

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -10,6 +10,7 @@ from math import ceil
 from toolz import merge, dissoc, assoc
 from operator import getitem
 from hashlib import md5
+import uuid
 
 from ..compatibility import BytesIO, unicode, range, apply
 from ..utils import textblock, file_size
@@ -275,7 +276,8 @@ def from_array(x, chunksize=50000, columns=None):
     divisions = tuple(range(0, len(x), chunksize))
     if divisions[-1] != len(x) - 1:
         divisions = divisions + (len(x) - 1,)
-    name = 'from_array' + next(tokens)
+    token = tokenize((id(x), x.dtype, x.shape, chunksize, columns))
+    name = 'from_array-' + token
     dsk = dict(((name, i), (pd.DataFrame,
                              (getitem, x,
                               slice(i * chunksize, (i + 1) * chunksize))))
@@ -392,7 +394,13 @@ def from_bcolz(x, chunksize=None, categorize=True, index=None, **kwargs):
     divisions = (0,) + tuple(range(-1, len(x), chunksize))[1:]
     if divisions[-1] != len(x) - 1:
         divisions = divisions + (len(x) - 1,)
-    new_name = 'from_bcolz' + next(tokens)
+    if x.rootdir:
+        token = tokenize((x.rootdir, os.path.getmtime(x.rootdir), chunksize,
+                          categorize, index, sorted(kwargs.items())))
+    else:
+        token = tokenize((id(x), x.shape, x.dtype, chunksize, categorize,
+                         index, sorted(kwargs.items())))
+    new_name = 'from_bcolz-' + token
     dsk = dict(((new_name, i),
                 (dataframe_from_ctable,
                  x,
@@ -446,8 +454,6 @@ def dataframe_from_ctable(x, slc, columns=None, categories=None):
             columns = list(columns)
         x = x[columns]
 
-    name = 'from-bcolz' + next(tokens)
-
     if isinstance(x, bcolz.ctable):
         chunks = [x[name][slc] for name in x.names]
         if categories is not None:
@@ -491,7 +497,7 @@ def from_dask_array(x, columns=None):
     2  1  1
     3  1  1
     """
-    name = 'from-dask-array' + next(tokens)
+    name = 'from-dask-array' + tokenize((x.name, columns))
     divisions = [0]
     for c in x.chunks[0]:
         divisions.append(divisions[-1] + c)
@@ -534,7 +540,7 @@ def _link(token, result):
 @wraps(pd.DataFrame.to_hdf)
 def to_hdf(df, path_or_buf, key, mode='a', append=False, complevel=0,
            complib=None, fletcher32=False, **kwargs):
-    name = 'to-hdf' + next(tokens)
+    name = 'to-hdf-' + uuid.uuid1().hex
 
     pd_to_hdf = getattr(df._partition_type, 'to_hdf')
 
@@ -574,7 +580,9 @@ def read_hdf(path_or_buf, key, start=0, stop=None, columns=None,
     if columns is None:
         columns = list(pd.read_hdf(path_or_buf, key, stop=0).columns)
 
-    name = 'read-hdf' + next(tokens)
+    token = tokenize((path_or_buf, os.path.getmtime(path_or_buf), key, start,
+                      stop, columns, chunksize))
+    name = 'read-hdf-' + token
 
     dsk = dict(((name, i), (apply, pd.read_hdf,
                              (path_or_buf, key),
@@ -599,7 +607,7 @@ def to_castra(df, fn=None, categories=None):
     if isinstance(categories, list):
         categories = (list, categories)
 
-    name = 'to-castra' + next(tokens)
+    name = 'to-castra-' + uuid.uuid1().hex
 
     dsk = dict()
     dsk[(name, -1)] = (Castra, fn, (df._name, 0), categories)
@@ -613,7 +621,7 @@ def to_castra(df, fn=None, categories=None):
 
 def to_csv(df, filename, **kwargs):
     myget = kwargs.pop('get', None)
-    name = 'to-csv' + next(tokens)
+    name = 'to-csv-' + uuid.uuid1().hex
 
     dsk = dict()
     dsk[(name, 0)] = (apply, pd.DataFrame.to_csv,

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -9,7 +9,7 @@ from glob import glob
 from math import ceil
 from toolz import merge, dissoc, assoc
 from operator import getitem
-from md5 import md5
+from hashlib import md5
 
 from ..compatibility import BytesIO, unicode, range, apply
 from ..utils import textblock, file_size
@@ -17,7 +17,8 @@ from ..base import compute
 from .. import array as da
 
 from . import core
-from .core import DataFrame, Series, concat, categorize_block, tokens
+from .core import (DataFrame, Series, concat, categorize_block, tokens,
+        tokenize)
 from .shuffle import set_partition
 
 
@@ -101,7 +102,7 @@ def read_csv(fn, *args, **kwargs):
     arg_token = (os.path.getmtime(fn),
                  args,
                  sorted(kwargs.items(), key=lambda kv: kv[0]))
-    name = 'read-csv-%s-%s' % (fn, md5(str(arg_token)).hexdigest())
+    name = 'read-csv-%s-%s' % (fn, tokenize(arg_token))
 
     columns = kwargs.pop('columns')
     header = kwargs.pop('header')
@@ -341,7 +342,7 @@ def from_pandas(data, npartitions):
     divisions = divisions + (data.index[-1],)
 
     token = (id(data), nrows, columns, chunksize) # this could be improved
-    name = 'from_pandas-' + md5(str(token)).hexdigest()
+    name = 'from_pandas-' + tokenize(token)
     dsk = dict(((name, i), data.iloc[i * chunksize:(i + 1) * chunksize])
                for i in range(npartitions - 1))
     dsk[(name, npartitions - 1)] = data.iloc[chunksize*(npartitions - 1):]

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -339,7 +339,9 @@ def from_pandas(data, npartitions):
     divisions = tuple(data.index[i]
                       for i in range(0, nrows, chunksize))
     divisions = divisions + (data.index[-1],)
-    name = 'from_pandas' + next(tokens)
+
+    token = (id(data), nrows, columns, chunksize) # this could be improved
+    name = 'from_pandas-' + md5(str(token)).hexdigest()
     dsk = dict(((name, i), data.iloc[i * chunksize:(i + 1) * chunksize])
                for i in range(npartitions - 1))
     dsk[(name, npartitions - 1)] = data.iloc[chunksize*(npartitions - 1):]

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -4,6 +4,7 @@ import pandas as pd
 import numpy as np
 from functools import wraps, partial
 import re
+import os
 from glob import glob
 from math import ceil
 from toolz import merge, dissoc, assoc
@@ -97,7 +98,9 @@ def read_csv(fn, *args, **kwargs):
     if '*' in fn:
         return concat([read_csv(f, *args, **kwargs) for f in sorted(glob(fn))])
 
-    arg_token = (args, sorted(kwargs.items(), key=lambda kv: kv[0]))
+    arg_token = (os.path.getmtime(fn),
+                 args,
+                 sorted(kwargs.items(), key=lambda kv: kv[0]))
     name = 'read-csv-%s-%s' % (fn, md5(str(arg_token)).hexdigest())
 
     columns = kwargs.pop('columns')

--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -54,7 +54,7 @@ We proceed with hash joins in the following stages:
 2.  Perform embarrassingly parallel join across shuffled inputs.
 """
 
-from .core import repartition, tokens, DataFrame, Index
+from .core import repartition, DataFrame, Index, tokenize
 from .io import from_pandas
 from .shuffle import shuffle
 from bisect import bisect_left, bisect_right
@@ -170,7 +170,8 @@ def join_indexed_dataframes(lhs, rhs, how='left', lsuffix='', rsuffix=''):
     left_empty = pd.DataFrame([], columns=lhs.columns)
     right_empty = pd.DataFrame([], columns=rhs.columns)
 
-    name = 'join-indexed' + next(tokens)
+    token = tokenize((lhs._name, rhs._name, how, lsuffix, rsuffix))
+    name = 'join-indexed-' + token
     dsk = dict(((name, i),
                 (pd.DataFrame.join, a, b, None, how, lsuffix, rsuffix)
                 if a is not None and b is not None else
@@ -234,7 +235,9 @@ def hash_join(lhs, on_left, rhs, on_right, how='inner', npartitions=None, suffix
                        left_columns=list(lhs.columns),
                        right_columns=list(rhs.columns))
 
-    name = 'hash-join' + next(tokens)
+    token = tokenize((lhs._name, on_left, rhs._name, on_right, how,
+                      npartitions, suffixes))
+    name = 'hash-join-' + token
     dsk = dict(((name, i), (pdmerge2, (lhs2._name, i), (rhs2._name, i),
                              how, None, on_left, on_right))
                 for i in range(npartitions))
@@ -258,7 +261,8 @@ def concat_indexed_dataframes(dfs, join='outer'):
                for df, empty in zip(part, empties)]
               for part in parts]
 
-    name = 'concat-indexed' + next(tokens)
+    token = tokenize(([df._name for df in dfs], join))
+    name = 'concat-indexed-' + token
     dsk = dict(((name, i), (pd.concat, part, 0, join))
                 for i, part in enumerate(parts2))
 

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -3,7 +3,7 @@ from functools import partial, wraps
 from toolz import merge
 import pandas as pd
 
-from .core import tokens
+from .core import tokenize
 
 
 def rolling_chunk(func, part1, part2, window, *args):
@@ -30,7 +30,8 @@ def wrap_rolling(func):
             raise NotImplementedError('Resampling before rolling computations '
                                       'not supported')
         old_name = arg._name
-        new_name = 'rolling' + next(tokens)
+        token = tokenize((arg._name, window, args, sorted(kwargs.items())))
+        new_name = 'rolling-' + token
         f = partial(func, **kwargs)
         dsk = {(new_name, 0): (f, (old_name, 0), window) + args}
         for i in range(1, arg.npartitions + 1):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -138,6 +138,11 @@ def test_split_apply_combine_on_series():
     assert eq(d.groupby('a').b.mean(), full.groupby('a').b.mean())
     assert eq(d.groupby(d.a > 3).b.mean(), full.groupby(full.a > 3).b.mean())
 
+    assert sorted(d.groupby('b').a.sum().dask) == \
+           sorted(d.groupby('b').a.sum().dask)
+    assert sorted(d.groupby(d.a > 3).b.mean().dask) == \
+           sorted(d.groupby(d.a > 3).b.mean().dask)
+
 
 def test_arithmetic():
     assert eq(d.a + d.b, full.a + full.b)
@@ -352,6 +357,18 @@ def test_map_partitions():
     assert eq(d.map_partitions(lambda df: df, 'a'), full)
 
 
+def test_map_partitions_names():
+    func = lambda x: x
+    assert sorted(dd.map_partitions(func, d.columns, d).dask) == \
+           sorted(dd.map_partitions(func, d.columns, d).dask)
+    assert sorted(dd.map_partitions(lambda x: x, d.columns, d, token=1).dask) == \
+           sorted(dd.map_partitions(lambda x: x, d.columns, d, token=1).dask)
+
+    func = lambda x, y: x
+    assert sorted(dd.map_partitions(func, d.columns, d, d).dask) == \
+           sorted(dd.map_partitions(func, d.columns, d, d).dask)
+
+
 def test_drop_duplicates():
     assert eq(d.a.drop_duplicates(), full.a.drop_duplicates())
 
@@ -364,6 +381,9 @@ def test_full_groupby():
         df['b'] = df.b - df.b.mean()
         return df
     assert eq(d.groupby('a').apply(func), full.groupby('a').apply(func))
+
+    assert sorted(d.groupby('a').apply(func).dask) == \
+           sorted(d.groupby('a').apply(func).dask)
 
 
 def test_groupby_on_index():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -51,8 +51,6 @@ def test_Dataframe():
 
     assert list(d.columns) == list(['a', 'b'])
 
-    assert eq(d.head(2), dsk[('x', 0)].head(2))
-    assert eq(d['a'].head(2), dsk[('x', 0)]['a'].head(2))
 
     full = d.compute()
     assert eq(d[d['b'] > 2], full[full['b'] > 2])
@@ -65,6 +63,15 @@ def test_Dataframe():
     assert d.index._name == d.index._name  # this is deterministic
 
     assert repr(d)
+
+
+def test_head():
+    assert eq(d.head(2), dsk[('x', 0)].head(2))
+    assert eq(d['a'].head(2), dsk[('x', 0)]['a'].head(2))
+    assert sorted(d.head(2, compute=False).dask) == \
+           sorted(d.head(2, compute=False).dask)
+    assert sorted(d.head(2, compute=False).dask) != \
+           sorted(d.head(3, compute=False).dask)
 
 
 def test_Series():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -766,3 +766,15 @@ def test_deterministic_reduction_names():
     assert a.x.min()._name == a.x.min()._name
     assert a.x.max()._name == a.x.max()._name
     assert a.x.count()._name == a.x.count()._name
+
+
+def test_deterministic_apply_concat_apply_names():
+    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [5, 6, 7, 8]})
+    a = dd.from_pandas(df, npartitions=2)
+
+    assert sorted(a.x.nlargest(2).dask) == sorted(a.x.nlargest(2).dask)
+    assert sorted(a.x.nlargest(2).dask) != sorted(a.x.nlargest(3).dask)
+    assert sorted(a.x.drop_duplicates().dask) == \
+           sorted(a.x.drop_duplicates().dask)
+    assert sorted(a.groupby('x').y.mean().dask) == \
+           sorted(a.groupby('x').y.mean().dask)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -10,6 +10,8 @@ from dask.utils import raises
 import dask.dataframe as dd
 from dask.dataframe.core import (concat, repartition_divisions, _loc,
         _coerce_loc_index)
+from dask.dataframe.core import (concat, repartition_divisions, _loc,
+        _coerce_loc_index, _concat)
 
 
 def eq(a, b):
@@ -496,8 +498,8 @@ def test_map():
 
 
 def test_concat():
-    x = concat([pd.DataFrame(columns=['a', 'b']),
-                pd.DataFrame(columns=['a', 'b'])])
+    x = _concat([pd.DataFrame(columns=['a', 'b']),
+                 pd.DataFrame(columns=['a', 'b'])])
     assert list(x.columns) == ['a', 'b']
     assert len(x) == 0
 
@@ -534,7 +536,7 @@ def test_unknown_divisions():
     assert raises(ValueError, lambda: d.loc[3])
 
 
-def test_concat():
+def test_concat2():
     dsk = {('x', 0): pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]}),
            ('x', 1): pd.DataFrame({'a': [4, 5, 6], 'b': [3, 2, 1]}),
            ('x', 2): pd.DataFrame({'a': [7, 8, 9], 'b': [0, 0, 0]})}
@@ -549,6 +551,8 @@ def test_concat():
     assert c.npartitions == a.npartitions + b.npartitions
 
     assert eq(pd.concat([a.compute(), b.compute()]), c)
+
+    assert dd.concat([a, b]).dask == dd.concat([a, b]).dask
 
 
 def test_dataframe_series_are_dillable():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -494,6 +494,8 @@ def test_loc():
     assert eq(d.loc[1000:], full.loc[1000:])
     assert eq(d.loc[-2000:-1000], full.loc[-2000:-1000])
 
+    assert sorted(d.loc[5].dask) == sorted(d.loc[5].dask)
+    assert sorted(d.loc[5].dask) != sorted(d.loc[6].dask)
 
 
 def test_loc_with_text_dates():
@@ -509,6 +511,9 @@ def test_loc_with_text_dates():
 
 def test_loc_with_series():
     assert eq(d.loc[d.a % 2 == 0], full.loc[full.a % 2 == 0])
+
+    assert sorted(d.loc[d.a % 2].dask) == sorted(d.loc[d.a % 2].dask)
+    assert sorted(d.loc[d.a % 2].dask) != sorted(d.loc[d.a % 3].dask)
 
 
 def test_iloc_raises():
@@ -781,6 +786,8 @@ def test_deterministic_arithmetic_names():
     a = dd.from_pandas(df, npartitions=2)
 
     assert sorted((a.x + a.y ** 2).dask) == sorted((a.x + a.y ** 2).dask)
+    assert sorted((a.x + a.y ** 2).dask) != sorted((a.x + a.y ** 3).dask)
+    assert sorted((a.x + a.y ** 2).dask) != sorted((a.x - a.y ** 2).dask)
 
 
 def test_deterministic_reduction_names():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -754,3 +754,15 @@ def test_deterministic_arithmetic_names():
     a = dd.from_pandas(df, npartitions=2)
 
     assert sorted((a.x + a.y ** 2).dask) == sorted((a.x + a.y ** 2).dask)
+
+
+def test_deterministic_reduction_names():
+    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [5, 6, 7, 8]})
+    a = dd.from_pandas(df, npartitions=2)
+
+    assert a.x.sum()._name == a.x.sum()._name
+    assert a.x.mean()._name == a.x.mean()._name
+    assert a.x.var()._name == a.x.var()._name
+    assert a.x.min()._name == a.x.min()._name
+    assert a.x.max()._name == a.x.max()._name
+    assert a.x.count()._name == a.x.count()._name

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -747,3 +747,10 @@ def test_query():
     df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [5, 6, 7, 8]})
     a = dd.from_pandas(df, npartitions=2)
     assert eq(a.query('x**2 > y'), df.query('x**2 > y'))
+
+
+def test_deterministic_arithmetic_names():
+    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [5, 6, 7, 8]})
+    a = dd.from_pandas(df, npartitions=2)
+
+    assert sorted((a.x + a.y ** 2).dask) == sorted((a.x + a.y ** 2).dask)

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -490,3 +490,15 @@ def test_read_csv_raises_on_no_files():
         assert False
     except Exception as e:
         assert "21hflkhfisfshf.*.csv" in str(e)
+
+
+def test_read_csv_has_deterministic_name():
+    with filetext(text) as fn:
+        a = read_csv(fn)
+        b = read_csv(fn)
+        assert a._name == b._name
+        assert sorted(a.dask.keys()) == sorted(b.dask.keys())
+        assert isinstance(a._name, str)
+
+        c = read_csv(fn, skiprows=1, na_values=[0])
+        assert a._name != c._name

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -482,3 +482,11 @@ def test_read_csv_with_nrows():
         assert list(f.columns) == ['name', 'amount']
         assert f.npartitions == 1
         assert eq(read_csv(fn, nrows=3), pd.read_csv(fn, nrows=3))
+
+
+def test_read_csv_raises_on_no_files():
+    try:
+        dd.read_csv('21hflkhfisfshf.*.csv')
+        assert False
+    except Exception as e:
+        assert "21hflkhfisfshf.*.csv" in str(e)

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -502,3 +502,16 @@ def test_read_csv_has_deterministic_name():
 
         c = read_csv(fn, skiprows=1, na_values=[0])
         assert a._name != c._name
+
+    try:
+        with open('_foo.1.csv', 'w') as f:
+            f.write(text)
+        with open('_foo.2.csv', 'w') as f:
+            f.write(text)
+        a = read_csv('_foo.*.csv')
+        b = read_csv('_foo.*.csv')
+
+        assert sorted(a.dask.keys()) == sorted(b.dask.keys())
+    finally:
+        os.remove('_foo.1.csv')
+        os.remove('_foo.2.csv')

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -503,6 +503,8 @@ def test_read_csv_has_deterministic_name():
         c = read_csv(fn, skiprows=1, na_values=[0])
         assert a._name != c._name
 
+
+def test_multiple_read_csv_has_deterministic_name():
     try:
         with open('_foo.1.csv', 'w') as f:
             f.write(text)
@@ -515,3 +517,14 @@ def test_read_csv_has_deterministic_name():
     finally:
         os.remove('_foo.1.csv')
         os.remove('_foo.2.csv')
+
+
+def test_read_csv_of_modified_file_has_different_name():
+    with filetext(text) as fn:
+        a = read_csv(fn)
+        with open(fn, 'a') as f:
+            f.write('\nGeorge,700')
+            os.fsync(f)
+        b = read_csv(fn)
+
+        assert sorted(a.dask) != sorted(b.dask)

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -236,6 +236,20 @@ def test_from_bcolz():
     L = list(d.index.compute(get=get_sync))
     assert L == [1, 2, 3] or L == [1, 3, 2]
 
+    # Names
+    assert sorted(dd.from_bcolz(t, chunksize=2).dask) == \
+           sorted(dd.from_bcolz(t, chunksize=2).dask)
+    assert sorted(dd.from_bcolz(t, chunksize=2).dask) != \
+           sorted(dd.from_bcolz(t, chunksize=3).dask)
+
+    dsk = dd.from_bcolz(t, chunksize=3).dask
+
+    t.append((4, 4., 'b'))
+    t.flush()
+
+    assert sorted(dd.from_bcolz(t, chunksize=2).dask) != \
+           sorted(dsk)
+
 
 def test_from_bcolz_filename():
     bcolz = pytest.importorskip('bcolz')
@@ -460,6 +474,9 @@ def test_read_hdf():
         tm.assert_frame_equal(
               dd.read_hdf(fn, '/data', chunksize=2, start=1, stop=3).compute(),
               pd.read_hdf(fn, '/data', start=1, stop=3))
+
+        assert sorted(dd.read_hdf(fn, '/data').dask) == \
+               sorted(dd.read_hdf(fn, '/data').dask)
 
 
 def test_to_csv():

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -101,10 +101,10 @@ def test_hash_join():
     assert sorted(result.fillna(100).values.tolist()) == \
            sorted(expected.fillna(100).values.tolist())
 
-    assert sorted(hash_join(a, 'y', b, 'y', 'inner').dask) == \
-           sorted(hash_join(a, 'y', b, 'y', 'inner').dask)
-    assert sorted(hash_join(a, 'y', b, 'y', 'inner').dask) != \
-           sorted(hash_join(a, 'y', b, 'y', 'outer').dask)
+    assert hash_join(a, 'y', b, 'y', 'inner')._name == \
+           hash_join(a, 'y', b, 'y', 'inner')._name
+    assert hash_join(a, 'y', b, 'y', 'inner')._name != \
+           hash_join(a, 'y', b, 'y', 'outer')._name
 
 
 def test_indexed_concat():

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -56,6 +56,11 @@ def test_join_indexed_dataframe_to_indexed_dataframe():
     assert c.divisions[-1] == 8
     tm.assert_frame_equal(c.compute(), A.join(B, how='outer'))
 
+    assert sorted(join_indexed_dataframes(a, b, how='inner').dask) == \
+           sorted(join_indexed_dataframes(a, b, how='inner').dask)
+    assert sorted(join_indexed_dataframes(a, b, how='inner').dask) != \
+           sorted(join_indexed_dataframes(a, b, how='outer').dask)
+
 
 def list_eq(a, b):
     if isinstance(a, dd.DataFrame):
@@ -96,6 +101,11 @@ def test_hash_join():
     assert sorted(result.fillna(100).values.tolist()) == \
            sorted(expected.fillna(100).values.tolist())
 
+    assert sorted(hash_join(a, 'y', b, 'y', 'inner').dask) == \
+           sorted(hash_join(a, 'y', b, 'y', 'inner').dask)
+    assert sorted(hash_join(a, 'y', b, 'y', 'inner').dask) != \
+           sorted(hash_join(a, 'y', b, 'y', 'outer').dask)
+
 
 def test_indexed_concat():
     A = pd.DataFrame({'x': [1, 2, 3, 4, 6, 7], 'y': list('abcdef')},
@@ -116,6 +126,11 @@ def test_indexed_concat():
 
         assert sorted(zip(result.values.tolist(), result.index.values.tolist())) == \
                sorted(zip(expected.values.tolist(), expected.index.values.tolist()))
+
+    assert sorted(concat_indexed_dataframes([a, b], join='inner').dask) == \
+           sorted(concat_indexed_dataframes([a, b], join='inner').dask)
+    assert sorted(concat_indexed_dataframes([a, b], join='inner').dask) != \
+           sorted(concat_indexed_dataframes([a, b], join='outer').dask)
 
 
 def test_merge():

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -57,3 +57,10 @@ def test_raises():
     assert raises(ValueError, lambda: dd.rolling_mean(ddf, -1))
     assert raises(NotImplementedError, lambda: dd.rolling_mean(ddf, 3, freq=2))
     assert raises(NotImplementedError, lambda: dd.rolling_mean(ddf, 3, how='min'))
+
+
+def test_rolling_names():
+    df = pd.DataFrame({'a': [1, 2, 3],
+                       'b': [4, 5, 6]})
+    a = dd.from_pandas(df, npartitions=2)
+    assert sorted(dd.rolling_sum(a, 2).dask) == sorted(dd.rolling_sum(a, 2).dask)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -25,6 +25,8 @@ def test_shuffle():
 
     assert not (set(x.b) & set(y.b))  # disjoint
 
+    assert shuffle(d, d.b, npartitions=2)._name == shuffle(d, d.b, npartitions=2)._name
+
 
 def test_default_partitions():
     assert shuffle(d, d.b).npartitions == d.npartitions

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -160,3 +160,11 @@ def get_categories(df):
     if iscategorical(df.index.dtype):
         result['.index'] = df.index.categories
     return result
+
+
+def tokenize_dataframe(df):
+    """ Provide unique identifier for a dataframe """
+    if isinstance(df, pd.DataFrame):
+        return (id(df), len(df), list(df.columns)) # this could be improved
+    else:
+        return (id(df), len(df), df.name) # this could be improved


### PR DESCRIPTION
Every collection has a name that the top-level/root nodes of the dask graph

```python
>>> df._name
'df-123'
>>> df.dask
{('df-123', 0): ...,
 ('df-123', 1): ...,
 ('read-csv-44', 0): ..., }
```

Currently these names usually consist of an operation name, like `concat` or `read_csv` along with an auto-incrementing number.  This is simple but means that equivalent dataframes don't have the same name.

```python
>>> dd.read_csv('myfile.csv')._name
'read_csv-123'
>>> dd.read_csv('myfile.csv')._name
'read_csv-124'
```

This limits our ability to perform meaningful caching (see #502).

To resolve this we introduce deterministic names that are generally an `md5` hash of necessary identifiers of the inputs to the operation.

```python
>>> dd.read_csv('myfile.csv')._name
'read_csv-1234FEDC'
>>> dd.read_csv('myfile.csv')._name  # same name
'read_csv-1234FEDC'
>>> dd.read_csv('myfile.csv', skiprows=1)._name  # different name
'read_csv-FFFF4321'
```

This will require some care and probably a full pass over the dataframe code.  So far it doesn't seem too complicated.  Feedback welcome on this idea before I go ahead.  This adds a slight burden on future dataframe development work.  We need to explicitly think about all inputs that might affect the output, turn those into a string and send them to a hash function.

Fixes #505 