### PR TITLE
Add DataFrame.tail

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -213,10 +213,26 @@ class _Frame(Base):
         Caveat, the only checks the first n rows of the first partition.
         """
         name = 'head-%d-%s' % (n, self._name)
-        dsk = {(name, 0): (head, (self._name, 0), n)}
+        dsk = {(name, 0): (lambda x, n: x.head(n=n), (self._name, 0), n)}
 
         result = self._constructor(merge(self.dask, dsk), name,
                                    self.column_info, self.divisions[:2])
+
+        if compute:
+            result = result.compute()
+        return result
+
+    def tail(self, n=5, compute=True):
+        """ Last n rows of the dataset
+
+        Caveat, the only checks the last n rows of the last partition.
+        """
+        name = 'tail-%d-%s' % (n, self._name)
+        dsk = {(name, 0): (lambda x, n: x.tail(n=n),
+                (self._name, self.npartitions - 1), n)}
+
+        result = self._constructor(merge(self.dask, dsk), name,
+                                   self.column_info, self.divisions[-2:])
 
         if compute:
             result = result.compute()
@@ -817,11 +833,6 @@ def _coerce_loc_index(divisions, o):
     if divisions and isinstance(divisions[0], np.datetime64):
         return np.datetime64(o)
     return o
-
-
-def head(x, n):
-    """ First n elements of dask.Dataframe or dask.Series """
-    return x.head(n)
 
 
 def consistent_name(names):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -83,13 +83,28 @@ def test_Dataframe():
     assert repr(d)
 
 
-def test_head():
+def test_head_tail():
+    assert eq(d.head(2), full.head(2))
+    assert eq(d.head(3), full.head(3))
     assert eq(d.head(2), dsk[('x', 0)].head(2))
+    assert eq(d['a'].head(2), full['a'].head(2))
+    assert eq(d['a'].head(3), full['a'].head(3))
     assert eq(d['a'].head(2), dsk[('x', 0)]['a'].head(2))
     assert sorted(d.head(2, compute=False).dask) == \
            sorted(d.head(2, compute=False).dask)
     assert sorted(d.head(2, compute=False).dask) != \
            sorted(d.head(3, compute=False).dask)
+
+    assert eq(d.tail(2), full.tail(2))
+    assert eq(d.tail(3), full.tail(3))
+    assert eq(d.tail(2), dsk[('x', 2)].tail(2))
+    assert eq(d['a'].tail(2), full['a'].tail(2))
+    assert eq(d['a'].tail(3), full['a'].tail(3))
+    assert eq(d['a'].tail(2), dsk[('x', 2)]['a'].tail(2))
+    assert sorted(d.tail(2, compute=False).dask) == \
+           sorted(d.tail(2, compute=False).dask)
+    assert sorted(d.tail(2, compute=False).dask) != \
+           sorted(d.tail(3, compute=False).dask)
 
 
 def test_Series():


### PR DESCRIPTION
Added ``DataFrame.tail`` as the same spec as ``head`` (only check last partition).

```
import pandas as pd
import dask.dataframe as dd
s = dd.from_pandas(pd.Series([1, 2 ,3, 4, 5, 6]), 2)
s.tail(n=2)
# 4    5
# 5    6
# dtype: int64
```
1 question: Should we avoid to use ``lambda`` and use module level funcs as much (to avoid instance reference)?