### PR TITLE
Dask imperative plays well with other collections.

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -174,7 +174,7 @@ def to_textfiles(b, path, name_function=str):
 
 def finalize(bag, results):
     if isinstance(bag, Item):
-        return results
+        return results[0]
     if isinstance(results, Iterator):
         results = list(results)
     if isinstance(results[0], Iterable) and not isinstance(results[0], str):
@@ -194,7 +194,7 @@ class Item(Base):
         self.key = key
 
     def _keys(self):
-        return self.key
+        return [self.key]
 
     def apply(self, func):
         name = next(names)

--- a/dask/imperative.py
+++ b/dask/imperative.py
@@ -6,8 +6,7 @@ from collections import Iterator
 from toolz import merge, unique, curry
 
 from .optimize import cull, fuse
-from .base import Base
-from .context import _globals
+from . import base
 from .compatibility import apply
 from . import threaded
 
@@ -64,7 +63,7 @@ def to_task_dasks(expr):
     """
     if isinstance(expr, Value):
         return expr.key, expr._dasks
-    elif isinstance(expr, Base):
+    elif isinstance(expr, base.Base):
         name = tokenize(str(expr), True)
         keys = expr._keys()
         dsk = expr._optimize(expr.dask, keys)
@@ -183,15 +182,12 @@ def optimize(dsk, keys):
     return fuse(dsk2)
 
 
-def get(dsk, keys, get=None, **kwargs):
-    """Specialized get function"""
-    get = get or _globals['get'] or threaded.get
-    dsk2 = optimize(dsk, keys)
-    return get(dsk2, keys, **kwargs)
-
-
 def compute(*args, **kwargs):
     """Evaluate several ``Value``s at once.
+
+    Note that the only difference between this function and
+    ``dask.base.compute`` is that this implicitly converts python objects to
+    ``Value``s, allowing for collections of dask objects to be computed.
 
     Examples
     --------
@@ -200,13 +196,11 @@ def compute(*args, **kwargs):
     >>> c = a + 3
     >>> compute(b, c)  # Compute both simultaneously
     (3, 4)
-    >>> compute(a, [b, c])
+    >>> compute(a, [b, c])  # Works for lists of Values
     (1, [3, 4])
     """
     args = [value(a) for a in args]
-    dsk = merge(*[arg.dask for arg in args])
-    keys = [arg.key for arg in args]
-    return tuple(get(dsk, keys, **kwargs))
+    return base.compute(*args, **kwargs)
 
 
 def right(method):
@@ -216,20 +210,19 @@ def right(method):
     return _inner
 
 
-class Value(object):
+class Value(base.Base):
     """Represents a value to be computed by dask.
 
     Equivalent to the output from a single key in a dask graph.
     """
     __slots__ = ('_key', '_dasks')
+    _optimize = staticmethod(optimize)
+    _finalize = staticmethod(lambda a, r: r[0])
+    _default_get = staticmethod(threaded.get)
 
     def __init__(self, name, dasks):
         object.__setattr__(self, '_key', name)
         object.__setattr__(self, '_dasks', dasks)
-
-    def compute(self, **kwargs):
-        """Compute the result."""
-        return get(self.dask, self.key, **kwargs)
 
     @property
     def dask(self):
@@ -239,13 +232,8 @@ class Value(object):
     def key(self):
         return self._key
 
-    def visualize(self, optimize_graph=False, **kwargs):
-        """Visualize the dask as a graph"""
-        from dask.dot import dot_graph
-        if optimize_graph:
-            return dot_graph(optimize(self.dask, self.key), **kwargs)
-        else:
-            return dot_graph(self.dask, **kwargs)
+    def _keys(self):
+        return [self.key]
 
     def __repr__(self):
         return "Value({0})".format(repr(self.key))

--- a/dask/imperative.py
+++ b/dask/imperative.py
@@ -6,6 +6,7 @@ from collections import Iterator
 from toolz import merge, unique, curry
 
 from .optimize import cull, fuse
+from .utils import concrete
 from . import base
 from .compatibility import apply
 from . import threaded
@@ -67,7 +68,7 @@ def to_task_dasks(expr):
         name = tokenize(str(expr), True)
         keys = expr._keys()
         dsk = expr._optimize(expr.dask, keys)
-        dsk[name] = (expr._finalize, expr, (list, keys))
+        dsk[name] = (expr._finalize, expr, (concrete, keys))
         return name, [dsk]
     elif isinstance(expr, (Iterator, list, tuple, set)):
         args, dasks = unzip(map(to_task_dasks, expr), 2)

--- a/dask/imperative.py
+++ b/dask/imperative.py
@@ -6,6 +6,7 @@ from collections import Iterator
 from toolz import merge, unique, curry
 
 from .optimize import cull, fuse
+from .base import Base
 from .context import _globals
 from .compatibility import apply
 from . import threaded
@@ -63,6 +64,12 @@ def to_task_dasks(expr):
     """
     if isinstance(expr, Value):
         return expr.key, expr._dasks
+    elif isinstance(expr, Base):
+        name = tokenize(str(expr), True)
+        keys = expr._keys()
+        dsk = expr._optimize(expr.dask, keys)
+        dsk[name] = (expr._finalize, expr, (list, keys))
+        return name, [dsk]
     elif isinstance(expr, (Iterator, list, tuple, set)):
         args, dasks = unzip(map(to_task_dasks, expr), 2)
         args = list(args)


### PR DESCRIPTION
```python
>>> import dask.array as da
>>> import dask.bag as db
>>> from dask.imperative import do
>>> from dask.diagnostics import ProgressBar
>>> import numpy as np

# Create a list of 2 numpy arrays, 2 dask arrays, and a bag
>>> arr1 = np.arange(100).reshape((10, 10))
>>> arr2 = arr1.dot(arr1.T)
>>> darr1 = da.from_array(arr1, chunks=(5, 5))
>>> darr2 = da.from_array(arr2, chunks=(5, 5))
>>> b = db.from_sequence([1, 2, 3])
>>> seq = [arr1, arr2, darr1, darr2, b]
# Sum the sums of each element in the list
# Inner sum is done by each collection, outer sum is done by imperative
>>> out = do(sum)([i.sum() for i in seq])
# Compute all at once. All dasks from all collections are merged.
>>> with ProgressBar():
...     out.compute()
[########################################] | 100% Completed |  0.1s
```

Fixes #497.