### PR TITLE
dask.dataframe.Series.__array_*_ for better use with ufuncs. 

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -512,6 +512,18 @@ class Series(_Frame):
                 (self.__class__.__name__, self._name,
                  repr_long_list(self.divisions)))
 
+    def __array__(self, dtype=None, **kwargs):
+        x = np.array(self.compute())
+        if dtype and x.dtype != dtype:
+            x = x.astype(dtype)
+        return x
+
+    def __array_wrap__(self, array, context=None):
+        return pd.Series(array)
+
+    def __array_prepare__(self, array, context=None):
+        return array
+
     def quantile(self, q):
         """ Approximate quantiles of column
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -519,7 +519,7 @@ class Series(_Frame):
         return x
 
     def __array_wrap__(self, array, context=None):
-        return pd.Series(array)
+        return pd.Series(array, name=self.name)
 
     def __array_prepare__(self, array, context=None):
         return array

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -521,9 +521,6 @@ class Series(_Frame):
     def __array_wrap__(self, array, context=None):
         return pd.Series(array, name=self.name)
 
-    def __array_prepare__(self, array, context=None):
-        return array
-
     def quantile(self, q):
         """ Approximate quantiles of column
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1236,3 +1236,9 @@ def test_drop_axis_1():
 
     assert eq(a.drop('y', axis=1), df.drop('y', axis=1))
 
+
+def test_gh580():
+    df = pd.DataFrame({'x': np.arange(10, dtype=float)})
+    ddf = dd.from_pandas(df, 2)
+    assert eq(np.cos(df['x']), np.cos(ddf['x']))
+    assert eq(np.cos(df['x']), np.cos(ddf['x']))


### PR DESCRIPTION
This "fixes" #580 

However it does not do the right thing. The right thing would be for `np.ufunc(dask.Series)` to return a `dask.Series` now it forces computation and returns a pandas dataframe.

We could eventually do that when it `__numpy_ufunc__` is included in NumPy, which might happen in numpy 1.10 or 1.11