### PR TITLE
Fuse getitem optimization

### DIFF
--- a/dask/dataframe/optimize.py
+++ b/dask/dataframe/optimize.py
@@ -3,29 +3,14 @@
 a, b, c, d, e = '~a', '~b', '~c', '~d', '~e'
 from ..rewrite import RuleSet, RewriteRule
 from .io import dataframe_from_ctable
-from ..optimize import cull, fuse, inline_functions
+from ..optimize import cull, fuse, inline_functions, fuse_getitem
+from ..core import istask
 from ..utils import ignoring
 from .. import core
 from toolz import valmap
 from operator import getitem
 import operator
 
-
-rules = [
-        # Merge column access into bcolz loading
-        RewriteRule((getitem, (dataframe_from_ctable, a, b, c, d), e),
-                    (dataframe_from_ctable, a, b, e, d),
-                    (a, b, c, d, e)),
-        ]
-with ignoring(ImportError):
-    from castra import Castra
-    rules.append(
-        RewriteRule((getitem, (Castra.load_partition, '~c', '~part', '~cols1'),
-                              '~cols2'),
-                    (Castra.load_partition, '~c', '~part', '~cols2'),
-                    ('~c', '~part', '~cols1', '~cols2')))
-
-rewrite_rules = RuleSet(*rules)
 
 fast_functions = [getattr(operator, attr) for attr in dir(operator)
                                           if not attr.startswith('_')]
@@ -37,6 +22,12 @@ def optimize(dsk, keys, **kwargs):
     else:
         dsk2 = cull(dsk, [keys])
     dsk3 = inline_functions(dsk2, fast_functions)
-    dsk4 = fuse(dsk3)
-    dsk5 = valmap(rewrite_rules.rewrite, dsk4)
-    return dsk5
+    try:
+        from castra import Castra
+        dsk4 = fuse_getitem(dsk3, Castra.load_partition, 3)
+    except ImportError:
+        dsk4 = dsk3
+    dsk5 = fuse_getitem(dsk4, dataframe_from_ctable, 3)
+    dsk6 = fuse(dsk5)
+    dsk7 = cull(dsk6, keys)
+    return dsk7

--- a/dask/dataframe/tests/test_optimize_dataframe.py
+++ b/dask/dataframe/tests/test_optimize_dataframe.py
@@ -1,7 +1,7 @@
 import pytest
 from operator import getitem
-from toolz import valmap
-from dask.dataframe.optimize import rewrite_rules, dataframe_from_ctable
+from toolz import valmap, merge
+from dask.dataframe.optimize import dataframe_from_ctable
 import dask.dataframe as dd
 import pandas as pd
 
@@ -22,18 +22,20 @@ def test_column_optimizations_with_bcolz_and_rewrite():
     bc = bcolz.ctable([[1, 2, 3], [10, 20, 30]], names=['a', 'b'])
     func = lambda x: x
     for cols in [None, 'abc', ['abc']]:
-        dsk2 = dict((('x', i),
-                     (func,
-                       (getitem,
-                         (dataframe_from_ctable, bc, slice(0, 2), cols, {}),
-                         (list, ['a', 'b']))))
-                for i in [1, 2, 3])
+        dsk2 = merge(dict((('x', i),
+                          (dataframe_from_ctable, bc, slice(0, 2), cols, {}))
+                          for i in [1, 2, 3]),
+                     dict((('y', i),
+                          (getitem, ('x', i), (list, ['a', 'b'])))
+                          for i in [1, 2, 3]),
+                     dict((('z', i), (func, ('y', i)))
+                          for i in [1, 2, 3]))
 
-        expected = dict((('x', i), (func, (dataframe_from_ctable,
+        expected = dict((('z', i), (func, (dataframe_from_ctable,
                                      bc, slice(0, 2), (list, ['a', 'b']), {})))
-                for i in [1, 2, 3])
-        result = valmap(rewrite_rules.rewrite, dsk2)
+                          for i in [1, 2, 3])
 
+        result = dd.optimize(dsk2, [('z', i) for i in [1, 2, 3]])
         assert result == expected
 
 


### PR DESCRIPTION
To use columns stores efficiently we need to combine getitem operations with load-from-columnstore operations 

*  Before: `load(mydata, columns='all')[['x', 'y']]`
*  After: `load(mydata, columns=['x', 'y'])`

Historically we've handled this with rewrite rules and it has worked quite well.  However rewrite rules depend on `fuse` and `fuse` doesn't play nicely with opportunistic caching.  To resolve this we implement a `fuse_getitem` optimization by hand and use it instead.

@eriknw @jcrist this could use your review.
    