### PR TITLE
Add dask.array.fft

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -28,4 +28,4 @@ from ..context import set_options
 from ..base import compute
 from .optimization import optimize
 from .creation import arange, linspace, diag
-from .fft import fft, ifft
+from .fft import fft, ifft, rfft, irfft, hfft, ihfft

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -28,4 +28,3 @@ from ..context import set_options
 from ..base import compute
 from .optimization import optimize
 from .creation import arange, linspace, diag
-from .fft import fft, ifft, rfft, irfft, hfft, ihfft

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -28,3 +28,4 @@ from ..context import set_options
 from ..base import compute
 from .optimization import optimize
 from .creation import arange, linspace, diag
+from .fft import fft, ifft

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -21,7 +21,7 @@ from .reductions import (sum, prod, mean, std, var, any, all, min, max, vnorm,
 from .percentile import percentile
 with ignoring(ImportError):
     from .reductions import nanprod
-from . import random, linalg, ghost, learn
+from . import random, linalg, ghost, learn, fft
 from .wrap import ones, zeros, empty, full
 from .rechunk import rechunk
 from ..context import set_options

--- a/dask/array/conftest.py
+++ b/dask/array/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+def pytest_ignore_collect(path, config):
+    if 'fft.py' in str(path):
+        return True

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import
+
+import numpy as np
+import numpy.fft as npfft
+
+from .core import map_blocks
+
+"""
+TODO: implement `n` kwarg of fft's. With the current approach this would mean
+specifying a how the chunks change to pass to map_blocks.
+"""
+
+
+def fft(a, axis=-1):
+    """
+    Compute the one-dimensional discrete Fourier Transform along an axis that
+    only has one chunk.
+
+    Parameters
+    ----------
+    a : dask.array
+        input array, can be complex
+    axis : int, optional
+        Axis over which to compute the FFT.  If not given, the last
+        axis is used.
+    """
+    if len(a.chunks[axis]) != 1:
+        raise ValueError("Dask array only supports indexing along an axis"
+                         "that has a single chunk. You tried FFTing axis %s"
+                         " which has chunks %s." % (axis, a.chunks[axis]))
+
+    return map_blocks(lambda x: npfft.fft(x, axis=axis), a, dtype=np.complex_)
+
+
+def ifft(a, axis=-1):
+    """
+    Compute the one-dimensional inverse discrete Fourier Transform along an
+    axis that only has one chunk.
+
+    Parameters
+    ----------
+    a : dask.array
+        input array, can be complex
+    axis : int, optional
+        Axis over which to compute the inverse FFT.  If not given, the last
+        axis is used.
+    """
+    if len(a.chunks[axis]) != 1:
+        raise ValueError("Dask array only supports indexing along an axis"
+                         "that has a single chunk. You tried FFTing axis %s"
+                         " which has chunks %s." % (axis, a.chunks[axis]))
+
+    return map_blocks(lambda x: npfft.ifft(x, axis=axis), a, dtype=np.complex_)

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -70,26 +70,10 @@ def fft(a, n=None, axis=-1):
     Compute the one-dimensional discrete Fourier Transform along an axis that
     only has one chunk.
 
-    Parameters
-    ----------
-    a : dask.array
-        input array, can be complex
-    n : int, optional
-        Length of the transformed axis of the output.
-        If `n` is smaller than the length of the input, the input is cropped.
-        If it is larger, the input is padded with zeros.  If `n` is not given,
-        the length of the input along the axis specified by `axis` is used.
-    axis : int, optional
-        Axis over which to compute the FFT.  If not given, the last
-        axis is used.
+    The numpy.fft.fft docstring follows below:
 
-    Returns
-    -------
-    out : complex dask.array
-        The truncated or zero-padded input, transformed along the axis
-        indicated by `axis`, or the last one if `axis` is not specified.
+    """ + npfft.fft.__doc__
 
-    """
     chunks = _fft_out_chunks(a, n, axis)
 
     return _fft_wrap(npfft.fft, a, n, axis, np.complex_, chunks)
@@ -100,36 +84,10 @@ def ifft(a, n=None, axis=-1):
     Compute the one-dimensional inverse discrete Fourier Transform along an
     axis that only has one chunk.
 
-    This function computes the inverse of the one-dimensional *n*-point
-    discrete Fourier transform computed by `fft`.  In other words,
-    ``ifft(fft(a)) == a`` to within numerical accuracy.
+    The numpy.fft.ifft docstring follows below:
 
-    The input should be ordered in the same way as is returned by `fft`,
-    i.e., ``a[0]`` should contain the zero frequency term,
-    ``a[1:n/2+1]`` should contain the positive-frequency terms, and
-    ``a[n/2+1:]`` should contain the negative-frequency terms, in order of
-    decreasingly negative frequency.
+    """ + npfft.ifft.__doc__
 
-    Parameters
-    ----------
-    a : dask.array
-        input array, can be complex
-    n : int, optional
-        Length of the transformed axis of the output.
-        If `n` is smaller than the length of the input, the input is cropped.
-        If it is larger, the input is padded with zeros.  If `n` is not given,
-        the length of the input along the axis specified by `axis` is used.
-        See notes about padding issues.
-    axis : int, optional
-        Axis over which to compute the inverse FFT.  If not given, the last
-        axis is used.
-
-    Returns
-    -------
-    out : complex dask.array
-        The truncated or zero-padded input, transformed along the axis
-        indicated by `axis`, or the last one if `axis` is not specified.
-    """
     chunks = _fft_out_chunks(a, n, axis)
 
     return _fft_wrap(npfft.ifft, a, n, axis, np.complex_, chunks)
@@ -140,31 +98,10 @@ def rfft(a, n=None, axis=-1):
     Compute the one-dimensional discrete Fourier Transform for real input,
     along an axis that has only one chunk.
 
-    This function computes the one-dimensional *n*-point discrete Fourier
-    Transform (DFT) of a real-valued array by means of an efficient algorithm
-    called the Fast Fourier Transform (FFT).
+    The numpy.fft.rfft docstring follows below:
 
-    Parameters
-    ----------
-    a : array_like
-        Input array
-    n : int, optional
-        Number of points along transformation axis in the input to use.
-        If `n` is smaller than the length of the input, the input is cropped.
-        If it is larger, the input is padded with zeros. If `n` is not given,
-        the length of the input along the axis specified by `axis` is used.
-    axis : int, optional
-        Axis over which to compute the FFT. If not given, the last axis is
-        used.
+    """ + npfft.rfft.__doc__
 
-    Returns
-    -------
-    out : complex dask.array
-        The truncated or zero-padded input, transformed along the axis
-        indicated by `axis`, or the last one if `axis` is not specified.
-        If `n` is even, the length of the transformed axis is ``(n/2)+1``.
-        If `n` is odd, the length is ``(n+1)/2``.
-    """
     chunks = _rfft_out_chunks(a, n=n, axis=axis)
 
     return _fft_wrap(npfft.rfft, a, n, axis, np.complex_, chunks)
@@ -175,40 +112,10 @@ def irfft(a, n=None, axis=-1):
     Compute the inverse of the n-point DFT for real input, along an axis that
     has only one chunk.
 
-    This function computes the inverse of the one-dimensional *n*-point
-    discrete Fourier Transform of real input computed by `rfft`.
-    In other words, ``irfft(rfft(a), len(a)) == a`` to within numerical
-    accuracy. (See Notes below for why ``len(a)`` is necessary here.)
+    The numpy.fft.irfft docstring follows below:
 
-    The input is expected to be in the form returned by `rfft`, i.e. the
-    real zero-frequency term followed by the complex positive frequency terms
-    in order of increasing frequency.  Since the discrete Fourier Transform of
-    real input is Hermitian-symmetric, the negative frequency terms are taken
-    to be the complex conjugates of the corresponding positive frequency terms.
+    """ + npfft.irfft.__doc__
 
-    Parameters
-    ----------
-    a : array_like
-        The input array.
-    n : int, optional
-        Length of the transformed axis of the output.
-        For `n` output points, ``n//2+1`` input points are necessary.  If the
-        input is longer than this, it is cropped.  If it is shorter than this,
-        it is padded with zeros.  If `n` is not given, it is determined from
-        the length of the input along the axis specified by `axis`.
-    axis : int, optional
-        Axis over which to compute the inverse FFT. If not given, the last
-        axis is used.
-
-    Returns
-    -------
-    out : dask.array
-        The truncated or zero-padded input, transformed along the axis
-        indicated by `axis`, or the last one if `axis` is not specified.
-        The length of the transformed axis is `n`, or, if `n` is not given,
-        ``2*(m-1)`` where ``m`` is the length of the transformed axis of the
-        input. To get an odd number of output points, `n` must be specified.
-    """
     chunks = _irfft_out_chunks(a, n=n, axis=axis)
 
     return _fft_wrap(npfft.irfft, a, n, axis, np.float_, chunks)
@@ -219,29 +126,10 @@ def hfft(a, n=None, axis=-1):
     Compute the FFT of a signal which has Hermitian symmetry (real spectrum),
     along an axis that has only one chunk.
 
-    Parameters
-    ----------
-    a : array_like
-        The input array.
-    n : int, optional
-        Length of the transformed axis of the output.
-        For `n` output points, ``n//2+1`` input points are necessary.  If the
-        input is longer than this, it is cropped.  If it is shorter than this,
-        it is padded with zeros.  If `n` is not given, it is determined from
-        the length of the input along the axis specified by `axis`.
-    axis : int, optional
-        Axis over which to compute the FFT. If not given, the last
-        axis is used.
+    The numpy.fft.hfft docstring follows below:
 
-    Returns
-    -------
-    out : dask.array
-        The truncated or zero-padded input, transformed along the axis
-        indicated by `axis`, or the last one if `axis` is not specified.
-        The length of the transformed axis is `n`, or, if `n` is not given,
-        ``2*(m-1)`` where ``m`` is the length of the transformed axis of the
-        input. To get an odd number of output points, `n` must be specified.
-    """
+    """ + npfft.hfft.__doc__
+
     chunks = _hfft_out_chunks(a, n=n, axis=axis)
 
     return _fft_wrap(npfft.hfft, a, n, axis, np.float_, chunks)
@@ -252,28 +140,10 @@ def ihfft(a, n=None, axis=-1):
     Compute the inverse FFT of a signal which has Hermitian symmetry, along
     an axis that has only one chunk.
 
-    Parameters
-    ----------
-    a : array_like
-        Input array.
-    n : int, optional
-        Length of the inverse FFT.
-        Number of points along transformation axis in the input to use.
-        If `n` is smaller than the length of the input, the input is cropped.
-        If it is larger, the input is padded with zeros. If `n` is not given,
-        the length of the input along the axis specified by `axis` is used.
-    axis : int, optional
-        Axis over which to compute the inverse FFT. If not given, the last
-        axis is used.
+    The numpy.fft.ihfft docstring follows below:
 
-    Returns
-    -------
-    out : complex dask.array
-        The truncated or zero-padded input, transformed along the axis
-        indicated by `axis`, or the last one if `axis` is not specified.
-        If `n` is even, the length of the transformed axis is ``(n/2)+1``.
-        If `n` is odd, the length is ``(n+1)/2``.
-    """
+    """ + npfft.ihfft.__doc__
+
     chunks = _ihfft_out_chunks(a, n=n, axis=axis)
 
     return _fft_wrap(npfft.ihfft, a, n, axis, np.complex_, chunks)

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -5,10 +5,6 @@ import numpy.fft as npfft
 
 from .core import map_blocks
 
-"""
-TODO: implement `n` kwarg of fft's. With the current approach this would mean
-specifying a how the chunks change to pass to map_blocks.
-"""
 
 chunk_error = ("Dask array only supports taking an FFT along an axis that \n"
                "has a single chunk. An FFT operation was tried on axis %s \n"
@@ -16,14 +12,60 @@ chunk_error = ("Dask array only supports taking an FFT along an axis that \n"
                "dask.Array.rechunk.")
 
 
-def _fft_wrap(fft_func, a, axis, dtype):
+def _fft_wrap(fft_func, a, n, axis, dtype, chunks):
     if len(a.chunks[axis]) != 1:
         raise ValueError(chunk_error % (axis, a.chunks[axis]))
 
-    return map_blocks(lambda x: fft_func(x, axis=axis), a, dtype=dtype)
+    return map_blocks(lambda x: fft_func(x, n=n, axis=axis), a, dtype=dtype,
+                      chunks=chunks)
 
 
-def fft(a, axis=-1):
+def _fft_out_chunks(a, n, axis):
+    """ For computing the output chunks of fft and ifft"""
+    if n is None:
+        return a.chunks
+    chunks = list(a.chunks)
+    chunks[axis] = (n,)
+    return chunks
+
+
+def _rfft_out_chunks(a, n, axis):
+    if n is None:
+        n = a.chunks[axis][0]
+    chunks = list(a.chunks)
+    chunks[axis] = (n//2 + 1,)
+    return chunks
+
+
+def _irfft_out_chunks(a, n, axis):
+    if n is None:
+        n = 2 * (a.chunks[axis][0] - 1)
+    chunks = list(a.chunks)
+    chunks[axis] = (n,)
+    return chunks
+
+
+def _hfft_out_chunks(a, n, axis):
+    if n is None:
+        n = 2 * (a.chunks[axis][0] - 1)
+    chunks = list(a.chunks)
+    chunks[axis] = (n,)
+    return chunks
+
+
+def _ihfft_out_chunks(a, n, axis):
+    if n is None:
+        n = a.chunks[axis][0]
+    chunks = list(a.chunks)
+    if n % 2 == 0:
+        m = (n//2) + 1
+    else:
+        m = (n + 1)//2
+    chunks[axis] = (m,)
+    return chunks
+
+
+def fft(a, n=None, axis=-1):
     """
     Compute the one-dimensional discrete Fourier Transform along an axis that
     only has one chunk.
@@ -36,10 +78,12 @@ def fft(a, axis=-1):
         Axis over which to compute the FFT.  If not given, the last
         axis is used.
     """
-    return _fft_wrap(npfft.fft, a, axis, np.complex_)
+    chunks = _fft_out_chunks(a, n, axis)
+
+    return _fft_wrap(npfft.fft, a, n, axis, np.complex_, chunks)
 
 
-def ifft(a, axis=-1):
+def ifft(a, n=None, axis=-1):
     """
     Compute the one-dimensional inverse discrete Fourier Transform along an
     axis that only has one chunk.
@@ -52,10 +96,12 @@ def ifft(a, axis=-1):
         Axis over which to compute the inverse FFT.  If not given, the last
         axis is used.
     """
-    return _fft_wrap(npfft.ifft, a, axis, np.complex_)
+    chunks = _fft_out_chunks(a, n, axis)
+
+    return _fft_wrap(npfft.ifft, a, n, axis, np.complex_, chunks)
 
 
-def rfft(a, axis=-1):
+def rfft(a, n=None, axis=-1):
     """
     Compute the one-dimensional discrete Fourier Transform for real input,
     along an axis that has only one chunk.
@@ -72,10 +118,12 @@ def rfft(a, axis=-1):
         Axis over which to compute the FFT. If not given, the last axis is
         used.
     """
-    return _fft_wrap(npfft.rfft, a, axis, np.complex_)
+    chunks = _rfft_out_chunks(a, n=n, axis=axis)
+
+    return _fft_wrap(npfft.rfft, a, n, axis, np.complex_, chunks)
 
 
-def irfft(a, axis=-1):
+def irfft(a, n=None, axis=-1):
     """
     Compute the inverse of the n-point DFT for real input, along an axis that
     has only one chunk.
@@ -99,10 +147,12 @@ def irfft(a, axis=-1):
         Axis over which to compute the inverse FFT. If not given, the last
         axis is used.
     """
-    return _fft_wrap(npfft.irfft, a, axis, np.float_)
+    chunks = _irfft_out_chunks(a, n=n, axis=axis)
+
+    return _fft_wrap(npfft.irfft, a, n, axis, np.float_, chunks)
 
 
-def hfft(a, axis=-1):
+def hfft(a, n=None, axis=-1):
     """
     Compute the FFT of a signal which has Hermitian symmetry (real spectrum),
     along an axis that has only one chunk.
@@ -115,10 +165,12 @@ def hfft(a, axis=-1):
         Axis over which to compute the FFT. If not given, the last
         axis is used.
     """
-    return _fft_wrap(npfft.hfft, a, axis, np.float_)
+    chunks = _hfft_out_chunks(a, n=n, axis=axis)
+
+    return _fft_wrap(npfft.hfft, a, n, axis, np.float_, chunks)
 
 
-def ihfft(a, axis=-1):
+def ihfft(a, n=None, axis=-1):
     """
     Compute the inverse FFT of a signal which has Hermitian symmetry, along
     an axis that has only one chunk.
@@ -131,4 +183,6 @@ def ihfft(a, axis=-1):
         Axis over which to compute the inverse FFT. If not given, the last
         axis is used.
     """
-    return _fft_wrap(npfft.ihfft, a, axis, np.complex_)
+    chunks = _ihfft_out_chunks(a, n=n, axis=axis)
+
+    return _fft_wrap(npfft.ihfft, a, n, axis, np.complex_, chunks)

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -11,9 +11,18 @@ chunk_error = ("Dask array only supports taking an FFT along an axis that \n"
                "which has chunks %s. To change the array's chunks use "
                "dask.Array.rechunk.")
 
+fft_preamble = """
+    Wrapping of numpy.fft.%s
 
-def _fft_wrap(fft_func, dtype, out_chunk_fn, doc_preamble,
-              func_name):
+    The axis along which the FFT is applied must have a one chunk. To change
+    the array's chunking use dask.Array.rechunk.
+
+    The numpy.fft.%s docstring follows below:
+
+    """
+
+
+def _fft_wrap(fft_func, dtype, out_chunk_fn):
     def func(a, n=None, axis=-1):
         if len(a.chunks[axis]) != 1:
             raise ValueError(chunk_error % (axis, a.chunks[axis]))
@@ -23,8 +32,9 @@ def _fft_wrap(fft_func, dtype, out_chunk_fn, doc_preamble,
         return map_blocks(lambda x: fft_func(x, n=n, axis=axis), a, dtype=dtype,
                           chunks=chunks)
 
-    func.__doc__ = doc_preamble + fft_func.__doc__
-    func.__name__ = func_name
+    np_name = fft_func.__name__
+    func.__doc__ = (fft_preamble % (np_name, np_name)) + fft_func.__doc__
+    func.__name__ = np_name
     return func
 
 
@@ -73,62 +83,19 @@ def _ihfft_out_chunks(a, n, axis):
     return chunks
 
 
-fft_preamble = """
-    Compute the one-dimensional discrete Fourier Transform along an axis that
-    only has one chunk.
-
-    The numpy.fft.fft docstring follows below:
-
-    """
-
-fft = _fft_wrap(npfft.fft, np.complex_, _fft_out_chunks, fft_preamble, 'fft')
+fft = _fft_wrap(npfft.fft, np.complex_, _fft_out_chunks)
 
 
-ifft_preamble = """
-    Compute the one-dimensional inverse discrete Fourier Transform along an
-    axis that only has one chunk.
-
-    The numpy.fft.ifft docstring follows below:
-
-    """
-ifft = _fft_wrap(npfft.ifft, np.complex_, _fft_out_chunks, ifft_preamble, 'ifft')
+ifft = _fft_wrap(npfft.ifft, np.complex_, _fft_out_chunks)
 
 
-rfft_preamble = """
-    Compute the one-dimensional discrete Fourier Transform for real input,
-    along an axis that has only one chunk.
-
-    The numpy.fft.rfft docstring follows below:
-
-    """
-rfft = _fft_wrap(npfft.rfft, np.complex_, _rfft_out_chunks, rfft_preamble, 'rfft')
+rfft = _fft_wrap(npfft.rfft, np.complex_, _rfft_out_chunks)
 
 
-irfft_preamble = """
-    Compute the inverse of the n-point DFT for real input, along an axis that
-    has only one chunk.
-
-    The numpy.fft.irfft docstring follows below:
-
-    """
-irfft = _fft_wrap(npfft.irfft, np.float_, _irfft_out_chunks, irfft_preamble, 'irfft')
+irfft = _fft_wrap(npfft.irfft, np.float_, _irfft_out_chunks)
 
 
-hfft_preamble = """
-    Compute the FFT of a signal which has Hermitian symmetry (real spectrum),
-    along an axis that has only one chunk.
-
-    The numpy.fft.hfft docstring follows below:
-
-    """
-hfft = _fft_wrap(npfft.hfft, np.float_, _hfft_out_chunks, hfft_preamble, 'hfft')
+hfft = _fft_wrap(npfft.hfft, np.float_, _hfft_out_chunks)
 
 
-ihfft_preamble = """
-    Compute the inverse FFT of a signal which has Hermitian symmetry, along
-    an axis that has only one chunk.
-
-    The numpy.fft.ihfft docstring follows below:
-
-    """
-ihfft = _fft_wrap(npfft.ihfft, np.complex_, _ihfft_out_chunks, ihfft_preamble, 'ihfft')
+ihfft = _fft_wrap(npfft.ihfft, np.complex_, _ihfft_out_chunks)

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -12,12 +12,20 @@ chunk_error = ("Dask array only supports taking an FFT along an axis that \n"
                "dask.Array.rechunk.")
 
 
-def _fft_wrap(fft_func, a, n, axis, dtype, chunks):
-    if len(a.chunks[axis]) != 1:
-        raise ValueError(chunk_error % (axis, a.chunks[axis]))
+def _fft_wrap(fft_func, dtype, out_chunk_fn, doc_preamble,
+              func_name):
+    def func(a, n=None, axis=-1):
+        if len(a.chunks[axis]) != 1:
+            raise ValueError(chunk_error % (axis, a.chunks[axis]))
 
-    return map_blocks(lambda x: fft_func(x, n=n, axis=axis), a, dtype=dtype,
-                      chunks=chunks)
+        chunks = out_chunk_fn(a, n, axis)
+
+        return map_blocks(lambda x: fft_func(x, n=n, axis=axis), a, dtype=dtype,
+                          chunks=chunks)
+
+    func.__doc__ = doc_preamble + fft_func.__doc__
+    func.__name__ = func_name
+    return func
 
 
 def _fft_out_chunks(a, n, axis):
@@ -65,85 +73,62 @@ def _ihfft_out_chunks(a, n, axis):
     return chunks
 
 
-def fft(a, n=None, axis=-1):
-    """
+fft_preamble = """
     Compute the one-dimensional discrete Fourier Transform along an axis that
     only has one chunk.
 
     The numpy.fft.fft docstring follows below:
 
-    """ + npfft.fft.__doc__
-
-    chunks = _fft_out_chunks(a, n, axis)
-
-    return _fft_wrap(npfft.fft, a, n, axis, np.complex_, chunks)
-
-
-def ifft(a, n=None, axis=-1):
     """
+
+fft = _fft_wrap(npfft.fft, np.complex_, _fft_out_chunks, fft_preamble, 'fft')
+
+
+ifft_preamble = """
     Compute the one-dimensional inverse discrete Fourier Transform along an
     axis that only has one chunk.
 
     The numpy.fft.ifft docstring follows below:
 
-    """ + npfft.ifft.__doc__
-
-    chunks = _fft_out_chunks(a, n, axis)
-
-    return _fft_wrap(npfft.ifft, a, n, axis, np.complex_, chunks)
-
-
-def rfft(a, n=None, axis=-1):
     """
+ifft = _fft_wrap(npfft.ifft, np.complex_, _fft_out_chunks, ifft_preamble, 'ifft')
+
+
+rfft_preamble = """
     Compute the one-dimensional discrete Fourier Transform for real input,
     along an axis that has only one chunk.
 
     The numpy.fft.rfft docstring follows below:
 
-    """ + npfft.rfft.__doc__
-
-    chunks = _rfft_out_chunks(a, n=n, axis=axis)
-
-    return _fft_wrap(npfft.rfft, a, n, axis, np.complex_, chunks)
-
-
-def irfft(a, n=None, axis=-1):
     """
+rfft = _fft_wrap(npfft.rfft, np.complex_, _rfft_out_chunks, rfft_preamble, 'rfft')
+
+
+irfft_preamble = """
     Compute the inverse of the n-point DFT for real input, along an axis that
     has only one chunk.
 
     The numpy.fft.irfft docstring follows below:
 
-    """ + npfft.irfft.__doc__
-
-    chunks = _irfft_out_chunks(a, n=n, axis=axis)
-
-    return _fft_wrap(npfft.irfft, a, n, axis, np.float_, chunks)
-
-
-def hfft(a, n=None, axis=-1):
     """
+irfft = _fft_wrap(npfft.irfft, np.float_, _irfft_out_chunks, irfft_preamble, 'irfft')
+
+
+hfft_preamble = """
     Compute the FFT of a signal which has Hermitian symmetry (real spectrum),
     along an axis that has only one chunk.
 
     The numpy.fft.hfft docstring follows below:
 
-    """ + npfft.hfft.__doc__
-
-    chunks = _hfft_out_chunks(a, n=n, axis=axis)
-
-    return _fft_wrap(npfft.hfft, a, n, axis, np.float_, chunks)
-
-
-def ihfft(a, n=None, axis=-1):
     """
+hfft = _fft_wrap(npfft.hfft, np.float_, _hfft_out_chunks, hfft_preamble, 'hfft')
+
+
+ihfft_preamble = """
     Compute the inverse FFT of a signal which has Hermitian symmetry, along
     an axis that has only one chunk.
 
     The numpy.fft.ihfft docstring follows below:
 
-    """ + npfft.ihfft.__doc__
-
-    chunks = _ihfft_out_chunks(a, n=n, axis=axis)
-
-    return _fft_wrap(npfft.ihfft, a, n, axis, np.complex_, chunks)
+    """
+ihfft = _fft_wrap(npfft.ihfft, np.complex_, _ihfft_out_chunks, ihfft_preamble, 'ihfft')

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -74,9 +74,21 @@ def fft(a, n=None, axis=-1):
     ----------
     a : dask.array
         input array, can be complex
+    n : int, optional
+        Length of the transformed axis of the output.
+        If `n` is smaller than the length of the input, the input is cropped.
+        If it is larger, the input is padded with zeros.  If `n` is not given,
+        the length of the input along the axis specified by `axis` is used.
     axis : int, optional
         Axis over which to compute the FFT.  If not given, the last
         axis is used.
+
+    Returns
+    -------
+    out : complex dask.array
+        The truncated or zero-padded input, transformed along the axis
+        indicated by `axis`, or the last one if `axis` is not specified.
+
     """
     chunks = _fft_out_chunks(a, n, axis)
 
@@ -88,13 +100,35 @@ def ifft(a, n=None, axis=-1):
     Compute the one-dimensional inverse discrete Fourier Transform along an
     axis that only has one chunk.
 
+    This function computes the inverse of the one-dimensional *n*-point
+    discrete Fourier transform computed by `fft`.  In other words,
+    ``ifft(fft(a)) == a`` to within numerical accuracy.
+
+    The input should be ordered in the same way as is returned by `fft`,
+    i.e., ``a[0]`` should contain the zero frequency term,
+    ``a[1:n/2+1]`` should contain the positive-frequency terms, and
+    ``a[n/2+1:]`` should contain the negative-frequency terms, in order of
+    decreasingly negative frequency.
+
     Parameters
     ----------
     a : dask.array
         input array, can be complex
+    n : int, optional
+        Length of the transformed axis of the output.
+        If `n` is smaller than the length of the input, the input is cropped.
+        If it is larger, the input is padded with zeros.  If `n` is not given,
+        the length of the input along the axis specified by `axis` is used.
+        See notes about padding issues.
     axis : int, optional
         Axis over which to compute the inverse FFT.  If not given, the last
         axis is used.
+
+    Returns
+    -------
+    out : complex dask.array
+        The truncated or zero-padded input, transformed along the axis
+        indicated by `axis`, or the last one if `axis` is not specified.
     """
     chunks = _fft_out_chunks(a, n, axis)
 
@@ -114,9 +148,22 @@ def rfft(a, n=None, axis=-1):
     ----------
     a : array_like
         Input array
+    n : int, optional
+        Number of points along transformation axis in the input to use.
+        If `n` is smaller than the length of the input, the input is cropped.
+        If it is larger, the input is padded with zeros. If `n` is not given,
+        the length of the input along the axis specified by `axis` is used.
     axis : int, optional
         Axis over which to compute the FFT. If not given, the last axis is
         used.
+
+    Returns
+    -------
+    out : complex dask.array
+        The truncated or zero-padded input, transformed along the axis
+        indicated by `axis`, or the last one if `axis` is not specified.
+        If `n` is even, the length of the transformed axis is ``(n/2)+1``.
+        If `n` is odd, the length is ``(n+1)/2``.
     """
     chunks = _rfft_out_chunks(a, n=n, axis=axis)
 
@@ -143,9 +190,24 @@ def irfft(a, n=None, axis=-1):
     ----------
     a : array_like
         The input array.
+    n : int, optional
+        Length of the transformed axis of the output.
+        For `n` output points, ``n//2+1`` input points are necessary.  If the
+        input is longer than this, it is cropped.  If it is shorter than this,
+        it is padded with zeros.  If `n` is not given, it is determined from
+        the length of the input along the axis specified by `axis`.
     axis : int, optional
         Axis over which to compute the inverse FFT. If not given, the last
         axis is used.
+
+    Returns
+    -------
+    out : dask.array
+        The truncated or zero-padded input, transformed along the axis
+        indicated by `axis`, or the last one if `axis` is not specified.
+        The length of the transformed axis is `n`, or, if `n` is not given,
+        ``2*(m-1)`` where ``m`` is the length of the transformed axis of the
+        input. To get an odd number of output points, `n` must be specified.
     """
     chunks = _irfft_out_chunks(a, n=n, axis=axis)
 
@@ -161,9 +223,24 @@ def hfft(a, n=None, axis=-1):
     ----------
     a : array_like
         The input array.
+    n : int, optional
+        Length of the transformed axis of the output.
+        For `n` output points, ``n//2+1`` input points are necessary.  If the
+        input is longer than this, it is cropped.  If it is shorter than this,
+        it is padded with zeros.  If `n` is not given, it is determined from
+        the length of the input along the axis specified by `axis`.
     axis : int, optional
         Axis over which to compute the FFT. If not given, the last
         axis is used.
+
+    Returns
+    -------
+    out : dask.array
+        The truncated or zero-padded input, transformed along the axis
+        indicated by `axis`, or the last one if `axis` is not specified.
+        The length of the transformed axis is `n`, or, if `n` is not given,
+        ``2*(m-1)`` where ``m`` is the length of the transformed axis of the
+        input. To get an odd number of output points, `n` must be specified.
     """
     chunks = _hfft_out_chunks(a, n=n, axis=axis)
 
@@ -179,9 +256,23 @@ def ihfft(a, n=None, axis=-1):
     ----------
     a : array_like
         Input array.
+    n : int, optional
+        Length of the inverse FFT.
+        Number of points along transformation axis in the input to use.
+        If `n` is smaller than the length of the input, the input is cropped.
+        If it is larger, the input is padded with zeros. If `n` is not given,
+        the length of the input along the axis specified by `axis` is used.
     axis : int, optional
         Axis over which to compute the inverse FFT. If not given, the last
         axis is used.
+
+    Returns
+    -------
+    out : complex dask.array
+        The truncated or zero-padded input, transformed along the axis
+        indicated by `axis`, or the last one if `axis` is not specified.
+        If `n` is even, the length of the transformed axis is ``(n/2)+1``.
+        If `n` is odd, the length is ``(n+1)/2``.
     """
     chunks = _ihfft_out_chunks(a, n=n, axis=axis)
 

--- a/dask/array/fft.py
+++ b/dask/array/fft.py
@@ -10,6 +10,18 @@ TODO: implement `n` kwarg of fft's. With the current approach this would mean
 specifying a how the chunks change to pass to map_blocks.
 """
 
+chunk_error = ("Dask array only supports taking an FFT along an axis that \n"
+               "has a single chunk. An FFT operation was tried on axis %s \n"
+               "which has chunks %s. To change the array's chunks use "
+               "dask.Array.rechunk.")
+
+
+def _fft_wrap(fft_func, a, axis, dtype):
+    if len(a.chunks[axis]) != 1:
+        raise ValueError(chunk_error % (axis, a.chunks[axis]))
+
+    return map_blocks(lambda x: fft_func(x, axis=axis), a, dtype=dtype)
+
 
 def fft(a, axis=-1):
     """
@@ -24,12 +36,7 @@ def fft(a, axis=-1):
         Axis over which to compute the FFT.  If not given, the last
         axis is used.
     """
-    if len(a.chunks[axis]) != 1:
-        raise ValueError("Dask array only supports indexing along an axis"
-                         "that has a single chunk. You tried FFTing axis %s"
-                         " which has chunks %s." % (axis, a.chunks[axis]))
-
-    return map_blocks(lambda x: npfft.fft(x, axis=axis), a, dtype=np.complex_)
+    return _fft_wrap(npfft.fft, a, axis, np.complex_)
 
 
 def ifft(a, axis=-1):
@@ -45,9 +52,83 @@ def ifft(a, axis=-1):
         Axis over which to compute the inverse FFT.  If not given, the last
         axis is used.
     """
-    if len(a.chunks[axis]) != 1:
-        raise ValueError("Dask array only supports indexing along an axis"
-                         "that has a single chunk. You tried FFTing axis %s"
-                         " which has chunks %s." % (axis, a.chunks[axis]))
+    return _fft_wrap(npfft.ifft, a, axis, np.complex_)
 
-    return map_blocks(lambda x: npfft.ifft(x, axis=axis), a, dtype=np.complex_)
+
+def rfft(a, axis=-1):
+    """
+    Compute the one-dimensional discrete Fourier Transform for real input,
+    along an axis that has only one chunk.
+
+    This function computes the one-dimensional *n*-point discrete Fourier
+    Transform (DFT) of a real-valued array by means of an efficient algorithm
+    called the Fast Fourier Transform (FFT).
+
+    Parameters
+    ----------
+    a : array_like
+        Input array
+    axis : int, optional
+        Axis over which to compute the FFT. If not given, the last axis is
+        used.
+    """
+    return _fft_wrap(npfft.rfft, a, axis, np.complex_)
+
+
+def irfft(a, axis=-1):
+    """
+    Compute the inverse of the n-point DFT for real input, along an axis that
+    has only one chunk.
+
+    This function computes the inverse of the one-dimensional *n*-point
+    discrete Fourier Transform of real input computed by `rfft`.
+    In other words, ``irfft(rfft(a), len(a)) == a`` to within numerical
+    accuracy. (See Notes below for why ``len(a)`` is necessary here.)
+
+    The input is expected to be in the form returned by `rfft`, i.e. the
+    real zero-frequency term followed by the complex positive frequency terms
+    in order of increasing frequency.  Since the discrete Fourier Transform of
+    real input is Hermitian-symmetric, the negative frequency terms are taken
+    to be the complex conjugates of the corresponding positive frequency terms.
+
+    Parameters
+    ----------
+    a : array_like
+        The input array.
+    axis : int, optional
+        Axis over which to compute the inverse FFT. If not given, the last
+        axis is used.
+    """
+    return _fft_wrap(npfft.irfft, a, axis, np.float_)
+
+
+def hfft(a, axis=-1):
+    """
+    Compute the FFT of a signal which has Hermitian symmetry (real spectrum),
+    along an axis that has only one chunk.
+
+    Parameters
+    ----------
+    a : array_like
+        The input array.
+    axis : int, optional
+        Axis over which to compute the FFT. If not given, the last
+        axis is used.
+    """
+    return _fft_wrap(npfft.hfft, a, axis, np.float_)
+
+
+def ihfft(a, axis=-1):
+    """
+    Compute the inverse FFT of a signal which has Hermitian symmetry, along
+    an axis that has only one chunk.
+
+    Parameters
+    ----------
+    a : array_like
+        Input array.
+    axis : int, optional
+        Axis over which to compute the inverse FFT. If not given, the last
+        axis is used.
+    """
+    return _fft_wrap(npfft.ihfft, a, axis, np.complex_)

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -39,96 +39,68 @@ def eq(a, b):
 
 
 class TestFFT(unittest.TestCase):
+    nparr = np.arange(100).reshape(10, 10)
+    darr = da.from_array(nparr, chunks=(1, 10))
+    darr2 = da.from_array(nparr, chunks=(10, 1))
+
     def test_cant_fft_chunked_axis(self):
-        nparr = np.arange(100).reshape(10, 10)
-        darr = da.from_array(nparr, chunks=(5, 5))
-        assert raises(ValueError, lambda: fft(darr))
-        assert raises(ValueError, lambda: fft(darr, axis=0))
+        bad_darr = da.from_array(self.nparr, chunks=(5, 5))
+
+        assert raises(ValueError, lambda: fft(bad_darr))
+        assert raises(ValueError, lambda: fft(bad_darr, axis=0))
 
     def test_fft(self):
-        nparr = np.arange(100).reshape(10, 10)
-        darr = da.from_array(nparr, chunks=(1, 10))
-
-        res = fft(darr)
-        expected = npfft.fft(nparr)
+        res = fft(self.darr)
+        expected = npfft.fft(self.nparr)
         assert eq(res, expected)
 
-    def test_fft_axis(self):
-        nparr = np.arange(100).reshape(10, 10)
-        darr = da.from_array(nparr, chunks=(10, 1))
-
-        res = fft(darr, axis=0)
-        expected = npfft.fft(nparr, axis=0)
-        assert eq(res, expected)
+        res2 = fft(self.darr2, axis=0)
+        expected2 = npfft.fft(self.nparr, axis=0)
+        assert eq(res2, expected2)
 
     def test_ifft(self):
-        nparr = np.arange(100).reshape(10, 10)
-        darr = da.from_array(nparr, chunks=(1, 10))
-
-        res = ifft(darr)
-        expected = npfft.ifft(nparr)
+        res = ifft(self.darr)
+        expected = npfft.ifft(self.nparr)
         assert eq(res, expected)
 
-        darr2 = da.from_array(nparr, chunks=(10, 1))
-
-        res2 = ifft(darr2, axis=0)
-        expected2 = npfft.ifft(nparr, axis=0)
+        res2 = ifft(self.darr2, axis=0)
+        expected2 = npfft.ifft(self.nparr, axis=0)
         assert eq(res2, expected2)
 
     def test_rfft(self):
-        nparr = np.arange(100).reshape(10, 10)
-        darr = da.from_array(nparr, chunks=(1, 10))
-
-        res = rfft(darr)
-        expected = npfft.rfft(nparr)
+        res = rfft(self.darr)
+        expected = npfft.rfft(self.nparr)
         assert eq(res, expected)
 
-        darr2 = da.from_array(nparr, chunks=(10, 1))
-
-        res2 = rfft(darr2, axis=0)
-        expected2 = npfft.rfft(nparr, axis=0)
+        res2 = rfft(self.darr2, axis=0)
+        expected2 = npfft.rfft(self.nparr, axis=0)
         assert eq(res2, expected2)
 
     def test_irfft(self):
-        nparr = np.arange(100).reshape(10, 10)
-        darr = da.from_array(nparr, chunks=(1, 10))
-
-        res = irfft(darr)
-        expected = npfft.irfft(nparr)
+        res = irfft(self.darr)
+        expected = npfft.irfft(self.nparr)
         assert eq(res, expected)
 
-        darr2 = da.from_array(nparr, chunks=(10, 1))
-
-        res2 = irfft(darr2, axis=0)
-        expected2 = npfft.irfft(nparr, axis=0)
+        res2 = irfft(self.darr2, axis=0)
+        expected2 = npfft.irfft(self.nparr, axis=0)
         assert eq(res2, expected2)
 
     def test_hfft(self):
-        nparr = np.arange(100).reshape(10, 10)
-        darr = da.from_array(nparr, chunks=(1, 10))
-
-        res = hfft(darr)
-        expected = npfft.hfft(nparr)
+        res = hfft(self.darr)
+        expected = npfft.hfft(self.nparr)
         assert eq(res, expected)
 
-        darr2 = da.from_array(nparr, chunks=(10, 1))
-
-        res2 = hfft(darr2, axis=0)
-        expected2 = npfft.hfft(nparr, axis=0)
+        res2 = hfft(self.darr2, axis=0)
+        expected2 = npfft.hfft(self.nparr, axis=0)
         assert eq(res2, expected2)
 
     def test_ihfft(self):
-        nparr = np.arange(100).reshape(10, 10)
-        darr = da.from_array(nparr, chunks=(1, 10))
-
-        res = ihfft(darr)
-        expected = npfft.ihfft(nparr)
+        res = ihfft(self.darr)
+        expected = npfft.ihfft(self.nparr)
         assert eq(res, expected)
 
-        darr2 = da.from_array(nparr, chunks=(10, 1))
-
-        res2 = ihfft(darr2, axis=0)
-        expected2 = npfft.ihfft(nparr, axis=0)
+        res2 = ihfft(self.darr2, axis=0)
+        expected2 = npfft.ihfft(self.nparr, axis=0)
         assert eq(res2, expected2)
 
 

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -7,7 +7,7 @@ import dask
 from dask.array.core import Array
 from dask.utils import raises
 import dask.array as da
-from dask.array.fft import fft, ifft
+from dask.array.fft import fft, ifft, rfft, irfft, hfft, ihfft
 
 
 def eq(a, b):
@@ -73,6 +73,62 @@ class TestFFT(unittest.TestCase):
 
         res2 = ifft(darr2, axis=0)
         expected2 = npfft.ifft(nparr, axis=0)
+        assert eq(res2, expected2)
+
+    def test_rfft(self):
+        nparr = np.arange(100).reshape(10, 10)
+        darr = da.from_array(nparr, chunks=(1, 10))
+
+        res = rfft(darr)
+        expected = npfft.rfft(nparr)
+        assert eq(res, expected)
+
+        darr2 = da.from_array(nparr, chunks=(10, 1))
+
+        res2 = rfft(darr2, axis=0)
+        expected2 = npfft.rfft(nparr, axis=0)
+        assert eq(res2, expected2)
+
+    def test_irfft(self):
+        nparr = np.arange(100).reshape(10, 10)
+        darr = da.from_array(nparr, chunks=(1, 10))
+
+        res = irfft(darr)
+        expected = npfft.irfft(nparr)
+        assert eq(res, expected)
+
+        darr2 = da.from_array(nparr, chunks=(10, 1))
+
+        res2 = irfft(darr2, axis=0)
+        expected2 = npfft.irfft(nparr, axis=0)
+        assert eq(res2, expected2)
+
+    def test_hfft(self):
+        nparr = np.arange(100).reshape(10, 10)
+        darr = da.from_array(nparr, chunks=(1, 10))
+
+        res = hfft(darr)
+        expected = npfft.hfft(nparr)
+        assert eq(res, expected)
+
+        darr2 = da.from_array(nparr, chunks=(10, 1))
+
+        res2 = hfft(darr2, axis=0)
+        expected2 = npfft.hfft(nparr, axis=0)
+        assert eq(res2, expected2)
+
+    def test_ihfft(self):
+        nparr = np.arange(100).reshape(10, 10)
+        darr = da.from_array(nparr, chunks=(1, 10))
+
+        res = ihfft(darr)
+        expected = npfft.ihfft(nparr)
+        assert eq(res, expected)
+
+        darr2 = da.from_array(nparr, chunks=(10, 1))
+
+        res2 = ihfft(darr2, axis=0)
+        expected2 = npfft.ihfft(nparr, axis=0)
         assert eq(res2, expected2)
 
 

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -50,181 +50,72 @@ class TestFFT(unittest.TestCase):
 
     def test_cant_fft_chunked_axis(self):
         bad_darr = da.from_array(self.nparr, chunks=(5, 5))
-
         assert raises(ValueError, lambda: fft(bad_darr))
         assert raises(ValueError, lambda: fft(bad_darr, axis=0))
 
     def test_fft(self):
-        res = fft(self.darr)
-        expected = npfft.fft(self.nparr)
-        assert eq(res, expected)
-
-        res2 = fft(self.darr2, axis=0)
-        expected2 = npfft.fft(self.nparr, axis=0)
-        assert eq(res2, expected2)
+        assert eq(fft(self.darr), npfft.fft(self.nparr))
+        assert eq(fft(self.darr2, axis=0), npfft.fft(self.nparr, axis=0))
 
     def test_fft_n_kwarg(self):
-        res = fft(self.darr, 5)
-        expected = npfft.fft(self.nparr, 5)
-        assert eq(res, expected)
-
-        res2 = fft(self.darr, 13)
-        expected2 = npfft.fft(self.nparr, 13)
-        assert eq(res2, expected2)
-
-        res3 = fft(self.darr2, 5, axis=0)
-        expected3 = npfft.fft(self.nparr, 5, axis=0)
-        assert eq(res3, expected3)
-
-        res4 = fft(self.darr2, 13, axis=0)
-        expected4 = npfft.fft(self.nparr, 13, axis=0)
-        assert eq(res4, expected4)
+        assert eq(fft(self.darr, 5), npfft.fft(self.nparr, 5))
+        assert eq(fft(self.darr, 13), npfft.fft(self.nparr, 13))
+        assert eq(fft(self.darr2, 5, axis=0), npfft.fft(self.nparr, 5, axis=0))
+        assert eq(fft(self.darr2, 13, axis=0), npfft.fft(self.nparr, 13, axis=0))
 
     def test_ifft(self):
-        res = ifft(self.darr)
-        expected = npfft.ifft(self.nparr)
-        assert eq(res, expected)
-
-        res2 = ifft(self.darr2, axis=0)
-        expected2 = npfft.ifft(self.nparr, axis=0)
-        assert eq(res2, expected2)
+        assert eq(ifft(self.darr), npfft.ifft(self.nparr))
+        assert eq(ifft(self.darr2, axis=0), npfft.ifft(self.nparr, axis=0))
 
     def test_ifft_n_kwarg(self):
-        res = ifft(self.darr, 5)
-        expected = npfft.ifft(self.nparr, 5)
-        assert eq(res, expected)
-
-        res2 = ifft(self.darr, 13)
-        expected2 = npfft.ifft(self.nparr, 13)
-        assert eq(res2, expected2)
-
-        res3 = ifft(self.darr2, 5, axis=0)
-        expected3 = npfft.ifft(self.nparr, 5, axis=0)
-        assert eq(res3, expected3)
-
-        res4 = ifft(self.darr2, 13, axis=0)
-        expected4 = npfft.ifft(self.nparr, 13, axis=0)
-        assert eq(res4, expected4)
+        assert eq(ifft(self.darr, 5), npfft.ifft(self.nparr, 5))
+        assert eq(ifft(self.darr, 13), npfft.ifft(self.nparr, 13))
+        assert eq(ifft(self.darr2, 5, axis=0), npfft.ifft(self.nparr, 5, axis=0))
+        assert eq(ifft(self.darr2, 13, axis=0), npfft.ifft(self.nparr, 13, axis=0))
 
     def test_rfft(self):
-        res0 = rfft(self.darr)
-        expected0 = npfft.rfft(self.nparr)
-        assert eq(res0, expected0)
-
-        res1 = rfft(self.darr2, axis=0)
-        expected1 = npfft.rfft(self.nparr, axis=0)
-        assert eq(res1, expected1)
+        assert eq(rfft(self.darr), npfft.rfft(self.nparr))
+        assert eq(rfft(self.darr2, axis=0), npfft.rfft(self.nparr, axis=0))
 
     def test_rfft_n_kwarg(self):
-        res = rfft(self.darr, 5)
-        expected = npfft.rfft(self.nparr, 5)
-        assert eq(res, expected)
-
-        res2 = rfft(self.darr, 13)
-        expected2 = npfft.rfft(self.nparr, 13)
-        assert eq(res2, expected2)
-
-        res3 = rfft(self.darr2, 5, axis=0)
-        expected3 = npfft.rfft(self.nparr, 5, axis=0)
-        assert eq(res3, expected3)
-
-        res4 = rfft(self.darr2, 13, axis=0)
-        expected4 = npfft.rfft(self.nparr, 13, axis=0)
-        assert eq(res4, expected4)
-
-        res5 = rfft(self.darr2, 12, axis=0)  # even n
-        expected5 = npfft.rfft(self.nparr, 12, axis=0)
-        assert eq(res5, expected5)
+        assert eq(rfft(self.darr, 5), npfft.rfft(self.nparr, 5))
+        assert eq(rfft(self.darr, 13), npfft.rfft(self.nparr, 13))
+        assert eq(rfft(self.darr2, 5, axis=0), npfft.rfft(self.nparr, 5, axis=0))
+        assert eq(rfft(self.darr2, 13, axis=0), npfft.rfft(self.nparr, 13, axis=0))
+        assert eq(rfft(self.darr2, 12, axis=0), npfft.rfft(self.nparr, 12, axis=0))
 
     def test_irfft(self):
-        res = irfft(self.darr)
-        expected = npfft.irfft(self.nparr)
-        assert eq(res, expected)
-
-        res2 = irfft(self.darr2, axis=0)
-        expected2 = npfft.irfft(self.nparr, axis=0)
-        assert eq(res2, expected2)
+        assert eq(irfft(self.darr), npfft.irfft(self.nparr))
+        assert eq(irfft(self.darr2, axis=0), npfft.irfft(self.nparr, axis=0))
 
     def test_irfft_n_kwarg(self):
-        res = irfft(self.darr, 5)
-        expected = npfft.irfft(self.nparr, 5)
-        assert eq(res, expected)
-
-        res2 = irfft(self.darr, 13)
-        expected2 = npfft.irfft(self.nparr, 13)
-        assert eq(res2, expected2)
-
-        res3 = irfft(self.darr2, 5, axis=0)
-        expected3 = npfft.irfft(self.nparr, 5, axis=0)
-        assert eq(res3, expected3)
-
-        res4 = irfft(self.darr2, 13, axis=0)
-        expected4 = npfft.irfft(self.nparr, 13, axis=0)
-        assert eq(res4, expected4)
-
-        res5 = irfft(self.darr2, 12, axis=0)  # even n
-        expected5 = npfft.irfft(self.nparr, 12, axis=0)
-        assert eq(res5, expected5)
+        assert eq(irfft(self.darr, 5), npfft.irfft(self.nparr, 5))
+        assert eq(irfft(self.darr, 13), npfft.irfft(self.nparr, 13))
+        assert eq(irfft(self.darr2, 5, axis=0), npfft.irfft(self.nparr, 5, axis=0))
+        assert eq(irfft(self.darr2, 13, axis=0), npfft.irfft(self.nparr, 13, axis=0))
+        assert eq(irfft(self.darr2, 12, axis=0), npfft.irfft(self.nparr, 12, axis=0))
 
     def test_hfft(self):
-        res = hfft(self.darr)
-        expected = npfft.hfft(self.nparr)
-        assert eq(res, expected)
-
-        res2 = hfft(self.darr2, axis=0)
-        expected2 = npfft.hfft(self.nparr, axis=0)
-        assert eq(res2, expected2)
+        assert eq(hfft(self.darr), npfft.hfft(self.nparr))
+        assert eq(hfft(self.darr2, axis=0), npfft.hfft(self.nparr, axis=0))
 
     def test_hfft_nkwarg(self):
-        res = hfft(self.darr, 5)
-        expected = npfft.hfft(self.nparr, 5)
-        assert eq(res, expected)
-
-        res2 = hfft(self.darr, 13)
-        expected2 = npfft.hfft(self.nparr, 13)
-        assert eq(res2, expected2)
-
-        res3 = hfft(self.darr2, 5, axis=0)
-        expected3 = npfft.hfft(self.nparr, 5, axis=0)
-        assert eq(res3, expected3)
-
-        res4 = hfft(self.darr2, 13, axis=0)
-        expected4 = npfft.hfft(self.nparr, 13, axis=0)
-        assert eq(res4, expected4)
-
-        res5 = hfft(self.darr2, 12, axis=0)  # even n
-        expected5 = npfft.hfft(self.nparr, 12, axis=0)
-        assert eq(res5, expected5)
+        assert eq(hfft(self.darr, 5), npfft.hfft(self.nparr, 5))
+        assert eq(hfft(self.darr, 13), npfft.hfft(self.nparr, 13))
+        assert eq(hfft(self.darr2, 5, axis=0), npfft.hfft(self.nparr, 5, axis=0))
+        assert eq(hfft(self.darr2, 13, axis=0), npfft.hfft(self.nparr, 13, axis=0))
+        assert eq(hfft(self.darr2, 12, axis=0), npfft.hfft(self.nparr, 12, axis=0))
 
     def test_ihfft(self):
-        res = ihfft(self.darr)
-        expected = npfft.ihfft(self.nparr)
-        assert eq(res, expected)
-
-        res2 = ihfft(self.darr2, axis=0)
-        expected2 = npfft.ihfft(self.nparr, axis=0)
-        assert eq(res2, expected2)
+        assert eq(ihfft(self.darr), npfft.ihfft(self.nparr))
+        assert eq(ihfft(self.darr2, axis=0), npfft.ihfft(self.nparr, axis=0))
 
     def test_ihfft_n_kwarg(self):
-        res = ihfft(self.darr, 5)
-        expected = npfft.ihfft(self.nparr, 5)
-        assert eq(res, expected)
-
-        res2 = ihfft(self.darr, 13)
-        expected2 = npfft.ihfft(self.nparr, 13)
-        assert eq(res2, expected2)
-
-        res3 = ihfft(self.darr2, 5, axis=0)
-        expected3 = npfft.ihfft(self.nparr, 5, axis=0)
-        assert eq(res3, expected3)
-
-        res4 = ihfft(self.darr2, 13, axis=0)
-        expected4 = npfft.ihfft(self.nparr, 13, axis=0)
-        assert eq(res4, expected4)
-
-        res5 = ihfft(self.darr2, 12, axis=0)  # even n
-        expected5 = npfft.ihfft(self.nparr, 12, axis=0)
-        assert eq(res5, expected5)
+        assert eq(ihfft(self.darr, 5), npfft.ihfft(self.nparr, 5))
+        assert eq(ihfft(self.darr, 13), npfft.ihfft(self.nparr, 13))
+        assert eq(ihfft(self.darr2, 5, axis=0), npfft.ihfft(self.nparr, 5, axis=0))
+        assert eq(ihfft(self.darr2, 13, axis=0), npfft.ihfft(self.nparr, 13, axis=0))
+        assert eq(ihfft(self.darr2, 12, axis=0), npfft.ihfft(self.nparr, 12, axis=0))
 
 if __name__ == '__main__':
     unittest.main()

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy as np
 import numpy.fft as npfft
 
@@ -43,79 +41,88 @@ def eq(a, b):
         return c
 
 
-class TestFFT(unittest.TestCase):
-    nparr = np.arange(100).reshape(10, 10)
-    darr = da.from_array(nparr, chunks=(1, 10))
-    darr2 = da.from_array(nparr, chunks=(10, 1))
+nparr = np.arange(100).reshape(10, 10)
+darr = da.from_array(nparr, chunks=(1, 10))
+darr2 = da.from_array(nparr, chunks=(10, 1))
 
-    def test_cant_fft_chunked_axis(self):
-        bad_darr = da.from_array(self.nparr, chunks=(5, 5))
-        assert raises(ValueError, lambda: fft(bad_darr))
-        assert raises(ValueError, lambda: fft(bad_darr, axis=0))
 
-    def test_fft(self):
-        assert eq(fft(self.darr), npfft.fft(self.nparr))
-        assert eq(fft(self.darr2, axis=0), npfft.fft(self.nparr, axis=0))
+def test_cant_fft_chunked_axis():
+    bad_darr = da.from_array(nparr, chunks=(5, 5))
+    assert raises(ValueError, lambda: fft(bad_darr))
+    assert raises(ValueError, lambda: fft(bad_darr, axis=0))
 
-    def test_fft_n_kwarg(self):
-        assert eq(fft(self.darr, 5), npfft.fft(self.nparr, 5))
-        assert eq(fft(self.darr, 13), npfft.fft(self.nparr, 13))
-        assert eq(fft(self.darr2, 5, axis=0), npfft.fft(self.nparr, 5, axis=0))
-        assert eq(fft(self.darr2, 13, axis=0), npfft.fft(self.nparr, 13, axis=0))
 
-    def test_ifft(self):
-        assert eq(ifft(self.darr), npfft.ifft(self.nparr))
-        assert eq(ifft(self.darr2, axis=0), npfft.ifft(self.nparr, axis=0))
+def test_fft():
+    assert eq(fft(darr), npfft.fft(nparr))
+    assert eq(fft(darr2, axis=0), npfft.fft(nparr, axis=0))
 
-    def test_ifft_n_kwarg(self):
-        assert eq(ifft(self.darr, 5), npfft.ifft(self.nparr, 5))
-        assert eq(ifft(self.darr, 13), npfft.ifft(self.nparr, 13))
-        assert eq(ifft(self.darr2, 5, axis=0), npfft.ifft(self.nparr, 5, axis=0))
-        assert eq(ifft(self.darr2, 13, axis=0), npfft.ifft(self.nparr, 13, axis=0))
 
-    def test_rfft(self):
-        assert eq(rfft(self.darr), npfft.rfft(self.nparr))
-        assert eq(rfft(self.darr2, axis=0), npfft.rfft(self.nparr, axis=0))
+def test_fft_n_kwarg():
+    assert eq(fft(darr, 5), npfft.fft(nparr, 5))
+    assert eq(fft(darr, 13), npfft.fft(nparr, 13))
+    assert eq(fft(darr2, 5, axis=0), npfft.fft(nparr, 5, axis=0))
+    assert eq(fft(darr2, 13, axis=0), npfft.fft(nparr, 13, axis=0))
 
-    def test_rfft_n_kwarg(self):
-        assert eq(rfft(self.darr, 5), npfft.rfft(self.nparr, 5))
-        assert eq(rfft(self.darr, 13), npfft.rfft(self.nparr, 13))
-        assert eq(rfft(self.darr2, 5, axis=0), npfft.rfft(self.nparr, 5, axis=0))
-        assert eq(rfft(self.darr2, 13, axis=0), npfft.rfft(self.nparr, 13, axis=0))
-        assert eq(rfft(self.darr2, 12, axis=0), npfft.rfft(self.nparr, 12, axis=0))
 
-    def test_irfft(self):
-        assert eq(irfft(self.darr), npfft.irfft(self.nparr))
-        assert eq(irfft(self.darr2, axis=0), npfft.irfft(self.nparr, axis=0))
+def test_ifft():
+    assert eq(ifft(darr), npfft.ifft(nparr))
+    assert eq(ifft(darr2, axis=0), npfft.ifft(nparr, axis=0))
 
-    def test_irfft_n_kwarg(self):
-        assert eq(irfft(self.darr, 5), npfft.irfft(self.nparr, 5))
-        assert eq(irfft(self.darr, 13), npfft.irfft(self.nparr, 13))
-        assert eq(irfft(self.darr2, 5, axis=0), npfft.irfft(self.nparr, 5, axis=0))
-        assert eq(irfft(self.darr2, 13, axis=0), npfft.irfft(self.nparr, 13, axis=0))
-        assert eq(irfft(self.darr2, 12, axis=0), npfft.irfft(self.nparr, 12, axis=0))
 
-    def test_hfft(self):
-        assert eq(hfft(self.darr), npfft.hfft(self.nparr))
-        assert eq(hfft(self.darr2, axis=0), npfft.hfft(self.nparr, axis=0))
+def test_ifft_n_kwarg():
+    assert eq(ifft(darr, 5), npfft.ifft(nparr, 5))
+    assert eq(ifft(darr, 13), npfft.ifft(nparr, 13))
+    assert eq(ifft(darr2, 5, axis=0), npfft.ifft(nparr, 5, axis=0))
+    assert eq(ifft(darr2, 13, axis=0), npfft.ifft(nparr, 13, axis=0))
 
-    def test_hfft_nkwarg(self):
-        assert eq(hfft(self.darr, 5), npfft.hfft(self.nparr, 5))
-        assert eq(hfft(self.darr, 13), npfft.hfft(self.nparr, 13))
-        assert eq(hfft(self.darr2, 5, axis=0), npfft.hfft(self.nparr, 5, axis=0))
-        assert eq(hfft(self.darr2, 13, axis=0), npfft.hfft(self.nparr, 13, axis=0))
-        assert eq(hfft(self.darr2, 12, axis=0), npfft.hfft(self.nparr, 12, axis=0))
 
-    def test_ihfft(self):
-        assert eq(ihfft(self.darr), npfft.ihfft(self.nparr))
-        assert eq(ihfft(self.darr2, axis=0), npfft.ihfft(self.nparr, axis=0))
+def test_rfft():
+    assert eq(rfft(darr), npfft.rfft(nparr))
+    assert eq(rfft(darr2, axis=0), npfft.rfft(nparr, axis=0))
 
-    def test_ihfft_n_kwarg(self):
-        assert eq(ihfft(self.darr, 5), npfft.ihfft(self.nparr, 5))
-        assert eq(ihfft(self.darr, 13), npfft.ihfft(self.nparr, 13))
-        assert eq(ihfft(self.darr2, 5, axis=0), npfft.ihfft(self.nparr, 5, axis=0))
-        assert eq(ihfft(self.darr2, 13, axis=0), npfft.ihfft(self.nparr, 13, axis=0))
-        assert eq(ihfft(self.darr2, 12, axis=0), npfft.ihfft(self.nparr, 12, axis=0))
 
-if __name__ == '__main__':
-    unittest.main()
+def test_rfft_n_kwarg():
+    assert eq(rfft(darr, 5), npfft.rfft(nparr, 5))
+    assert eq(rfft(darr, 13), npfft.rfft(nparr, 13))
+    assert eq(rfft(darr2, 5, axis=0), npfft.rfft(nparr, 5, axis=0))
+    assert eq(rfft(darr2, 13, axis=0), npfft.rfft(nparr, 13, axis=0))
+    assert eq(rfft(darr2, 12, axis=0), npfft.rfft(nparr, 12, axis=0))
+
+
+def test_irfft():
+    assert eq(irfft(darr), npfft.irfft(nparr))
+    assert eq(irfft(darr2, axis=0), npfft.irfft(nparr, axis=0))
+
+
+def test_irfft_n_kwarg():
+    assert eq(irfft(darr, 5), npfft.irfft(nparr, 5))
+    assert eq(irfft(darr, 13), npfft.irfft(nparr, 13))
+    assert eq(irfft(darr2, 5, axis=0), npfft.irfft(nparr, 5, axis=0))
+    assert eq(irfft(darr2, 13, axis=0), npfft.irfft(nparr, 13, axis=0))
+    assert eq(irfft(darr2, 12, axis=0), npfft.irfft(nparr, 12, axis=0))
+
+
+def test_hfft():
+    assert eq(hfft(darr), npfft.hfft(nparr))
+    assert eq(hfft(darr2, axis=0), npfft.hfft(nparr, axis=0))
+
+
+def test_hfft_nkwarg():
+    assert eq(hfft(darr, 5), npfft.hfft(nparr, 5))
+    assert eq(hfft(darr, 13), npfft.hfft(nparr, 13))
+    assert eq(hfft(darr2, 5, axis=0), npfft.hfft(nparr, 5, axis=0))
+    assert eq(hfft(darr2, 13, axis=0), npfft.hfft(nparr, 13, axis=0))
+    assert eq(hfft(darr2, 12, axis=0), npfft.hfft(nparr, 12, axis=0))
+
+
+def test_ihfft():
+    assert eq(ihfft(darr), npfft.ihfft(nparr))
+    assert eq(ihfft(darr2, axis=0), npfft.ihfft(nparr, axis=0))
+
+
+def test_ihfft_n_kwarg():
+    assert eq(ihfft(darr, 5), npfft.ihfft(nparr, 5))
+    assert eq(ihfft(darr, 13), npfft.ihfft(nparr, 13))
+    assert eq(ihfft(darr2, 5, axis=0), npfft.ihfft(nparr, 5, axis=0))
+    assert eq(ihfft(darr2, 13, axis=0), npfft.ihfft(nparr, 13, axis=0))
+    assert eq(ihfft(darr2, 12, axis=0), npfft.ihfft(nparr, 12, axis=0))

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -1,0 +1,80 @@
+import unittest
+
+import numpy as np
+import numpy.fft as npfft
+
+import dask
+from dask.array.core import Array
+from dask.utils import raises
+import dask.array as da
+from dask.array.fft import fft, ifft
+
+
+def eq(a, b):
+    if isinstance(a, Array):
+        adt = a._dtype
+        a = a.compute(get=dask.get)
+    else:
+        adt = getattr(a, 'dtype', None)
+    if isinstance(b, Array):
+        bdt = b._dtype
+        b = b.compute(get=dask.get)
+    else:
+        bdt = getattr(b, 'dtype', None)
+
+    if not str(adt) == str(bdt):
+        return False
+
+    try:
+        return np.allclose(a, b)
+    except TypeError:
+        pass
+
+    c = a == b
+
+    if isinstance(c, np.ndarray):
+        return c.all()
+    else:
+        return c
+
+
+class TestFFT(unittest.TestCase):
+    def test_cant_fft_chunked_axis(self):
+        nparr = np.arange(100).reshape(10, 10)
+        darr = da.from_array(nparr, chunks=(5, 5))
+        assert raises(ValueError, lambda: fft(darr))
+        assert raises(ValueError, lambda: fft(darr, axis=0))
+
+    def test_fft(self):
+        nparr = np.arange(100).reshape(10, 10)
+        darr = da.from_array(nparr, chunks=(1, 10))
+
+        res = fft(darr)
+        expected = npfft.fft(nparr)
+        assert eq(res, expected)
+
+    def test_fft_axis(self):
+        nparr = np.arange(100).reshape(10, 10)
+        darr = da.from_array(nparr, chunks=(10, 1))
+
+        res = fft(darr, axis=0)
+        expected = npfft.fft(nparr, axis=0)
+        assert eq(res, expected)
+
+    def test_ifft(self):
+        nparr = np.arange(100).reshape(10, 10)
+        darr = da.from_array(nparr, chunks=(1, 10))
+
+        res = ifft(darr)
+        expected = npfft.ifft(nparr)
+        assert eq(res, expected)
+
+        darr2 = da.from_array(nparr, chunks=(10, 1))
+
+        res2 = ifft(darr2, axis=0)
+        expected2 = npfft.ifft(nparr, axis=0)
+        assert eq(res2, expected2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/dask/array/tests/test_fft.py
+++ b/dask/array/tests/test_fft.py
@@ -10,7 +10,13 @@ import dask.array as da
 from dask.array.fft import fft, ifft, rfft, irfft, hfft, ihfft
 
 
+def mismatch_err(mismatch_type, got, expected):
+    return '%s mismatch, got %s, expected %s' % (mismatch_type, got, expected)
+
+
 def eq(a, b):
+    assert a.shape == b.shape, mismatch_err('shape', a.shape, b.shape)
+
     if isinstance(a, Array):
         adt = a._dtype
         a = a.compute(get=dask.get)
@@ -22,8 +28,7 @@ def eq(a, b):
     else:
         bdt = getattr(b, 'dtype', None)
 
-    if not str(adt) == str(bdt):
-        return False
+    assert str(adt) == str(bdt), mismatch_err('dtype', str(adt), str(bdt))
 
     try:
         return np.allclose(a, b)
@@ -58,6 +63,23 @@ class TestFFT(unittest.TestCase):
         expected2 = npfft.fft(self.nparr, axis=0)
         assert eq(res2, expected2)
 
+    def test_fft_n_kwarg(self):
+        res = fft(self.darr, 5)
+        expected = npfft.fft(self.nparr, 5)
+        assert eq(res, expected)
+
+        res2 = fft(self.darr, 13)
+        expected2 = npfft.fft(self.nparr, 13)
+        assert eq(res2, expected2)
+
+        res3 = fft(self.darr2, 5, axis=0)
+        expected3 = npfft.fft(self.nparr, 5, axis=0)
+        assert eq(res3, expected3)
+
+        res4 = fft(self.darr2, 13, axis=0)
+        expected4 = npfft.fft(self.nparr, 13, axis=0)
+        assert eq(res4, expected4)
+
     def test_ifft(self):
         res = ifft(self.darr)
         expected = npfft.ifft(self.nparr)
@@ -67,14 +89,52 @@ class TestFFT(unittest.TestCase):
         expected2 = npfft.ifft(self.nparr, axis=0)
         assert eq(res2, expected2)
 
-    def test_rfft(self):
-        res = rfft(self.darr)
-        expected = npfft.rfft(self.nparr)
+    def test_ifft_n_kwarg(self):
+        res = ifft(self.darr, 5)
+        expected = npfft.ifft(self.nparr, 5)
         assert eq(res, expected)
 
-        res2 = rfft(self.darr2, axis=0)
-        expected2 = npfft.rfft(self.nparr, axis=0)
+        res2 = ifft(self.darr, 13)
+        expected2 = npfft.ifft(self.nparr, 13)
         assert eq(res2, expected2)
+
+        res3 = ifft(self.darr2, 5, axis=0)
+        expected3 = npfft.ifft(self.nparr, 5, axis=0)
+        assert eq(res3, expected3)
+
+        res4 = ifft(self.darr2, 13, axis=0)
+        expected4 = npfft.ifft(self.nparr, 13, axis=0)
+        assert eq(res4, expected4)
+
+    def test_rfft(self):
+        res0 = rfft(self.darr)
+        expected0 = npfft.rfft(self.nparr)
+        assert eq(res0, expected0)
+
+        res1 = rfft(self.darr2, axis=0)
+        expected1 = npfft.rfft(self.nparr, axis=0)
+        assert eq(res1, expected1)
+
+    def test_rfft_n_kwarg(self):
+        res = rfft(self.darr, 5)
+        expected = npfft.rfft(self.nparr, 5)
+        assert eq(res, expected)
+
+        res2 = rfft(self.darr, 13)
+        expected2 = npfft.rfft(self.nparr, 13)
+        assert eq(res2, expected2)
+
+        res3 = rfft(self.darr2, 5, axis=0)
+        expected3 = npfft.rfft(self.nparr, 5, axis=0)
+        assert eq(res3, expected3)
+
+        res4 = rfft(self.darr2, 13, axis=0)
+        expected4 = npfft.rfft(self.nparr, 13, axis=0)
+        assert eq(res4, expected4)
+
+        res5 = rfft(self.darr2, 12, axis=0)  # even n
+        expected5 = npfft.rfft(self.nparr, 12, axis=0)
+        assert eq(res5, expected5)
 
     def test_irfft(self):
         res = irfft(self.darr)
@@ -85,6 +145,27 @@ class TestFFT(unittest.TestCase):
         expected2 = npfft.irfft(self.nparr, axis=0)
         assert eq(res2, expected2)
 
+    def test_irfft_n_kwarg(self):
+        res = irfft(self.darr, 5)
+        expected = npfft.irfft(self.nparr, 5)
+        assert eq(res, expected)
+
+        res2 = irfft(self.darr, 13)
+        expected2 = npfft.irfft(self.nparr, 13)
+        assert eq(res2, expected2)
+
+        res3 = irfft(self.darr2, 5, axis=0)
+        expected3 = npfft.irfft(self.nparr, 5, axis=0)
+        assert eq(res3, expected3)
+
+        res4 = irfft(self.darr2, 13, axis=0)
+        expected4 = npfft.irfft(self.nparr, 13, axis=0)
+        assert eq(res4, expected4)
+
+        res5 = irfft(self.darr2, 12, axis=0)  # even n
+        expected5 = npfft.irfft(self.nparr, 12, axis=0)
+        assert eq(res5, expected5)
+
     def test_hfft(self):
         res = hfft(self.darr)
         expected = npfft.hfft(self.nparr)
@@ -93,6 +174,27 @@ class TestFFT(unittest.TestCase):
         res2 = hfft(self.darr2, axis=0)
         expected2 = npfft.hfft(self.nparr, axis=0)
         assert eq(res2, expected2)
+
+    def test_hfft_nkwarg(self):
+        res = hfft(self.darr, 5)
+        expected = npfft.hfft(self.nparr, 5)
+        assert eq(res, expected)
+
+        res2 = hfft(self.darr, 13)
+        expected2 = npfft.hfft(self.nparr, 13)
+        assert eq(res2, expected2)
+
+        res3 = hfft(self.darr2, 5, axis=0)
+        expected3 = npfft.hfft(self.nparr, 5, axis=0)
+        assert eq(res3, expected3)
+
+        res4 = hfft(self.darr2, 13, axis=0)
+        expected4 = npfft.hfft(self.nparr, 13, axis=0)
+        assert eq(res4, expected4)
+
+        res5 = hfft(self.darr2, 12, axis=0)  # even n
+        expected5 = npfft.hfft(self.nparr, 12, axis=0)
+        assert eq(res5, expected5)
 
     def test_ihfft(self):
         res = ihfft(self.darr)
@@ -103,6 +205,26 @@ class TestFFT(unittest.TestCase):
         expected2 = npfft.ihfft(self.nparr, axis=0)
         assert eq(res2, expected2)
 
+    def test_ihfft_n_kwarg(self):
+        res = ihfft(self.darr, 5)
+        expected = npfft.ihfft(self.nparr, 5)
+        assert eq(res, expected)
+
+        res2 = ihfft(self.darr, 13)
+        expected2 = npfft.ihfft(self.nparr, 13)
+        assert eq(res2, expected2)
+
+        res3 = ihfft(self.darr2, 5, axis=0)
+        expected3 = npfft.ihfft(self.nparr, 5, axis=0)
+        assert eq(res3, expected3)
+
+        res4 = ihfft(self.darr2, 13, axis=0)
+        expected4 = npfft.ihfft(self.nparr, 13, axis=0)
+        assert eq(res4, expected4)
+
+        res5 = ihfft(self.darr2, 12, axis=0)  # even n
+        expected5 = npfft.ihfft(self.nparr, 12, axis=0)
+        assert eq(res5, expected5)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds `dask.array.fft` and `dask.array.ifft`, which only work along axes that are not chunked.

Some potential todo's:
* The `fft.py` module is not importable since the `fft` function clashes with it. We should consider renaming the module but I couldn't think of a good name immediately.
* Add support for the padding keyword argument `n` which either trims or pads the input. There is a little added complexity since the output dask array's size will change. But it is doable.
* Add more stuff from `numpy.fft`, these were pretty easy to wrap. The rest are not much more complex. List of numpy's fft functions here: http://docs.scipy.org/doc/numpy/reference/routines.fft.html

If these seem pressing or mildly important, I'll do them.

Docstrings are mostly copied from numpy.

Also note that I wrote the tests in the idiomatic unittest way. I have been more fond of unittest lately since its invocation time is so much faster than py.test. And it is in the stdlib.

Partially closes #405 