### PR TITLE
Add `sorted_column_index` option to `to_castra`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -794,7 +794,8 @@ class DataFrame(_Frame):
             return df.dropna(how=how, subset=subset)
         return map_partitions(f, self.columns, self)
 
-    def to_castra(self, fn=None, categories=None, compute=True):
+    def to_castra(self, fn=None, categories=None, sorted_index_column=None,
+                  compute=True):
         """ Write DataFrame to Castra on-disk store
 
         See https://github.com/blosc/castra for details
@@ -803,7 +804,8 @@ class DataFrame(_Frame):
             Castra.to_dask
         """
         from .io import to_castra
-        return to_castra(self, fn, categories, compute=compute)
+        return to_castra(self, fn, categories, sorted_index_column,
+                         compute=compute)
 
     @wraps(pd.DataFrame.to_csv)
     def to_csv(self, filename, **kwargs):

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -417,7 +417,7 @@ def test_from_dask_array_raises():
 def test_to_castra():
     pytest.importorskip('castra')
     df = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
-                       'y': [1, 2, 3, 4]},
+                       'y': [2, 3, 4, 5]},
                        index=pd.Index([1., 2., 3., 4.], name='ind'))
     a = dd.from_pandas(df, 2)
 
@@ -432,6 +432,12 @@ def test_to_castra():
     c = a.to_castra(categories=['x'])
     try:
         assert c[:].dtypes['x'] == 'category'
+    finally:
+        c.drop()
+
+    c = a.to_castra(sorted_index_column='y')
+    try:
+        tm.assert_frame_equal(c[:], df.set_index('y'))
     finally:
         c.drop()
 


### PR DESCRIPTION
This is for setting a known to be sorted column as the index when storing in castra.