### PR TITLE
BUG: DataFrame.columns and Series.name may be incorrect

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -60,6 +60,9 @@ def set_partition(df, index, divisions, compute=False, **kwargs):
     """
     if isinstance(index, _Frame):
         assert df.divisions == index.divisions
+        columns = df.columns
+    else:
+        columns = tuple([c for c in df.columns if c != index])
 
     token = tokenize((df._name,
                       (index._name if isinstance(index, _Frame) else  index),
@@ -122,7 +125,7 @@ def set_partition(df, index, divisions, compute=False, **kwargs):
     if compute:
         dsk = cull(dsk, list(dsk4.keys()))
 
-    return DataFrame(dsk, name, df.columns, divisions)
+    return DataFrame(dsk, name, columns, divisions)
 
 
 def barrier(args):


### PR DESCRIPTION
``DataFrame.columns`` and ``Series.name`` are mismatched with actual computation result. Adding tests to detect it.

- [x] ``drop_duplicates``
- [x] ``Series`` aggfuncs
- [x] ``DataFrame`` single column slicing (``_loc_element``).
- [x] ``SeriesGroupBy`` aggfuncs
- [x] ``map_partition``
- [x] ``GroupBy.apply``

NOTE: There are some ``pandas`` bugs, and I've added comments in such cases.
