### PR TITLE
Add DataFrame.get_division

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -145,6 +145,18 @@ class _Frame(Base):
         """Whether divisions are already known"""
         return len(self.divisions) > 0 and self.divisions[0] is not None
 
+    def get_division(self, n):
+        """ Get nth division of the data """
+        if 0 <= n < self.npartitions:
+            name = 'get-division-%s-%s' % (str(n), self._name)
+            dsk = {(name, 0): (self._name, n)}
+            divisions = self.divisions[n:n+2]
+            return self._constructor(merge(self.dask, dsk), name,
+                                     self.column_info, divisions)
+        else:
+            msg = "n must be 0 <= n < {0}".format(self.npartitions)
+            raise ValueError(msg)
+
     def cache(self, cache=Cache):
         """ Evaluate Dataframe and store in local cache
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -754,6 +754,34 @@ def test_set_partition_compute():
     assert len(d4.dask) > len(d5.dask)
 
 
+def test_get_division():
+    pdf = pd.DataFrame(np.random.randn(10, 5), columns=list('abcde'))
+    ddf = dd.from_pandas(pdf, 3)
+    assert ddf.divisions == (0, 4, 8, 9)
+
+    # DataFrame
+    div1 = ddf.get_division(0)
+    assert isinstance(div1, dd.DataFrame)
+    eq(div1, pdf.loc[0:3])
+    div2 = ddf.get_division(1)
+    eq(div2, pdf.loc[4:7])
+    div3 = ddf.get_division(2)
+    eq(div3, pdf.loc[8:9])
+    assert len(div1) + len(div2) + len(div3) == len(pdf)
+
+    # Series
+    div1 = ddf.a.get_division(0)
+    assert isinstance(div1, dd.Series)
+    eq(div1, pdf.a.loc[0:3])
+    div2 = ddf.a.get_division(1)
+    eq(div2, pdf.a.loc[4:7])
+    div3 = ddf.a.get_division(2)
+    eq(div3, pdf.a.loc[8:9])
+    assert len(div1) + len(div2) + len(div3) == len(pdf.a)
+
+    assert raises(ValueError, lambda: ddf.get_division(-1))
+    assert raises(ValueError, lambda: ddf.get_division(3))
+
 def test_categorize():
     dsk = {('x', 0): pd.DataFrame({'a': ['Alice', 'Bob', 'Alice'],
                                    'b': ['C', 'D', 'E']},


### PR DESCRIPTION
Nice to have a function to get nth division from DataFrame/Seires.

```
import numpy as np
import pandas as pd
import dask.dataframe as dd

pdf1 = pd.DataFrame({'a': [1, 2, 3, 4, 5], 'b': [3, 5, 2, 5, 7]},
                    index=[1, 2, 3, 4, 5])
ddf1 = dd.from_pandas(pdf1, 2)

ddf1.get_division(0)
# dd.DataFrame<get-division-0-from_pandas-e8dd9a7364593a595b2614b57e119a85, divisions=(1, 4)>

ddf1.get_division(0).compute()
#    a  b
# 1  1  3
# 2  2  5
# 3  3  2
```