### PR TITLE
Fix for pandas Categorical.name deprecation

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1373,8 +1373,7 @@ def categorize_block(df, categories):
     """
     df = df.copy()
     for col, vals in categories.items():
-        df[col] = pd.Categorical(df[col], categories=vals,
-                                    ordered=False, name=col)
+        df[col] = pd.Categorical(df[col], categories=vals, ordered=False)
     return df
 
 


### PR DESCRIPTION
``Categorical(name=...)`` is being deprecated in pandas 0.17 and show warning as below, see https://github.com/pydata/pandas/pull/10632.

```
UserWarning: the 'name' keyword is removed, use 'name' with consumers of the categorical instead (e.g. 'Series(cat, name="something")'
  ordered=False, name=col)
```