### PR TITLE
Add da.image.imread function

### DIFF
--- a/dask/array/image.py
+++ b/dask/array/image.py
@@ -27,9 +27,9 @@ def imread(filename):
     Example
     -------
 
-    >>> import dask.array as da
-    >>> im = da.imread('2015-*-*.png')
-    >>> im.shape
+    >>> from dask.array.image import imread
+    >>> im = imread('2015-*-*.png')  # doctest: +SKIP
+    >>> im.shape  # doctest: +SKIP
     (365, 1000, 1000, 3)
 
     Returns

--- a/dask/array/image.py
+++ b/dask/array/image.py
@@ -1,15 +1,13 @@
-from .core import Array
 from glob import glob
 import os
+
 try:
     from skimage.io import imread as sk_imread
 except ImportError:
     pass
 
-
-def tokenize(*args):
-    from hashlib import md5
-    return md5(str(args).encode()).hexdigest()
+from .core import Array
+from ..base import tokenize
 
 def add_leading_dimension(x):
     return x[None, ...]

--- a/dask/array/image.py
+++ b/dask/array/image.py
@@ -1,0 +1,55 @@
+from .core import Array
+from glob import glob
+import os
+try:
+    from skimage.io import imread as sk_imread
+except ImportError:
+    pass
+
+
+def tokenize(*args):
+    from hashlib import md5
+    return md5(str(args).encode()).hexdigest()
+
+def add_leading_dimension(x):
+    return x[None, ...]
+
+
+def imread(filename):
+    """ Read a stack of images into a dask array
+
+    Parameters
+    ----------
+
+    filename: string
+        A globstring like 'myfile.*.png'
+
+    Example
+    -------
+
+    >>> import dask.array as da
+    >>> im = da.imread('2015-*-*.png')
+    >>> im.shape
+    (365, 1000, 1000, 3)
+
+    Returns
+    -------
+
+    Dask array of all images stacked along the first dimension.  All images
+    will be treated as individual chunks
+    """
+    filenames = sorted(glob(filename))
+    if not filenames:
+        raise ValueError("No files found under name %s" % filename)
+
+    name = 'imread-%s' % tokenize(filenames, map(os.path.getmtime, filenames))
+
+    sample = sk_imread(filenames[0])
+
+    dsk = dict(((name, i) + (0,) * len(sample.shape),
+                (add_leading_dimension, (sk_imread, filename)))
+                for i, filename in enumerate(filenames))
+
+    chunks = ((1,) * len(filenames),) + tuple((d,) for d in sample.shape)
+
+    return Array(dsk, name, chunks, sample.dtype)

--- a/dask/array/tests/test_image.py
+++ b/dask/array/tests/test_image.py
@@ -1,0 +1,35 @@
+from contextlib import contextmanager
+import os
+import shutil
+from tempfile import mkdtemp
+
+import pytest
+pytest.importorskip('skimage')
+from dask.array.image import imread as da_imread
+import numpy as np
+from skimage.io import imread, imsave
+
+
+@contextmanager
+def random_images(n, shape):
+    dirname = mkdtemp()
+    for i in range(n):
+        fn = os.path.join(dirname, 'image.%d.png' % i)
+        x = np.random.randint(0, 255, size=shape).astype('i1')
+        imsave(fn, x)
+
+    try:
+        yield os.path.join(dirname, '*.png')
+    finally:
+        shutil.rmtree(dirname)
+
+
+def test_imread():
+    with random_images(4, (5, 6, 3)) as globstring:
+        im = da_imread(globstring)
+        assert im.shape == (4, 5, 6, 3)
+        assert im.chunks == ((1, 1, 1, 1), (5,), (6,), (3,))
+        assert im.dtype == 'uint8'
+
+        assert im.compute().shape == (4, 5, 6, 3)
+        assert im.compute().dtype == 'uint8'


### PR DESCRIPTION
Example
-------

```python
>>> from dask.array.image import imread
>>> x = imread('2014-*-*.png')
>>> x.shape
(365, 1000, 1000, 3)
```

Arose in Stack Overflow question:
http://stackoverflow.com/questions/31951507/out-of-core-4d-image-tif-storage-as-hdf5-python