### PR TITLE
Add heuristics around map_partitions names

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1209,6 +1209,12 @@ def map_partitions(func, column_info, *args, **kwargs):
         else:
             return_type = type(args[0])
 
+    if (return_type == DataFrame and isinstance(column_info, (str, unicode)) or
+        return_type == Series and isinstance(column_info, (tuple, list, pd.Index))):
+        raise ValueError("Arguments to map_partitions are not consistent.\n"
+                "Received columns=%s and return_type=%s" %
+                (str(column_info), str(return_type)))
+
     if kwargs:
         raise ValueError("Keyword arguments not yet supported in map_partitions")
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -169,8 +169,7 @@ class _Frame(Base):
     def __len__(self):
         return reduction(self, len, np.sum).compute()
 
-    def map_partitions(self, func, column_info=no_default, return_type=None,
-                             name=no_default, columns=no_default):
+    def map_partitions(self, func, columns=no_default, return_type=None):
         """ Apply Python function on each DataFrame block
 
         When using ``map_partitions`` you should provide both column
@@ -196,12 +195,9 @@ class _Frame(Base):
             If None, class will be inferred from column names or default to
             the class of the input.
         """
-        try:
-            column_info = next(x for x in [column_info, columns, name]
-                                 if x != no_default)
-        except StopIteration:
-            column_info = self.column_info
-        return map_partitions(func, column_info, self, return_type=return_type)
+        if columns == no_default:
+            columns = self.column_info
+        return map_partitions(func, columns, self, return_type=return_type)
 
     def random_split(self, p, seed=None):
         """ Pseudorandomly split dataframe into different pieces row-wise

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3,6 +3,7 @@ from __future__ import division
 from itertools import count
 from math import sqrt
 from functools import wraps, reduce
+from collections import Iterable
 import bisect
 import uuid
 from hashlib import md5
@@ -25,6 +26,9 @@ from ..compatibility import unicode, apply
 from ..utils import repr_long_list, IndexCallable, pseudorandom
 from .utils import shard_df_on_index, tokenize_dataframe
 from ..base import Base, compute
+
+
+no_default = '__no_default__'
 
 
 def tokenize(obj):
@@ -165,22 +169,39 @@ class _Frame(Base):
     def __len__(self):
         return reduction(self, len, np.sum).compute()
 
-    def map_partitions(self, func, columns=None, return_type=None):
+    def map_partitions(self, func, column_info=no_default, return_type=None,
+                             name=no_default, columns=no_default):
         """ Apply Python function on each DataFrame block
+
+        When using ``map_partitions`` you should provide both column
+        information, the name or list of column names of the output, as well as
+        the output type (``dd.DataFrame`` or ``dd.Series``).
+
+        If you provide the column information only then the return type will be
+        inferred from the number of names
+
+        >>> df.map_partitions(lambda df: df.x + 1, name='x')  # doctest: +SKIP
+
+        >>> df.map_partitions(lambda df: df.head(), columns=df.columns)  # doctest: +SKIP
 
         Parameters
         ----------
 
-        columns: tuple
-            Provide columns of the output if they are not the same as the input.
+        column_info: tuple or string
+            Column names or name of the output.
+            Defaults to names of the input.
         return_type: class, default None
             Specify the class of the result. Be sure to pass correct class
             because it will not be validated by the function.
-            If None, class of 1st element of ``args`` will be used.
+            If None, class will be inferred from column names or default to
+            the class of the input.
         """
-        if columns is None:
-            columns = self.column_info
-        return map_partitions(func, columns, self, return_type=return_type)
+        try:
+            column_info = next(x for x in [column_info, columns, name]
+                                 if x != no_default)
+        except StopIteration:
+            column_info = self.column_info
+        return map_partitions(func, column_info, self, return_type=return_type)
 
     def random_split(self, p, seed=None):
         """ Pseudorandomly split dataframe into different pieces row-wise
@@ -1163,11 +1184,15 @@ def apply_concat_apply(args, chunk=None, aggregate=None, columns=None,
     dasks = [a.dask for a in args if isinstance(a, _Frame)]
     return return_type(merge(dsk, dsk2, *dasks), b, columns, [None, None])
 
-def map_partitions(func, columns, *args, **kwargs):
+
+aca = apply_concat_apply
+
+
+def map_partitions(func, column_info, *args, **kwargs):
     """ Apply Python function on each DataFrame block
 
-    columns: tuple
-        Provide columns of the output if they are not the same as the input.
+    column_info: tuple or string
+        Column names or name of the output
     targets: list
         List of target DataFrame / Series.
     return_type: class, default None
@@ -1182,14 +1207,17 @@ def map_partitions(func, columns, *args, **kwargs):
 
     return_type = kwargs.pop('return_type', None)
     if return_type is None:
-        # return_type can be None if _Frame.map_partition is used
-        return_type = type(args[0])
+        if (isinstance(column_info, (str, unicode)) or not
+            isinstance(column_info, Iterable)):
+            return_type = Series
+        else:
+            return_type = type(args[0])
 
     if kwargs:
         raise ValueError("Keyword arguments not yet supported in map_partitions")
 
     token = ((token or func),
-             columns,
+             column_info,
              [arg._name if isinstance(arg, _Frame) else arg for arg in args])
 
     name = 'map-partitions' + tokenize(token)
@@ -1201,9 +1229,8 @@ def map_partitions(func, columns, *args, **kwargs):
                 for i in range(args[0].npartitions))
 
     dasks = [arg.dask for arg in args if isinstance(arg, _Frame)]
-    return return_type(merge(dsk, *dasks), name, columns, args[0].divisions)
+    return return_type(merge(dsk, *dasks), name, column_info, args[0].divisions)
 
-aca = apply_concat_apply
 
 def categorize_block(df, categories):
     """ Categorize a dataframe with given categories

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -437,6 +437,19 @@ def test_map_partitions_method_names():
     assert b.name == 'x'
 
 
+def test_map_partitions_return_type_and_names_agree():
+    df = pd.DataFrame({'x': [1, 2, 3, 4], 'y': [5, 6, 7, 8]})
+    a = dd.from_pandas(df, npartitions=2)
+    try:
+        a.map_partitions(lambda x: x, columns='zzzz', return_type=dd.DataFrame)
+    except ValueError as e:
+        assert 'zzzz' in str(e)
+    try:
+        a.map_partitions(lambda x: x, columns=['zzzz'], return_type=dd.Series)
+    except ValueError as e:
+        assert 'zzzz' in str(e)
+
+
 def test_drop_duplicates():
     assert eq(d.a.drop_duplicates(), full.a.drop_duplicates())
     assert eq(d.drop_duplicates(), full.drop_duplicates())

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -428,11 +428,11 @@ def test_map_partitions_method_names():
     assert isinstance(b, dd.DataFrame)
     assert b.columns == a.columns
 
-    b = a.map_partitions(lambda df: df.x + 1, name=None)
+    b = a.map_partitions(lambda df: df.x + 1, columns=None)
     assert isinstance(b, dd.Series)
     assert b.name == None
 
-    b = a.map_partitions(lambda df: df.x + 1, name='x')
+    b = a.map_partitions(lambda df: df.x + 1, columns='x')
     assert isinstance(b, dd.Series)
     assert b.name == 'x'
 


### PR DESCRIPTION
Policy is as follows:

1.  The map_partitions function expects explicit column names/name
2.  The map_partitions function will infer return type based on names
3.  The map_partitions method accepts either columns=, or name= and
    defaults to its own columns if nothing is given

Any thoughts on this @sinhrks ?