### PR TITLE
Add ``dd.io.to_bag``

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -652,6 +652,18 @@ class Series(_Frame):
     def notnull(self):
         return map_partitions(pd.Series.notnull, self.name, self)
 
+    def to_bag(self, index=False):
+        """Convert to a dask Bag.
+
+        Parameters
+        ----------
+        index : bool, optional
+            If True, the elements are tuples of ``(index, value)``, otherwise
+            they're just the ``value``.  Default is False.
+        """
+        from .io import to_bag
+        return to_bag(self, index)
+
 
 class Index(Series):
 
@@ -848,6 +860,18 @@ class DataFrame(_Frame):
     def to_csv(self, filename, **kwargs):
         from .io import to_csv
         return to_csv(self, filename, **kwargs)
+
+    def to_bag(self, index=False):
+        """Convert to a dask Bag of tuples of each row.
+
+        Parameters
+        ----------
+        index : bool, optional
+            If True, the index is included as the first element of each tuple.
+            Default is False.
+        """
+        from .io import to_bag
+        return to_bag(self, index)
 
     @wraps(pd.DataFrame._get_numeric_data)
     def _get_numeric_data(self, how='any', subset=None):

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -584,3 +584,16 @@ def test_read_csv_of_modified_file_has_different_name():
         b = read_csv(fn)
 
         assert sorted(a.dask) != sorted(b.dask)
+
+
+def test_to_bag():
+    pytest.importorskip('dask.bag')
+    a = pd.DataFrame({'x': ['a', 'b', 'c', 'd'],
+                      'y': [2, 3, 4, 5]},
+                     index=pd.Index([1., 2., 3., 4.], name='ind'))
+    ddf = dd.from_pandas(a, 2)
+
+    assert ddf.to_bag().compute(get=get_sync) == list(a.itertuples(False))
+    assert ddf.to_bag(True).compute(get=get_sync) == list(a.itertuples(True))
+    assert ddf.x.to_bag(True).compute(get=get_sync) == list(a.x.iteritems())
+    assert ddf.x.to_bag().compute(get=get_sync) == list(a.x)


### PR DESCRIPTION
Allows for converting dask DataFrames and Series to Bags. This is useful for performing complicated python operations that don't fit the dataframe model, but use data that starts out in a dataframe format.