### PR TITLE
Quote list literals given to fold

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -361,6 +361,8 @@ class Bag(Base):
         """
         a = next(names)
         b = next(names)
+        if isinstance(initial, list):
+            initial = (list2, initial)
         if initial is not no_default:
             dsk = dict(((a, i), (reduce, binop, (self.name, i), initial))
                             for i in range(self.npartitions))

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -147,6 +147,10 @@ def test_fold():
     d = db.from_sequence('hello')
     assert set(d.fold(lambda a, b: ''.join([a, b]), initial='').compute()) == set('hello')
 
+    e = db.from_sequence([[1], [2], [3]], npartitions=2)
+    with dask.set_options(get=get_sync):
+        assert set(e.fold(add, initial=[]).compute()) == set([1, 2, 3])
+
 
 def test_distinct():
     assert sorted(b.distinct()) == [0, 1, 2, 3, 4]


### PR DESCRIPTION
When we give a list to the fold method the schedulers interpret it
as a generator, this can upset user code.  Here we quote the initial
value with a call to `list`.

This should be replaced by a more robust `quote` function.

Fixes #554