### PR TITLE
Make df.apply_concat_apply work with df.Index objects (Closes #517)

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 from itertools import count
 from math import sqrt
-from functools import wraps
+from functools import wraps, reduce
 import bisect
 import uuid
 from hashlib import md5
@@ -1068,6 +1068,13 @@ def apply_concat_apply(args, chunk=None, aggregate=None, columns=None,
     """
     if not isinstance(args, (tuple, list)):
         args = [args]
+
+    def concat(args):
+        if isinstance(args[0], pd.Index):
+            concat = lambda a: reduce(lambda b, c: b.append(c), a)
+        else:
+            concat = pd.concat
+        return concat(args)
     assert all(arg.npartitions == args[0].npartitions
                 for arg in args
                 if isinstance(arg, _Frame))
@@ -1085,7 +1092,7 @@ def apply_concat_apply(args, chunk=None, aggregate=None, columns=None,
 
     b = 'apply-concat-apply--second' + token
     dsk2 = {(b, 0): (aggregate,
-                      (pd.concat,
+                      (concat,
                         (list, [(a, i) for i in range(args[0].npartitions)])))}
 
     return type(args[0])(

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1069,12 +1069,6 @@ def apply_concat_apply(args, chunk=None, aggregate=None, columns=None,
     if not isinstance(args, (tuple, list)):
         args = [args]
 
-    def concat(args):
-        if isinstance(args[0], pd.Index):
-            concat = lambda a: reduce(lambda b, c: b.append(c), a)
-        else:
-            concat = pd.concat
-        return concat(args)
     assert all(arg.npartitions == args[0].npartitions
                 for arg in args
                 if isinstance(arg, _Frame))
@@ -1092,7 +1086,7 @@ def apply_concat_apply(args, chunk=None, aggregate=None, columns=None,
 
     b = 'apply-concat-apply--second' + token
     dsk2 = {(b, 0): (aggregate,
-                      (concat,
+                      (_concat,
                         (list, [(a, i) for i in range(args[0].npartitions)])))}
 
     return type(args[0])(

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -530,7 +530,12 @@ class Series(_Frame):
 
 
 class Index(Series):
-    pass
+    def nunique(self):
+        return self.drop_duplicates().count()
+
+    def count(self):
+        f = lambda x: pd.notnull(x).sum()
+        return reduction(self, f, np.sum)
 
 
 class DataFrame(_Frame):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -812,3 +812,13 @@ def test_deterministic_apply_concat_apply_names():
            sorted(a.x.drop_duplicates().dask)
     assert sorted(a.groupby('x').y.mean().dask) == \
            sorted(a.groupby('x').y.mean().dask)
+
+
+def test_gh_517():
+    arr = np.random.randn(100, 2)
+    df = pd.DataFrame(arr, columns=['a', 'b'])
+    ddf = dd.from_pandas(df, 2)
+    assert ddf.index.nunique().compute() == 100
+
+    ddf2 = dd.from_pandas(pd.concat([df, df]), 5)
+    assert ddf2.index.nunique().compute() == 100


### PR DESCRIPTION
We were using `pd.concat` inside `apply_concat_apply` to "concat" after the first "apply". But `pd.concat` does not work for `pd.Index` objects. So we use this little funtion to do the concats now.
```python
def concat(args):
    if isinstance(args[0], pd.Index):
        concat = lambda a: reduce(lambda b, c: b.append(c), a)
    else:
        concat = pd.concat
    return concat(args)
```
 (Closes #517)