### PR TITLE
Changes to profiler plotting

### DIFF
--- a/dask/diagnostics/profile_visualize.py
+++ b/dask/diagnostics/profile_visualize.py
@@ -5,6 +5,7 @@ from operator import itemgetter
 
 from toolz import unique, groupby
 import bokeh.plotting as bp
+from bokeh.io import _state
 from bokeh.palettes import brewer
 from bokeh.models import HoverTool
 
@@ -78,7 +79,7 @@ def get_colors(palette, funcs):
     return [color_lookup[n] for n in funcs]
 
 
-def visualize(results, dsk, palette='GnBu', file_path="profile.html",
+def visualize(results, dsk, palette='GnBu', file_path=None,
               show=True, **kwargs):
     """Visualize the results of profiling in a bokeh plot.
 
@@ -103,7 +104,9 @@ def visualize(results, dsk, palette='GnBu', file_path="profile.html",
     The completed bokeh plot object.
     """
 
-    bp.output_file(file_path)
+    if not _state._notebook:
+        file_path = file_path or "profile.html"
+        bp.output_file(file_path)
     keys, tasks, starts, ends, ids = zip(*results)
 
     id_group = groupby(itemgetter(4), results)


### PR DESCRIPTION
If `bokeh.plotting.output_notebook()` is called, don't call `bokeh.plotting.output_file(...)`. This allows `prof.visualize()` to do all the plotting related stuff automatically in terminal, but will still display in notebook by adding a call to `bokeh.plotting.output_notebook()`.

![profile_in_notebook](https://cloud.githubusercontent.com/assets/2783717/9286300/2bb5e7c0-42b6-11e5-9f30-18a6447aeba3.png)
