### PR TITLE
Fixes around to-castra

### DIFF
--- a/dask/async.py
+++ b/dask/async.py
@@ -185,7 +185,7 @@ def start_state_from_dask(dsk, cache=None, sortkey=None):
     waiting_data = dict((k, v.copy()) for k, v in dependents.items() if v)
 
     ready_set = set([k for k, v in waiting.items() if not v])
-    ready = sorted(ready_set, key=sortkey)
+    ready = sorted(ready_set, key=sortkey, reverse=True)
     waiting = dict((k, v) for k, v in waiting.items() if v)
 
     state = {'dependencies': dependencies,
@@ -307,7 +307,7 @@ def finish_task(dsk, key, state, results, sortkey, delete=True,
     if key in state['ready-set']:
         state['ready-set'].remove(key)
 
-    for dep in sorted(state['dependents'][key], key=sortkey):
+    for dep in sorted(state['dependents'][key], key=sortkey, reverse=True):
         s = state['waiting'][dep]
         s.remove(key)
         if not s:

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -616,7 +616,7 @@ def to_castra(df, fn=None, categories=None, compute=True):
                           (Castra.extend, (name, -1), (df._name, i)))
 
     dsk = merge(dsk, df.dask)
-    keys = [(name, -1), list(dsk.keys())]
+    keys = [(name, -1), (name, df.npartitions - 1)]
     if compute:
         c, _ = DataFrame._get(dsk, keys)
         return c

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -17,6 +17,7 @@ from ..utils import textblock, file_size
 from ..base import compute
 from .utils import tokenize_dataframe
 from .. import array as da
+from ..async import get_sync
 
 from . import core
 from .core import (DataFrame, Series, concat, categorize_block, tokens,
@@ -618,7 +619,7 @@ def to_castra(df, fn=None, categories=None, compute=True):
     dsk = merge(dsk, df.dask)
     keys = [(name, -1), (name, df.npartitions - 1)]
     if compute:
-        c, _ = DataFrame._get(dsk, keys)
+        c, _ = DataFrame._get(dsk, keys, get=get_sync)
         return c
     else:
         return dsk, keys

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -437,6 +437,8 @@ def test_to_castra():
     dsk, keys = a.to_castra(compute=False)
     assert isinstance(dsk, dict)
     assert isinstance(keys, list)
+    c, last = keys
+    assert last[1] == a.npartitions - 1
 
 
 def test_to_hdf():

--- a/dask/order.py
+++ b/dask/order.py
@@ -27,12 +27,12 @@ Breaking Ties
 -------------
 
 And so we create a total ordering over all nodes to serve as a tie breaker.  We
-represent this ordering with a dictionary.  Larger scores have higher priority.
+represent this ordering with a dictionary.  Lower scores have higher priority.
 
-    {'a': 3,
-     'c': 2,
-     'd': 1,
-     'b': 1}
+    {'d': 0,
+     'c': 1,
+     'a': 2,
+     'b': 3}
 
 There are several ways in which we might order our keys.  In practice we have
 found the following objectives important:
@@ -159,7 +159,7 @@ def _child_max(key, scores, result, dependencies, dependents):
     if key not in result:
         deps = dependencies[key]
         result[key] = max([_child_max(k, scores, result, dependencies,
-                                      dependents) for k in deps]) - 0.5
+                                      dependents) for k in deps]) + scores[key]
     return result[key]
 
 
@@ -186,19 +186,21 @@ def dfs(dependencies, dependents, key=lambda x: x):
     i = 0
 
     roots = [k for k, v in dependents.items() if not v]
-    stack = sorted(roots, key=key, reverse=True)
+    stack = sorted(roots, key=key)
     seen = set()
 
     while stack:
         item = stack.pop()
+        if item in seen:
+            continue
         seen.add(item)
 
         result[item] = i
         deps = dependencies[item]
-        deps = deps - seen
-        seen |= deps
-        deps = sorted(deps, key=key, reverse=True)
-        stack.extend(deps)
+        if deps:
+            deps = deps - seen
+            deps = sorted(deps, key=key)
+            stack.extend(deps)
         i += 1
 
     return result

--- a/dask/order.py
+++ b/dask/order.py
@@ -70,7 +70,7 @@ def order(dsk):
 
     >>> dsk = {'a': 1, 'b': 2, 'c': (inc, 'a'), 'd': (add, 'b', 'c')}
     >>> order(dsk)
-    {'a': 3, 'c': 2, 'b': 1, 'd': 0}
+    {'a': 2, 'c': 1, 'b': 3, 'd': 0}
     """
     dependencies, dependents = get_deps(dsk)
     ndeps = ndependents(dependencies, dependents)
@@ -121,13 +121,11 @@ def child_max(dependencies, dependents, scores):
     """ Maximum-ish of scores of children
 
     This takes a dictionary of scores per key and returns a new set of scores
-    per key that is the maximum of the scores of all children of that node
-    minus a half.  In some sense this ranks each node by the maximum importance
-    of their children but then subtracts a little bit to ensure that the parent
-    node is slightly less important.  This half-score stops us from losing
-    information about depth, otherwise things tend to flatten out.
+    per key that is the maximum of the scores of all children of that node plus
+    its own score.  In some sense this ranks each node by the maximum
+    importance of their children plus their own value.
 
-    This is generally fed in the result from ``ndependents``
+    This is generally fed the result from ``ndependents``
 
     Examples
     --------
@@ -137,7 +135,7 @@ def child_max(dependencies, dependents, scores):
     >>> dependencies, dependents = get_deps(dsk)
 
     >>> sorted(child_max(dependencies, dependents, scores).items())
-    [('a', 3), ('b', 2), ('c', 2.5), ('d', 2.0)]
+    [('a', 3), ('b', 2), ('c', 5), ('d', 6)]
     """
     result = dict()
 
@@ -180,7 +178,7 @@ def dfs(dependencies, dependents, key=lambda x: x):
     >>> dependencies, dependents = get_deps(dsk)
 
     >>> sorted(dfs(dependencies, dependents).items())
-    [('a', 3), ('b', 1), ('c', 2), ('d', 0)]
+    [('a', 2), ('b', 3), ('c', 1), ('d', 0)]
     """
     result = dict()
     i = 0

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -90,7 +90,7 @@ def test_base_of_reduce_preferred():
                  ('b', 2): 7,
                  ('b', 3): 8}
 
-    # ('b', 1) is the most important out of ('b', i)
+    # ('b', 0) is the most important out of ('b', i)
     assert min([('b', i) for i in [0, 1, 2, 3]], key=o.get) == ('b', 0)
 
 

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -1,27 +1,16 @@
-from dask.order import dfs, child_max, ndependents, order, inc
+from dask.order import dfs, child_max, ndependents, order, inc, get_deps
 
 
 def issorted(L, reverse=False):
     return sorted(L, reverse=reverse) == L
 
 
-def test_ordering_prefers_depth_first():
-    a, b, c = 'abc'
-    f = lambda *args: None
-    d = {(a, 0): (f,), (b, 0): 0, (c, 0): (f,),
-         (a, 1): (f,), (b, 1): (f, (a, 0), (b, 0), (c, 0)), (c, 1): (f,),
-         (a, 2): (f,), (b, 2): (f, (a, 1), (b, 1), (c, 1)), (c, 2): (f,),
-         (a, 3): (f,), (b, 3): (f, (a, 2), (b, 2), (c, 2)), (c, 3): (f,)}
-
-    o = order(d)
-
-    assert issorted(list(map(o.get, [(a, i) for i in range(4)])), reverse=True)
-    assert issorted(list(map(o.get, [(c, i) for i in range(4)])), reverse=True)
+def f(*args):
+    pass
 
 
 def test_ordering_keeps_groups_together():
     a, b, c = 'abc'
-    f = lambda *args: None
     d = dict(((a, i), (f,)) for i in range(4))
     d.update({(b, 0): (f, (a, 0), (a, 1)),
               (b, 1): (f, (a, 2), (a, 3))})
@@ -39,19 +28,106 @@ def test_ordering_keeps_groups_together():
     assert abs(o[(a, 1)] - o[(a, 3)]) == 1
 
 
-def test_ordering_prefers_tasks_that_release_data():
-    a, b, c = 'abc'
-    f = lambda *args: None
-    d = {(a, 0): (f,), (a, 1): (f,),
-         (b, 0): (f, (a, 0)), (b, 1): (f, (a, 1)), (b, 2): (f, (a, 1))}
+def test_prefer_broker_nodes():
+    """
 
-    o = order(d)
+    b0    b1  b2
+    |      \  /
+    a0      a1
+
+    a1 should be run before a0
+    """
+    a, b, c = 'abc'
+    dsk = {(a, 0): (f,), (a, 1): (f,),
+           (b, 0): (f, (a, 0)), (b, 1): (f, (a, 1)), (b, 2): (f, (a, 1))}
+
+    dependencies, dependents = get_deps(dsk)
+    nd = ndependents(dependencies, dependents)
+    cm = child_max(dependencies, dependents, nd)
+    o = order(dsk)
+
+    assert o[(a, 1)] < o[(a, 0)]
+
+    # Switch name of 0, 1 to ensure that this isn't due to string comparison
+    dsk = {(a, 0): (f,), (a, 1): (f,),
+           (b, 0): (f, (a, 0)), (b, 1): (f, (a, 1)), (b, 2): (f, (a, 0))}
+
+    o = order(dsk)
 
     assert o[(a, 1)] > o[(a, 0)]
 
-    d = {(a, 0): (f,), (a, 1): (f,),
-         (b, 0): (f, (a, 0)), (b, 1): (f, (a, 1)), (b, 2): (f, (a, 0))}
 
-    o = order(d)
+def test_base_of_reduce_preferred():
+    """
+               a3
+              /|
+            a2 |
+           /|  |
+         a1 |  |
+        /|  |  |
+      a0 |  |  |
+      |  |  |  |
+      b0 b1 b2 b3
+        \ \ / /
+           c
 
-    assert o[(a, 1)] < o[(a, 0)]
+    We really want to run b0 quickly
+    """
+    dsk = dict((('a', i), (f, ('a', i - 1), ('b', i))) for i in [1, 2, 3])
+    dsk[('a', 0)] = (f, ('b', 0))
+    dsk.update(dict((('b', i), (f, 'c', 1)) for i in [0, 1, 2, 3]))
+    dsk['c'] = 1
+
+    o = order(dsk)
+
+    assert o == {('a', 3): 0,
+                 ('a', 2): 1,
+                 ('a', 1): 2,
+                 ('a', 0): 3,
+                 ('b', 0): 4,
+                  'c':     5,
+                 ('b', 1): 6,
+                 ('b', 2): 7,
+                 ('b', 3): 8}
+
+    # ('b', 1) is the most important out of ('b', i)
+    assert min([('b', i) for i in [0, 1, 2, 3]], key=o.get) == ('b', 0)
+
+
+def test_deep_bases_win_over_dependents():
+    """
+    d should come before e and probably before one of b and c
+
+            a
+          / | \   .
+         b  c |
+        / \ | /
+       e    d
+    """
+    dsk = {'a': (f, 'b', 'c', 'd'), 'b': (f, 'd', 'e'), 'c': (f, 'd'), 'd': 1,
+            'e': 2}
+
+    dependencies, dependents = get_deps(dsk)
+    nd = ndependents(dependencies, dependents)
+    cm = child_max(dependencies, dependents, nd)
+
+    o = order(dsk)
+    assert o['d'] < o['e']
+    assert o['d'] < o['b'] or o['d'] < o['c']
+
+
+def test_prefer_deep():
+    """
+        c
+        |
+    y   b
+    |   |
+    x   a
+
+    Prefer longer chains first so we should start with c
+    """
+    dsk = {'a': 1, 'b': (f, 'a'), 'c': (f, 'b'),
+           'x': 1, 'y': (f, 'x')}
+
+    o = order(dsk)
+    assert o == {'c': 0, 'b': 1, 'a': 2, 'y': 3, 'x': 4}


### PR DESCRIPTION
This changes castra in a few ways

1.  `to_castra` uses `get_sync`
2.  I updated the ordering heuristics for the async scheduler (cc @jcrist).  The tests are now hopefully more accessible (with pictures!)
3.  General bugfixes