### PR TITLE
Meaningful label for elemwise with scalar

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1548,11 +1548,21 @@ def partial_by_order(op, other):
     >>> f(5)
     15
     """
+    if (not isinstance(other, list) or
+        not all(isinstance(o, tuple) and len(o) == 2 for o in other)):
+        raise ValueError('input must be list of tuples')
+
     def f(*args):
         args2 = list(args)
         for i, arg in other:
             args2.insert(i, arg)
         return op(*args2)
+
+    if len(other) == 1:
+        other_arg = other[0][1]
+    else:
+        other_arg = '...'
+    f.__name__ = '{0}({1})'.format(op.__name__, other_arg)
     return f
 
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -349,6 +349,18 @@ def test_elemwise_on_scalars():
     assert eq(a, x)
 
 
+def test_partial_by_order():
+    f = partial_by_order(add, [(1, 20)])
+    assert f(5) == 25
+    assert f.__name__ == 'add(20)'
+
+    f = partial_by_order(lambda x, y, z: x + y + z, [(1, 10), (2, 15)])
+    assert f(3) == 28
+    assert f.__name__ == '<lambda>(...)'
+
+    assert raises(ValueError, lambda: partial_by_order(add, 1))
+    assert raises(ValueError, lambda: partial_by_order(add, [1]))
+
 def test_operators():
     x = np.arange(10)
     y = np.arange(10).reshape((10, 1))


### PR DESCRIPTION
Currently, scalar arithmetic for ``DataFrame`` shows a graph with node labelled ``f``.

```
(df1 + 1).visualize()
```

![index](https://cloud.githubusercontent.com/assets/1696302/9211025/7105723a-40ba-11e5-9e96-b4ec8b3be96f.png)

This PR intends to change the label to be more understandable.

![index2](https://cloud.githubusercontent.com/assets/1696302/9211089/bf262a5e-40ba-11e5-81d3-2296b6b34799.png)

I've done it by changing the function name. Another idea is creating ``Function`` class to allow arbitrary formatting (or is it already there)?