### PR TITLE
Run Worker.close from main thread

### DIFF
--- a/dask/distributed/tests/test_client.py
+++ b/dask/distributed/tests/test_client.py
@@ -24,9 +24,9 @@ def scheduler_and_workers(n=2):
     try:
         yield s, workers
     finally:
-        s.close()
         for w in workers:
             w.close()
+        s.close()
 
 
 def test_get():


### PR DESCRIPTION
Previously we ran this operation from a thread.  This was bad because
this operation kills the thread pool in which it runs.  We create a
special set of remote functions that get run in the main event loop