### PR TITLE
Fix Index repr / index attribute access

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -442,8 +442,9 @@ class Series(_Frame):
         return (self.name,)
 
     def __repr__(self):
-        return ("dd.Series<%s, divisions=%s>" %
-                (self._name, repr_long_list(self.divisions)))
+        return ("dd.%s<%s, divisions=%s>" %
+                (self.__class__.__name__, self._name,
+                 repr_long_list(self.divisions)))
 
     def quantile(self, q):
         """ Approximate quantiles of column
@@ -566,6 +567,12 @@ class Series(_Frame):
 
 
 class Index(Series):
+
+    @property
+    def index(self):
+        msg = "'{0}' object has no attribute 'index'"
+        raise AttributeError(msg.format(self.__class__.__name__))
+
     @property
     def _constructor(self):
         return Index

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -95,8 +95,8 @@ def test_head():
 def test_Series():
     assert isinstance(d.a, dd.Series)
     assert isinstance(d.a + 1, dd.Series)
-
     assert eq((d + 1), full + 1)
+    assert repr(d.a).startswith('dd.Series')
 
 
 def test_Index():
@@ -105,6 +105,8 @@ def test_Index():
                     index=pd.date_range('2011-01-01', freq='D', periods=10))]:
         ddf = dd.from_pandas(case, 3)
         assert eq(ddf.index, case.index)
+        assert repr(ddf.index).startswith('dd.Index')
+        assert raises(AttributeError, lambda: ddf.index.index)
 
 
 def test_attributes():


### PR DESCRIPTION
Fixed following 2 points.

```
import pandas as pd
import dask.dataframe as dd
s = dd.from_pandas(pd.Series([1, 2 ,3]), 2)

# OK
s
# dd.Series<from_pandas-f8e060673005453ee0bdb092335cafe2, divisions=(0, 2, 2)>

# NG, class name must be dd.Index
s.index
# dd.Series<from_pandas-f8e060673005453ee0bdb092335cafe2-index, divisions=(0, 2, 2)>

# NG, must raise AttributeError
s.index.index
# dd.Series<from_pandas-f8e060673005453ee0bdb092335cafe2-index-index, divisions=(0, 2, 2)>
```