### PR TITLE
Use base.tokenize in dask imperative

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -30,7 +30,7 @@ from ..core import istask, get_dependencies, reverse_dict
 from ..optimize import fuse, cull, inline
 from ..compatibility import (apply, BytesIO, unicode, urlopen, urlparse, quote,
         unquote, StringIO)
-from ..base import Base
+from ..base import Base, normalize_token
 
 names = ('bag-%d' % i for i in itertools.count(1))
 tokens = ('-%d' % i for i in itertools.count(1))
@@ -799,6 +799,10 @@ class Bag(Base):
 
         return dd.DataFrame(merge(optimize(self.dask, self._keys()), dsk),
                             name, columns, divisions)
+
+
+normalize_token.register(Item, lambda a: a.key)
+normalize_token.register(Bag, lambda a: a.name)
 
 
 def partition(grouper, sequence, npartitions, p, nelements=2**20):

--- a/dask/imperative.py
+++ b/dask/imperative.py
@@ -65,7 +65,7 @@ def to_task_dasks(expr):
     if isinstance(expr, Value):
         return expr.key, expr._dasks
     elif isinstance(expr, base.Base):
-        name = tokenize(str(expr), True)
+        name = tokenize(expr, True)
         keys = expr._keys()
         dsk = expr._optimize(expr.dask, keys)
         dsk[name] = (expr._finalize, expr, (concrete, keys))
@@ -89,24 +89,20 @@ def to_task_dasks(expr):
 tokens = ('_{0}'.format(i) for i in count(1))
 
 
-def tokenize(v, pure=False):
+def tokenize(*args, **kwargs):
     """Mapping function from task -> consistent name.
 
     Parameters
     ----------
-    v : object
-        Any python object (or tuple of objects) that summarize the task.
+    args : object
+        Python objects that summarize the task.
     pure : boolean, optional
         If True, a consistent hash function is tried on the input. If this
         fails, then a unique identifier is used. If False (default), then a
         unique identifier is always used.
     """
-    # TODO: May have hash collisions...
-    if pure:
-        try:
-            return str(hash(v))
-        except TypeError:
-            pass
+    if kwargs.pop('pure', False):
+        return base.tokenize(*args)
     return next(tokens)
 
 
@@ -118,9 +114,9 @@ def applyfunc(func, args, kwargs, pure=False):
 
     args, dasks = unzip(map(to_task_dasks, args), 2)
     dasks = flat_unique(dasks)
-    name = tokenize((func, args, frozenset(kwargs.items())), pure)
     if kwargs:
         func = partial(func, **kwargs)
+    name = tokenize(func, *args, pure=pure)
     dasks.append({name: (func,) + args})
     return Value(name, dasks)
 
@@ -306,6 +302,9 @@ class Value(base.Base):
     __sub__ = do(operator.sub, True)
     __truediv__ = do(operator.truediv, True)
     __xor__ = do(operator.xor, True)
+
+
+base.normalize_token.register(Value, lambda a: a.key)
 
 
 def value(val, name=None):


### PR DESCRIPTION
Allows for more robust deterministic names for imperative.