### PR TITLE
Add compute to collection namespaces

### DIFF
--- a/dask/bag/__init__.py
+++ b/dask/bag/__init__.py
@@ -3,3 +3,4 @@ from __future__ import absolute_import, division, print_function
 from .core import (Bag, Item, from_sequence, from_filenames, from_hdfs,
                    from_url, to_textfiles, concat, from_s3)
 from ..context import set_options
+from ..base import compute

--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -8,3 +8,4 @@ from .rolling import (rolling_count, rolling_sum, rolling_mean, rolling_median,
                       rolling_min, rolling_max, rolling_std, rolling_var,
                       rolling_skew, rolling_kurt, rolling_quantile, rolling_apply,
                       rolling_window)
+from ..base import compute


### PR DESCRIPTION
Given that I often only do the following

    import dask.array as da

or

    import dask.dataframe as dd

It's nice to have the `da.compute` or `dd.compute` functions available.  This imports these functions from base.